### PR TITLE
add deserializeUnknown method

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/queryspec/DefaultQuerySpecDeserializer.java
+++ b/crnk-core/src/main/java/io/crnk/core/queryspec/DefaultQuerySpecDeserializer.java
@@ -169,7 +169,7 @@ public class DefaultQuerySpecDeserializer implements QuerySpecDeserializer {
 					deserializePage(querySpec, parameter);
 					break;
 				default:
-					throw new IllegalStateException(parameter.paramType.toString());
+					deserializeUnknown(querySpec, parameter);
 			}
 
 		}
@@ -281,6 +281,10 @@ public class DefaultQuerySpecDeserializer implements QuerySpecDeserializer {
 				querySpec.addSort(new SortSpec(attributePath, dir));
 			}
 		}
+	}
+
+	protected void deserializeUnknown(QuerySpec querySpec, Parameter parameter) {
+		throw new IllegalStateException(parameter.paramType.toString());
 	}
 
 	private List<Parameter> parseParameters(Map<String, Set<String>> params, ResourceInformation rootResourceInformation) {
@@ -412,7 +416,7 @@ public class DefaultQuerySpecDeserializer implements QuerySpecDeserializer {
 		this.ignoreParseExceptions = ignoreParseExceptions;
 	}
 
-	class Parameter {
+	public class Parameter {
 
 		String pageParameter;
 

--- a/crnk-core/src/main/java/io/crnk/core/queryspec/DefaultQuerySpecDeserializer.java
+++ b/crnk-core/src/main/java/io/crnk/core/queryspec/DefaultQuerySpecDeserializer.java
@@ -140,9 +140,13 @@ public class DefaultQuerySpecDeserializer implements QuerySpecDeserializer {
 		this.typeParser = ctx.getTypeParser();
 	}
 
+	protected QuerySpec createQuerySpec(Class<?> resourceClass) {
+		return new QuerySpec(resourceClass);
+	}
+
 	@Override
 	public QuerySpec deserialize(ResourceInformation resourceInformation, Map<String, Set<String>> parameterMap) {
-		QuerySpec rootQuerySpec = new QuerySpec(resourceInformation.getResourceClass());
+		QuerySpec rootQuerySpec = createQuerySpec(resourceInformation.getResourceClass());
 		setupDefaults(rootQuerySpec);
 
 		List<Parameter> parameters = parseParameters(parameterMap, resourceInformation);

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/repository/DefaultQuerySpecDeserializerTestBase.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/repository/DefaultQuerySpecDeserializerTestBase.java
@@ -399,6 +399,14 @@ public abstract class DefaultQuerySpecDeserializerTestBase extends AbstractQuery
 		deserializer.deserialize(taskInformation, params);
 	}
 
+	@Test(expected = IllegalStateException.class)
+	public void testUnknownProperty() throws InstantiationException, IllegalAccessException {
+		Map<String, Set<String>> params = new HashMap<>();
+		add(params, "group", "test");
+		deserializer.setIgnoreParseExceptions(false);
+		deserializer.deserialize(taskInformation, params);
+	}
+
 	protected void add(Map<String, Set<String>> params, String key, String value) {
 		params.put(key, new HashSet<>(Arrays.asList(value)));
 	}


### PR DESCRIPTION
fix #1
If an unknown Parameter is passed, `deserializeUnknown` will be called so you can easily intercept it.
By default it will throw `IllegalStateException` as before.