### PR TITLE
build improvements

### DIFF
--- a/crnk-brave/src/test/java/io/crnk/brave/AbstractBraveModuleTest.java
+++ b/crnk-brave/src/test/java/io/crnk/brave/AbstractBraveModuleTest.java
@@ -26,8 +26,8 @@ import io.crnk.core.queryspec.QuerySpec;
 import io.crnk.core.repository.RelationshipRepositoryV2;
 import io.crnk.core.repository.ResourceRepositoryV2;
 import io.crnk.rs.CrnkFeature;
+import io.crnk.test.JerseyTestBase;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,7 +37,7 @@ import zipkin.BinaryAnnotation;
 import zipkin.Span;
 import zipkin.reporter.Reporter;
 
-public abstract class AbstractBraveModuleTest extends JerseyTest {
+public abstract class AbstractBraveModuleTest extends JerseyTestBase {
 
 	protected CrnkClient client;
 

--- a/crnk-client/src/test/java/io/crnk/client/AbstractClientTest.java
+++ b/crnk-client/src/test/java/io/crnk/client/AbstractClientTest.java
@@ -15,6 +15,7 @@ import io.crnk.legacy.queryParams.QueryParamsBuilder;
 import io.crnk.rs.CrnkFeature;
 import io.crnk.rs.JsonApiResponseFilter;
 import io.crnk.rs.JsonapiExceptionMapperBridge;
+import io.crnk.test.JerseyTestBase;
 import io.crnk.test.mock.repository.ProjectRepository;
 import io.crnk.test.mock.repository.ProjectToTaskRepository;
 import io.crnk.test.mock.repository.ScheduleRepositoryImpl;
@@ -22,17 +23,17 @@ import io.crnk.test.mock.repository.TaskRepository;
 import io.crnk.test.mock.repository.TaskToProjectRepository;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Assert;
 import org.junit.Before;
 
-public abstract class AbstractClientTest extends JerseyTest {
+public abstract class AbstractClientTest extends JerseyTestBase {
 
 	protected CrnkClient client;
 
 	protected TestApplication testApplication;
 
 	protected QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder(new DefaultQueryParamsParser());
+
 
 	@Before
 	public void setup() {
@@ -73,9 +74,6 @@ public abstract class AbstractClientTest extends JerseyTest {
 
 	/**
 	 * Assert the specified header name has the specified value.
-	 *
-	 * @param name
-	 * @param value
 	 */
 	protected void assertHasHeaderValue(String name, String value) {
 		MultivaluedMap<String, String> headers = getLastReceivedHeaders();
@@ -96,8 +94,6 @@ public abstract class AbstractClientTest extends JerseyTest {
 
 	/**
 	 * Return the last received headers.
-	 *
-	 * @return
 	 */
 	private MultivaluedMap<String, String> getLastReceivedHeaders() {
 		return getTestFilter().getLastReceivedHeaders();
@@ -105,8 +101,6 @@ public abstract class AbstractClientTest extends JerseyTest {
 
 	/**
 	 * Return the configured test filter.
-	 *
-	 * @return
 	 */
 	private TestRequestFilter getTestFilter() {
 		return ((CrnkTestFeature) testApplication.getFeature()).getTestFilter();
@@ -125,9 +119,12 @@ public abstract class AbstractClientTest extends JerseyTest {
 			property(CrnkProperties.RESOURCE_SEARCH_PACKAGE, "io.crnk.test.mock");
 
 			if (!querySpec) {
-				feature = new CrnkTestFeature(new ObjectMapper(), new QueryParamsBuilder(new DefaultQueryParamsParser()), new SampleJsonServiceLocator());
-			} else {
-				feature = new CrnkTestFeature(new ObjectMapper(), new DefaultQuerySpecDeserializer(), new SampleJsonServiceLocator());
+				feature = new CrnkTestFeature(new ObjectMapper(), new QueryParamsBuilder(new DefaultQueryParamsParser()),
+						new SampleJsonServiceLocator());
+			}
+			else {
+				feature = new CrnkTestFeature(new ObjectMapper(), new DefaultQuerySpecDeserializer(),
+						new SampleJsonServiceLocator());
 			}
 
 			feature.addModule(new TestModule());

--- a/crnk-examples/jersey-example/src/test/java/io/crnk/example/jersey/JerseyApplicationTest.java
+++ b/crnk-examples/jersey-example/src/test/java/io/crnk/example/jersey/JerseyApplicationTest.java
@@ -1,5 +1,22 @@
 package io.crnk.example.jersey;
 
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -10,19 +27,6 @@ import io.crnk.example.jersey.domain.model.Task;
 import io.crnk.rs.type.JsonApiMediaType;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Test;
-
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
 
 public class JerseyApplicationTest extends JerseyTest {
 
@@ -79,7 +83,8 @@ public class JerseyApplicationTest extends JerseyTest {
 				onode.put(f.getKey(), f.getValue().textValue());
 			}
 			return mapper.treeToValue(onode, Task.class);
-		} else {
+		}
+		else {
 			throw new JsonMappingException("Not an object: " + node);
 		}
 	}

--- a/crnk-jpa/build.gradle
+++ b/crnk-jpa/build.gradle
@@ -13,25 +13,17 @@ dependencies {
 
 	testCompile project(':crnk-client')
 	testCompile project(':crnk-rs')
+	testCompile project(':crnk-test')
 	testCompile group: 'javax', name: 'javaee-api', version: '7.0'
 	testCompile group: 'com.querydsl', name: 'querydsl-core', version: '4.1.3'
 	testCompile group: 'com.querydsl', name: 'querydsl-jpa', version: '4.1.3'
-	testCompile group: 'org.reflections', name: 'reflections', version: '0.9.9'
 	testCompile group: 'org.hibernate', name: 'hibernate-core', version: '5.2.10.Final'
-	testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.4.1'
 	testCompile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0.1'
-	testCompile group: 'io.rest-assured', name: 'rest-assured', version: '3.0.2'
 	testCompile group: 'org.springframework', name: 'spring-orm', version: '4.3.1.RELEASE'
 	testCompile group: 'org.springframework', name: 'spring-context', version: '4.3.1.RELEASE'
 	testCompile group: 'org.springframework', name: 'spring-test', version: '4.3.1.RELEASE'
 	testCompile group: 'org.hibernate', name: 'hibernate-entitymanager', version: '5.2.10.Final'
 	testCompile group: 'com.h2database', name: 'h2', version: '1.4.187'
-	testCompile group: 'org.glassfish.jersey.core', name: 'jersey-common', version: '2.17'
-	testCompile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: '2.17'
-	testCompile group: 'org.glassfish.jersey.test-framework.providers', name: 'jersey-test-framework-provider-grizzly2', version: '2.17'
-	testCompile group: 'org.glassfish.jersey.test-framework', name: 'jersey-test-framework-core', version: '2.17'
-	testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
-	testCompile group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.13'
 	testCompile(group: 'org.hibernate.javax.persistence', name: 'hibernate-jpa-2.1-api', version: '1.0.0.Final')
 	testCompile(group: 'com.querydsl', name: 'querydsl-apt', version: '4.1.3', classifier: 'jpa')
 }

--- a/crnk-jpa/src/main/java/io/crnk/jpa/internal/query/AnyUtils.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/internal/query/AnyUtils.java
@@ -1,9 +1,11 @@
 package io.crnk.jpa.internal.query;
 
+import io.crnk.jpa.meta.MetaJpaDataObject;
 import io.crnk.jpa.query.AnyTypeObject;
 import io.crnk.meta.MetaLookup;
 import io.crnk.meta.model.MetaAttribute;
 import io.crnk.meta.model.MetaDataObject;
+import io.crnk.meta.model.MetaElement;
 
 public class AnyUtils {
 
@@ -20,7 +22,10 @@ public class AnyUtils {
 	 * @param value      the new value
 	 */
 	public static void setValue(MetaLookup metaLookup, AnyTypeObject dataObject, Object value) {
-		MetaDataObject meta = metaLookup.getMeta(dataObject.getClass()).asDataObject();
+		MetaDataObject meta = metaLookup.getMeta(dataObject.getClass(), MetaJpaDataObject.class, true);
+		if(meta == null){
+			meta = (MetaDataObject) metaLookup.getMeta(dataObject.getClass(), MetaElement.class);
+		}
 		if (value == null) {
 			for (MetaAttribute attr : meta.getAttributes()) {
 				attr.setValue(dataObject, null);

--- a/crnk-jpa/src/main/java/io/crnk/jpa/meta/internal/AbstractEntityMetaProvider.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/meta/internal/AbstractEntityMetaProvider.java
@@ -24,6 +24,7 @@ import io.crnk.meta.model.MetaAttribute;
 import io.crnk.meta.model.MetaDataObject;
 import io.crnk.meta.model.MetaElement;
 import io.crnk.meta.model.MetaPrimaryKey;
+import io.crnk.meta.model.MetaType;
 
 public abstract class AbstractEntityMetaProvider<T extends MetaJpaDataObject> extends AbstractJpaDataObjectProvider<T> {
 
@@ -175,8 +176,8 @@ public abstract class AbstractEntityMetaProvider<T extends MetaJpaDataObject> ex
 			MetaAttribute attr = (MetaAttribute) element;
 			String mappedBy = getMappedBy(attr);
 			if (mappedBy != null) {
-
-				MetaDataObject oppositeType = attr.getType().getElementType().asDataObject();
+				MetaType attrType = attr.getType();
+				MetaDataObject oppositeType = attrType.getElementType().asDataObject();
 				if (!mappedBy.contains(".")) {
 					MetaAttribute oppositeAttr = oppositeType.getAttribute(mappedBy);
 					attr.setOppositeAttribute(oppositeAttr);

--- a/crnk-jpa/src/main/java/io/crnk/jpa/meta/internal/AbstractJpaDataObjectProvider.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/meta/internal/AbstractJpaDataObjectProvider.java
@@ -1,5 +1,14 @@
 package io.crnk.jpa.meta.internal;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Map;
+import javax.persistence.Embeddable;
+import javax.persistence.Entity;
+import javax.persistence.MappedSuperclass;
+
+import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.engine.internal.utils.PropertyUtils;
 import io.crnk.jpa.meta.MetaJpaDataObject;
 import io.crnk.meta.internal.MetaDataObjectProviderBase;
@@ -7,14 +16,6 @@ import io.crnk.meta.model.MetaAttribute;
 import io.crnk.meta.model.MetaDataObject;
 import io.crnk.meta.model.MetaElement;
 import io.crnk.meta.model.MetaType;
-
-import javax.persistence.Embeddable;
-import javax.persistence.Entity;
-import javax.persistence.MappedSuperclass;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.Collection;
-import java.util.Map;
 
 public abstract class AbstractJpaDataObjectProvider<T extends MetaJpaDataObject> extends MetaDataObjectProviderBase<T> {
 
@@ -32,6 +33,8 @@ public abstract class AbstractJpaDataObjectProvider<T extends MetaJpaDataObject>
 
 			Class<? extends MetaType> metaClass = jpaObject ? MetaJpaDataObject.class : MetaType.class;
 			MetaType metaType = context.getLookup().getMeta(implementationType, metaClass);
+			PreconditionUtil.assertNotNull("no type available", metaType);
+
 			attr.setType(metaType);
 		}
 	}

--- a/crnk-jpa/src/main/java/io/crnk/jpa/meta/internal/EmbeddableMetaProvider.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/meta/internal/EmbeddableMetaProvider.java
@@ -1,5 +1,10 @@
 package io.crnk.jpa.meta.internal;
 
+import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.Embeddable;
+
 import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.jpa.meta.MetaEmbeddable;
 import io.crnk.jpa.meta.MetaEmbeddableAttribute;
@@ -8,11 +13,6 @@ import io.crnk.jpa.query.AnyTypeObject;
 import io.crnk.meta.model.MetaAttribute;
 import io.crnk.meta.model.MetaDataObject;
 import io.crnk.meta.model.MetaElement;
-
-import javax.persistence.Embeddable;
-import java.lang.reflect.Type;
-import java.util.HashSet;
-import java.util.Set;
 
 public class EmbeddableMetaProvider extends AbstractJpaDataObjectProvider<MetaEmbeddable> {
 
@@ -28,7 +28,7 @@ public class EmbeddableMetaProvider extends AbstractJpaDataObjectProvider<MetaEm
 	@Override
 	public boolean accept(Type type, Class<? extends MetaElement> metaClass) {
 		boolean hasAnnotation = ClassUtils.getRawType(type).getAnnotation(Embeddable.class) != null;
-		boolean hasType = metaClass == MetaElement.class || metaClass == MetaEmbeddable.class || metaClass == MetaJpaDataObject.class;
+		boolean hasType = metaClass == MetaEmbeddable.class || metaClass == MetaJpaDataObject.class;
 		return hasAnnotation && hasType;
 	}
 

--- a/crnk-jpa/src/test/java/io/crnk/jpa/AbstractJpaJerseyTest.java
+++ b/crnk-jpa/src/test/java/io/crnk/jpa/AbstractJpaJerseyTest.java
@@ -1,5 +1,15 @@
 package io.crnk.jpa;
 
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.metamodel.ManagedType;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.crnk.client.CrnkClient;
 import io.crnk.client.http.okhttp.OkHttpAdapter;
@@ -24,25 +34,15 @@ import io.crnk.meta.model.resource.MetaResource;
 import io.crnk.meta.model.resource.MetaResourceBase;
 import io.crnk.meta.provider.resource.ResourceMetaProvider;
 import io.crnk.rs.CrnkFeature;
+import io.crnk.test.JerseyTestBase;
 import okhttp3.OkHttpClient.Builder;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.metamodel.ManagedType;
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-
-public abstract class AbstractJpaJerseyTest extends JerseyTest {
+public abstract class AbstractJpaJerseyTest extends JerseyTestBase {
 
 	protected CrnkClient client;
 

--- a/crnk-meta/src/main/java/io/crnk/meta/internal/JsonObjectMetaProvider.java
+++ b/crnk-meta/src/main/java/io/crnk/meta/internal/JsonObjectMetaProvider.java
@@ -1,19 +1,24 @@
 package io.crnk.meta.internal;
 
+import java.lang.reflect.Type;
+
 import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.core.resource.annotations.JsonApiResource;
 import io.crnk.meta.model.MetaDataObject;
 import io.crnk.meta.model.MetaElement;
 import io.crnk.meta.model.resource.MetaJsonObject;
 
-import java.lang.reflect.Type;
-
 public class JsonObjectMetaProvider extends MetaDataObjectProvider {
 
 	@Override
 	public boolean accept(Type type, Class<? extends MetaElement> metaClass) {
 		boolean hasResourceAnnotation = ClassUtils.getRawType(type).getAnnotation(JsonApiResource.class) != null;
-		return type instanceof Class && metaClass == MetaJsonObject.class && !hasResourceAnnotation;
+		if (type instanceof Class && metaClass == MetaJsonObject.class && !hasResourceAnnotation) {
+			// a bit tricky as there is no clear maker what a "jsonObject" makes up. So we check whether
+			// another provider on the generic MetaElement, which catches Arrays, primitives, lists, etc.
+			return !context.getLookup().exists(type, MetaElement.class);
+		}
+		return false;
 	}
 
 	@Override

--- a/crnk-meta/src/main/java/io/crnk/meta/internal/MetaDataObjectProvider.java
+++ b/crnk-meta/src/main/java/io/crnk/meta/internal/MetaDataObjectProvider.java
@@ -1,14 +1,14 @@
 package io.crnk.meta.internal;
 
+import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Set;
+
 import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.core.engine.internal.utils.PropertyUtils;
 import io.crnk.meta.model.MetaAttribute;
 import io.crnk.meta.model.MetaDataObject;
 import io.crnk.meta.model.MetaElement;
-
-import java.lang.reflect.Type;
-import java.util.HashSet;
-import java.util.Set;
 
 public abstract class MetaDataObjectProvider extends MetaDataObjectProviderBase<MetaDataObject> {
 

--- a/crnk-meta/src/main/java/io/crnk/meta/internal/ResourceMetaProviderImpl.java
+++ b/crnk-meta/src/main/java/io/crnk/meta/internal/ResourceMetaProviderImpl.java
@@ -250,7 +250,15 @@ public class ResourceMetaProviderImpl extends MetaProviderBase {
 			ResourceField field = information.findFieldByUnderlyingName(attr.getName());
 			PreconditionUtil.assertNotNull(attr.getName(), field);
 			Type implementationType = field.getGenericType();
-			MetaElement metaType = context.getLookup().getMeta(implementationType, MetaJsonObject.class);
+
+			MetaElement metaType = context.getLookup().getMeta(implementationType, MetaJsonObject.class, true);
+			if (metaType == null) {
+				metaType = context.getLookup().getMeta(implementationType);
+			}
+
+			PreconditionUtil.assertFalse("should not reference jpa objects", metaType.getClass().getSimpleName().equals("MetaEmbeddable"));
+
+
 			attr.setType(metaType.asType());
 		}
 

--- a/crnk-meta/src/test/java/io/crnk/meta/AbstractMetaJerseyTest.java
+++ b/crnk-meta/src/test/java/io/crnk/meta/AbstractMetaJerseyTest.java
@@ -12,14 +12,14 @@ import io.crnk.client.http.okhttp.OkHttpAdapterListenerBase;
 import io.crnk.core.boot.CrnkProperties;
 import io.crnk.meta.provider.resource.ResourceMetaProvider;
 import io.crnk.rs.CrnkFeature;
+import io.crnk.test.JerseyTestBase;
 import io.crnk.test.mock.models.Schedule;
 import io.crnk.test.mock.repository.ScheduleRepository;
 import okhttp3.OkHttpClient.Builder;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Before;
 
-public abstract class AbstractMetaJerseyTest extends JerseyTest {
+public abstract class AbstractMetaJerseyTest extends JerseyTestBase {
 
 	protected CrnkClient client;
 

--- a/crnk-operations/src/test/java/io/crnk/operations/AbstractOperationsTest.java
+++ b/crnk-operations/src/test/java/io/crnk/operations/AbstractOperationsTest.java
@@ -32,16 +32,16 @@ import io.crnk.operations.server.TransactionOperationFilter;
 import io.crnk.rs.CrnkFeature;
 import io.crnk.spring.internal.SpringServiceDiscovery;
 import io.crnk.spring.jpa.SpringTransactionRunner;
+import io.crnk.test.JerseyTestBase;
 import io.crnk.validation.ValidationModule;
 import okhttp3.OkHttpClient.Builder;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
-public abstract class AbstractOperationsTest extends JerseyTest {
+public abstract class AbstractOperationsTest extends JerseyTestBase {
 
 	protected CrnkClient client;
 

--- a/crnk-rs/src/test/java/io/crnk/rs/InteroperabilityTest.java
+++ b/crnk-rs/src/test/java/io/crnk/rs/InteroperabilityTest.java
@@ -15,6 +15,7 @@ import io.crnk.core.engine.internal.dispatcher.path.ActionPath;
 import io.crnk.core.module.SimpleModule;
 import io.crnk.core.queryspec.QuerySpec;
 import io.crnk.rs.controller.SampleControllerWithPrefix;
+import io.crnk.test.JerseyTestBase;
 import io.crnk.test.mock.TestModule;
 import io.crnk.test.mock.models.Schedule;
 import io.crnk.test.mock.repository.ScheduleRepository;
@@ -22,7 +23,6 @@ import io.crnk.test.mock.repository.ScheduleRepositoryImpl;
 import io.crnk.test.mock.repository.TaskRepository;
 import io.restassured.RestAssured;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.jetty.JettyTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.hamcrest.Matchers;
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-public class InteroperabilityTest extends JerseyTest {
+public class InteroperabilityTest extends JerseyTestBase {
 
 	private static DocumentFilter filter;
 

--- a/crnk-rs/src/test/java/io/crnk/rs/UriInfoServiceUrlProviderTest.java
+++ b/crnk-rs/src/test/java/io/crnk/rs/UriInfoServiceUrlProviderTest.java
@@ -8,18 +8,18 @@ import javax.ws.rs.core.Application;
 
 import io.crnk.core.boot.CrnkProperties;
 import io.crnk.rs.controller.SampleControllerWithPrefix;
+import io.crnk.test.JerseyTestBase;
 import io.crnk.test.mock.TestModule;
 import io.crnk.test.mock.models.Task;
 import io.crnk.test.mock.repository.TaskRepository;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.jetty.JettyTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class UriInfoServiceUrlProviderTest extends JerseyTest {
+public class UriInfoServiceUrlProviderTest extends JerseyTestBase {
 
 	@Override
 	protected TestContainerFactory getTestContainerFactory() {

--- a/crnk-rs/src/test/java/io/crnk/rs/controller/ControllerTest.java
+++ b/crnk-rs/src/test/java/io/crnk/rs/controller/ControllerTest.java
@@ -8,16 +8,16 @@ import java.io.IOException;
 import javax.ws.rs.core.Response;
 
 import io.crnk.core.engine.internal.dispatcher.path.PathBuilder;
+import io.crnk.test.JerseyTestBase;
 import io.crnk.test.mock.TestExceptionMapper;
 import io.crnk.test.mock.models.Task;
 import io.crnk.test.mock.repository.TaskRepository;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public abstract class ControllerTest extends JerseyTest {
+public abstract class ControllerTest extends JerseyTestBase {
 
 	@Before
 	public void setup() {

--- a/crnk-security/src/test/java/io/crnk/security/SecurityModuleIntTest.java
+++ b/crnk-security/src/test/java/io/crnk/security/SecurityModuleIntTest.java
@@ -23,6 +23,7 @@ import io.crnk.security.model.Project;
 import io.crnk.security.model.ProjectRepository;
 import io.crnk.security.model.Task;
 import io.crnk.security.model.TaskRepository;
+import io.crnk.test.JerseyTestBase;
 import okhttp3.Authenticator;
 import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
@@ -34,7 +35,6 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.spi.TestContainer;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
@@ -43,7 +43,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SecurityModuleIntTest extends JerseyTest {
+public class SecurityModuleIntTest extends JerseyTestBase {
 
 	private final InMemoryIdentityManager identityManager = new InMemoryIdentityManager();
 
@@ -104,7 +104,8 @@ public class SecurityModuleIntTest extends JerseyTest {
 						securityHandler.setHandler(handler);
 					}
 					server.setHandler(securityHandler);
-				} catch (Exception e) {
+				}
+				catch (Exception e) {
 					throw new IllegalStateException(e);
 				}
 				return container;
@@ -260,7 +261,8 @@ public class SecurityModuleIntTest extends JerseyTest {
 		}
 
 		@Override
-		public Request authenticate(Route route, Response response) throws IOException { // NOSONAR this is a lambda, legacy cannot be removed!
+		public Request authenticate(Route route, Response response)
+				throws IOException { // NOSONAR this is a lambda, legacy cannot be removed!
 			if (responseCount(response) >= 3) {
 				return null; // If we've failed 3 times, give up.
 			}

--- a/crnk-test/src/main/java/io/crnk/test/JerseyTestBase.java
+++ b/crnk-test/src/main/java/io/crnk/test/JerseyTestBase.java
@@ -1,0 +1,17 @@
+package io.crnk.test;
+
+import java.util.Random;
+
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.BeforeClass;
+
+public class JerseyTestBase extends JerseyTest {
+
+	@BeforeClass
+	public static void selectPort() {
+		Random random = new Random();
+		random.setSeed(System.nanoTime());
+		int port = 40000 + random.nextInt(10000);
+		System.setProperty("jersey.config.test.container.port", Integer.toString(port));
+	}
+}

--- a/crnk-test/src/main/java/io/crnk/test/JerseyTestBase.java
+++ b/crnk-test/src/main/java/io/crnk/test/JerseyTestBase.java
@@ -1,17 +1,22 @@
 package io.crnk.test;
 
-import java.util.Random;
-
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.net.ServerSocket;
 
 public class JerseyTestBase extends JerseyTest {
 
 	@BeforeClass
 	public static void selectPort() {
-		Random random = new Random();
-		random.setSeed(System.nanoTime());
-		int port = 40000 + random.nextInt(10000);
-		System.setProperty("jersey.config.test.container.port", Integer.toString(port));
+		try {
+			ServerSocket s = new ServerSocket(0);
+			int port = s.getLocalPort();
+			s.close();
+			System.setProperty("jersey.config.test.container.port", Integer.toString(port));
+		} catch (IOException e) {
+			throw new IllegalStateException(e);
+		}
 	}
 }

--- a/crnk-ui/build.gradle
+++ b/crnk-ui/build.gradle
@@ -35,9 +35,7 @@ task npmRunBuild(type: NpmTask) {
 	outputs.dir 'build/npm/io/crnk/ui'
 }
 
-tasks.jar.dependsOn 'npmRunBuild'
-
-tasks.assemble.dependsOn 'npmRunBuild'
+tasks.processResources.dependsOn 'npmRunBuild'
 
 task war(type: War) {
 	group = 'Build'

--- a/crnk-validation/build.gradle
+++ b/crnk-validation/build.gradle
@@ -9,18 +9,11 @@ dependencies {
 
 	testCompile project(':crnk-client')
 	testCompile project(':crnk-rs')
+	testCompile project(':crnk-test')
 	testCompile group: 'org.hibernate', name: 'hibernate-validator', version: '5.2.1.Final'
-	testCompile group: 'org.reflections', name: 'reflections', version: '0.9.9'
-	testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.4.1'
 	testCompile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0.1'
 	testCompile group: 'org.springframework', name: 'spring-orm', version: '4.3.1.RELEASE'
 	testCompile group: 'org.springframework', name: 'spring-context', version: '4.3.1.RELEASE'
 	testCompile group: 'org.springframework', name: 'spring-test', version: '4.3.1.RELEASE'
-	testCompile group: 'org.glassfish.jersey.core', name: 'jersey-common', version: '2.17'
-	testCompile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: '2.17'
-	testCompile group: 'org.glassfish.jersey.test-framework.providers', name: 'jersey-test-framework-provider-grizzly2', version: '2.17'
-	testCompile group: 'org.glassfish.jersey.test-framework', name: 'jersey-test-framework-core', version: '2.17'
-	testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
-	testCompile group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.13'
 	testCompile(group: 'javax', name: 'javaee-api', version: '7.0')
 }

--- a/crnk-validation/src/test/java/io/crnk/validation/AbstractValidationTest.java
+++ b/crnk-validation/src/test/java/io/crnk/validation/AbstractValidationTest.java
@@ -13,14 +13,14 @@ import io.crnk.legacy.locator.SampleJsonServiceLocator;
 import io.crnk.legacy.queryParams.DefaultQueryParamsParser;
 import io.crnk.legacy.queryParams.QueryParamsBuilder;
 import io.crnk.rs.CrnkFeature;
+import io.crnk.test.JerseyTestBase;
 import io.crnk.validation.mock.models.Project;
 import io.crnk.validation.mock.models.Task;
 import io.crnk.validation.mock.repository.TaskRepository;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Before;
 
-public abstract class AbstractValidationTest extends JerseyTest {
+public abstract class AbstractValidationTest extends JerseyTestBase {
 
 	protected CrnkClient client;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP_ID=io.crnk
 org.gradle.configureondemand=true
-# org.gradle.parallel=true
+org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx2G
 


### PR DESCRIPTION
- random port for Jersey tests
- proper npm/resource task dependencies in crnk-ui
- enabled parallel build
- crnk-validation and crnk-jpa makes partial use of crnk-test
- fixed random build failure in meta lookup due to duplicate list issues