### PR TITLE
Support Typescript generation #12

### DIFF
--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/runtime/RuntimeClassLoaderFactory.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/runtime/RuntimeClassLoaderFactory.java
@@ -61,6 +61,13 @@ public class RuntimeClassLoaderFactory {
 
 		@Override
 		protected synchronized URL findResource(String name) {
+			if ("logback-test.xml".equals(name)) {
+				URL logbackUrl = RuntimeClassLoaderFactory.class.getClassLoader().getResource("logback-test.xml");
+				if (logbackUrl == null) {
+					throw new IllegalStateException("logback-test.xml could not be found");
+				}
+				return logbackUrl;
+			}
 			URL sharedResourceUrl = GenerateTypescriptTask.class.getClassLoader().getResource(name);
 			if (sharedResourceUrl != null) {
 				return sharedResourceUrl;

--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/TSGeneratorPlugin.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/TSGeneratorPlugin.java
@@ -9,6 +9,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
+import org.gradle.api.artifacts.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,13 +27,15 @@ public class TSGeneratorPlugin implements Plugin<Project> {
 		final File workingDir = new File(project.getBuildDir(), "generated/source/typescript/");
 		compileTypescriptTask.setWorkingDir(workingDir);
 
+		Configuration compileConfiguration = project.getConfigurations().getByName("compile");
+		generateTask.getInputs().file(compileConfiguration.getFiles());
+
 		try {
 			NpmInstallTask npmInstall = (NpmInstallTask) project.getTasks().getByName("npmInstall");
 			npmInstall.setWorkingDir(workingDir);
 			npmInstall.dependsOn(generateTask);
 			npmInstall.getInputs().file(new File(workingDir, "package.json"));
 			npmInstall.getOutputs().dir(new File(workingDir, "node_modules"));
-
 
 			// copy .npmrc file from root to working directory if available
 			final File npmrcFile = new File(project.getProjectDir(), ".npmrc");
@@ -47,8 +50,9 @@ public class TSGeneratorPlugin implements Plugin<Project> {
 				});
 			}
 			compileTypescriptTask.dependsOn(npmInstall);
-		}catch(UnknownTaskException e){
-			e.printStackTrace(); // TODO testing
+		}
+		catch (UnknownTaskException e) {
+			e.printStackTrace(); // TODO needed for testing
 		}
 		try {
 			Task processIntegrationTestResourcesTask = project.getTasks().getByName("processIntegrationTestResources");

--- a/crnk-gen-typescript/src/main/resources/logback-test.xml
+++ b/crnk-gen-typescript/src/main/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<charset>UTF-8</charset>
+			<pattern>%d{HH:mm:ss,SSS} %-5.5p [%15.15t] [%30.30c] %X{indent}%m%n
+			</pattern>
+		</encoder>
+	</appender>
+
+	<root level="ERROR">
+		<appender-ref ref="CONSOLE"/>
+	</root>
+</configuration>
+


### PR DESCRIPTION
- added application jars as task input for generateTypescript for proper up-to-date checking
- logback-test.xml to suppress non-error logging during typescript generation