### PR TITLE
Support Typescript generation refinement #12

### DIFF
--- a/crnk-gen-typescript/build.gradle
+++ b/crnk-gen-typescript/build.gradle
@@ -7,6 +7,9 @@ dependencies {
 	compileOnly project(':crnk-meta')
 	compileOnly 'junit:junit:4.12'
 	compileOnly 'org.apache.deltaspike.modules:deltaspike-test-control-module-api:1.7.1'
+	compileOnly 'org.apache.deltaspike.cdictrl:deltaspike-cdictrl-api:1.7.1'
+
+
 	compileOnly 'javax:javaee-api:7.0'
 
 	compile 'com.moowork.gradle:gradle-node-plugin:1.1.1'

--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/runtime/RuntimeClassLoaderFactory.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/runtime/RuntimeClassLoaderFactory.java
@@ -32,7 +32,7 @@ public class RuntimeClassLoaderFactory {
 		this.project = project;
 	}
 
-	public ClassLoader createClassLoader(ClassLoader parentClassLoader, Map<String, Class<?>> sharedClasses) {
+	public URLClassLoader createClassLoader(ClassLoader parentClassLoader, Map<String, Class<?>> sharedClasses) {
 		Set<URL> classURLs = new HashSet<>(); // NOSONAR URL needed by URLClassLoader
 		classURLs.addAll(getProjectClassUrls());
 		classURLs.add(getPluginUrl());

--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/runtime/deltaspike/DeltaspikeRunner.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/runtime/deltaspike/DeltaspikeRunner.java
@@ -3,6 +3,8 @@ package io.crnk.gen.runtime.deltaspike;
 import java.util.List;
 
 import io.crnk.gen.runtime.GeneratorTrigger;
+import org.apache.deltaspike.cdise.api.CdiContainer;
+import org.apache.deltaspike.cdise.api.CdiContainerLoader;
 import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
@@ -14,27 +16,37 @@ import org.junit.runners.model.InitializationError;
 public class DeltaspikeRunner {
 
 	public void run(GeneratorTrigger context) {
-		DeltaspikeTypescriptGenerator.setContext(context);
-		Runner runner;
 		try {
-			runner = new CdiTestRunner(DeltaspikeTypescriptGenerator.class);
+			DeltaspikeTypescriptGenerator.setContext(context);
+			Runner runner;
+			try {
+				runner = new CdiTestRunner(DeltaspikeTypescriptGenerator.class);
+			}
+			catch (InitializationError e) {
+				throw new IllegalStateException(e);
+			}
+
+			JUnitCore c = new JUnitCore();
+			Result result = c.run(Request.runner(runner));
+			List<Failure> failures = result.getFailures();
+			if (!failures.isEmpty()) {
+				Failure failure = failures.get(0);
+				Throwable exception = failure.getException();
+				if (exception instanceof RuntimeException) {
+					throw (RuntimeException) exception;
+				}
+				else {
+					throw new IllegalStateException(exception);
+				}
+			}
+
 		}
-		catch (InitializationError e) {
-			throw new IllegalStateException(e);
+		finally {
+			CdiContainer cdiContainer = CdiContainerLoader.getCdiContainer();
+			if (cdiContainer != null) {
+				cdiContainer.shutdown();
+			}
 		}
 
-		JUnitCore c = new JUnitCore();
-		Result result = c.run(Request.runner(runner));
-		List<Failure> failures = result.getFailures();
-		if (!failures.isEmpty()) {
-			Failure failure = failures.get(0);
-			Throwable exception = failure.getException();
-			if (exception instanceof RuntimeException) {
-				throw (RuntimeException) exception;
-			}
-			else {
-				throw new IllegalStateException(exception);
-			}
-		}
 	}
 }

--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/GenerateTypescriptTask.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/GenerateTypescriptTask.java
@@ -2,6 +2,7 @@ package io.crnk.gen.typescript;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URLClassLoader;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -74,7 +75,7 @@ public class GenerateTypescriptTask extends DefaultTask {
 		sharedClasses.put(TSGeneratorRuntimeContext.class.getName(), TSGeneratorRuntimeContext.class);
 
 		RuntimeClassLoaderFactory classLoaderFactory = new RuntimeClassLoaderFactory(getProject());
-		ClassLoader classloader = classLoaderFactory.createClassLoader(contextClassLoader, sharedClasses);
+		URLClassLoader classloader = classLoaderFactory.createClassLoader(contextClassLoader, sharedClasses);
 
 		TSGeneratorConfiguration config = getConfig();
 		setupDefaultConfig(config);
@@ -87,6 +88,9 @@ public class GenerateTypescriptTask extends DefaultTask {
 		finally {
 			// make sure to restore the classloader when leaving this task
 			thread.setContextClassLoader(contextClassLoader);
+
+			// dispose classloader
+			classloader.close();
 		}
 
 	}

--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/TSGeneratorPlugin.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/TSGeneratorPlugin.java
@@ -26,9 +26,19 @@ public class TSGeneratorPlugin implements Plugin<Project> {
 
 		final File workingDir = new File(project.getBuildDir(), "generated/source/typescript/");
 		compileTypescriptTask.setWorkingDir(workingDir);
+		compileTypescriptTask.getInputs().dir(new File(workingDir, "src"));
+		compileTypescriptTask.getInputs().dir(new File(workingDir, "package.json"));
+		compileTypescriptTask.getInputs().dir(new File(workingDir, "package-lock.json"));
+		compileTypescriptTask.getInputs().dir(new File(workingDir, ".npmrc"));
+		compileTypescriptTask.getOutputs().dir(new File(project.getBuildDir(), "build/npm"));
 
 		Configuration compileConfiguration = project.getConfigurations().getByName("compile");
 		generateTask.getInputs().file(compileConfiguration.getFiles());
+
+		generateTask.getOutputs().dir(new File(workingDir, "src"));
+		generateTask.getOutputs().file(new File(workingDir, "package.json"));
+		generateTask.getOutputs().file(new File(workingDir, "package-lock.json"));
+		generateTask.getOutputs().file(new File(workingDir, ".npmrc"));
 
 		try {
 			NpmInstallTask npmInstall = (NpmInstallTask) project.getTasks().getByName("npmInstall");


### PR DESCRIPTION
- update-to-date check improvements
- disposal of deltaspike container after typescript generator, can lead to classpath issues otherwise due to use of gradle wrapper and repeated invocations (like beans.xml not found)