### PR TITLE
ambiguous pagination #50

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/boot/CrnkProperties.java
+++ b/crnk-core/src/main/java/io/crnk/core/boot/CrnkProperties.java
@@ -109,6 +109,18 @@ public class CrnkProperties {
 	 */
 	public static final String NULL_DATA_RESPONSE_ENABLED = "crnk.config.null.data.response.enabled";
 
+	/**
+	 * <p>
+	 * 	 Set a boolean whether Crnk should allow pagination on inclusions. Most to all times application will choose to do
+	 *   a second request. By default this is disabled.
+	 * </p>
+	 * <p>
+	 *   Note that it is currently not possible to specify different paging parameters for the same entity when
+	 *   it is the root resp. an included entity. This can lead to confusion if inclusions are cyclic (not that uncommon).
+	 *   For this reason support is disabled by default.
+	 * </p>
+	 */
+	public static final String INCLUDE_PAGING_ENABLED = "crnk.config.include.paging.enabled";
 
 	/**
 	 * <p>
@@ -116,4 +128,6 @@ public class CrnkProperties {
 	 * </p>
 	 */
 	public static final String RETURN_404_ON_NULL = "crnk.config.resource.response.return_404";
+
+
 }

--- a/crnk-core/src/test/java/io/crnk/core/mock/models/HierarchicalTask.java
+++ b/crnk-core/src/test/java/io/crnk/core/mock/models/HierarchicalTask.java
@@ -1,11 +1,12 @@
 package io.crnk.core.mock.models;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.crnk.core.resource.annotations.JsonApiId;
 import io.crnk.core.resource.annotations.JsonApiRelation;
 import io.crnk.core.resource.annotations.JsonApiResource;
-
-import java.util.List;
+import io.crnk.core.resource.annotations.LookupIncludeBehavior;
 
 @JsonApiResource(type = "hierarchicalTask")
 @JsonPropertyOrder(alphabetic = true)
@@ -19,7 +20,7 @@ public class HierarchicalTask {
 	@JsonApiRelation(opposite = "children")
 	private HierarchicalTask parent;
 
-	@JsonApiRelation(opposite = "parent")
+	@JsonApiRelation(opposite = "parent", lookUp =  LookupIncludeBehavior.AUTOMATICALLY_ALWAYS)
 	private List<HierarchicalTask> children;
 
 	public Long getId() {

--- a/crnk-core/src/test/java/io/crnk/core/mock/repository/HierarchicalTaskRelationshipRepository.java
+++ b/crnk-core/src/test/java/io/crnk/core/mock/repository/HierarchicalTaskRelationshipRepository.java
@@ -1,0 +1,13 @@
+package io.crnk.core.mock.repository;
+
+import io.crnk.core.mock.models.HierarchicalTask;
+import io.crnk.core.repository.RelationshipRepositoryBase;
+
+public class HierarchicalTaskRelationshipRepository
+		extends RelationshipRepositoryBase<HierarchicalTask, Long, HierarchicalTask, Long> {
+
+
+	public HierarchicalTaskRelationshipRepository() {
+		super(HierarchicalTask.class, HierarchicalTask.class);
+	}
+}


### PR DESCRIPTION
introduced flag to enable/disable pagination on included resources. In most use cases not necessary but cyclic dependencies could leading back to the main resources could be paged as well, which is highly undesirable. So flag is disabled by default.