### PR TITLE
set preset for null values

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/FieldResourceGet.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/FieldResourceGet.java
@@ -17,6 +17,7 @@ import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.exception.ResourceFieldNotFoundException;
 import io.crnk.core.repository.response.JsonApiResponse;
+import io.crnk.core.utils.Nullable;
 import io.crnk.legacy.internal.RepositoryMethodParameterProvider;
 
 public class FieldResourceGet extends ResourceIncludeField {
@@ -58,6 +59,11 @@ public class FieldResourceGet extends ResourceIncludeField {
 			entities = relationshipRepositoryForClass.findOneTarget(castedResourceId, relationshipField, queryAdapter);
 		}
 		Document responseDocument = documentMapper.toDocument(entities, queryAdapter, parameterProvider);
+
+		// return explicit { data : null } if values found
+		if (!responseDocument.getData().isPresent()) {
+			responseDocument.setData(Nullable.nullValue());
+		}
 
 		return new Response(responseDocument, 200);
 	}


### PR DESCRIPTION
fix #49 

Checklist:
- [x] Analyse / Fix Problem
- [ ] Write a Test

The problem with the response beeing `{}` seems to be the value `present`.

```Java
public class Document implements MetaContainer, LinksContainer {

	@JsonInclude(Include.NON_EMPTY)
	@JsonDeserialize(using = DocumentDataDeserializer.class)
	@JsonSerialize(using = NullableSerializer.class)
	private Nullable<Object> data = Nullable.empty();
//...
```

data.preset is by default false.

```Java
	private void setResponse(HttpRequestContext requestContext, Response crnkResponse)
			throws IOException {
		if (crnkResponse != null) {
			ObjectMapper objectMapper = moduleContext.getObjectMapper();
			String responseBody = objectMapper.writeValueAsString(crnkResponse.getDocument());

			requestContext.setResponse(crnkResponse.getHttpStatus(), responseBody);
			requestContext.setResponseHeader("Content-Type", HttpHeaders.JSONAPI_CONTENT_TYPE_AND_CHARSET);
		}
	}
```

With present = false, `objectMapper.writeValueAsString(crnkResponse.getDocument());` will produce `{}`