### PR TITLE
Typescript generation refinement #12

### DIFF
--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/runtime/RuntimeClassLoaderFactory.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/runtime/RuntimeClassLoaderFactory.java
@@ -61,18 +61,19 @@ public class RuntimeClassLoaderFactory {
 
 		@Override
 		protected synchronized URL findResource(String name) {
-			if ("logback-test.xml".equals(name)) {
+			URL sharedResourceUrl = GenerateTypescriptTask.class.getClassLoader().getResource(name);
+			if (sharedResourceUrl != null) {
+				return sharedResourceUrl;
+			}
+			URL resource = super.findResource(name);
+			if (resource == null && "logback-test.xml".equals(name)) {
 				URL logbackUrl = RuntimeClassLoaderFactory.class.getClassLoader().getResource("logback-test.xml");
 				if (logbackUrl == null) {
 					throw new IllegalStateException("logback-test.xml could not be found");
 				}
 				return logbackUrl;
 			}
-			URL sharedResourceUrl = GenerateTypescriptTask.class.getClassLoader().getResource(name);
-			if (sharedResourceUrl != null) {
-				return sharedResourceUrl;
-			}
-			return super.findResource(name);
+			return resource;
 		}
 
 		@Override

--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/model/TSElementBase.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/model/TSElementBase.java
@@ -1,5 +1,7 @@
 package io.crnk.gen.typescript.model;
 
+import io.crnk.meta.model.MetaElement;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,5 +35,7 @@ public abstract class TSElementBase implements TSElement {
 	public void setPrivateData(String key, Object value) {
 		privateData.put(key, value);
 	}
+
+
 
 }

--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/model/TSObjectType.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/model/TSObjectType.java
@@ -56,7 +56,7 @@ public abstract class TSObjectType extends TSTypeBase implements TSExportedEleme
 			}
 		}
 
-		return declaredMembers;
+		return members;
 	}
 
 	public void setDeclaredMembers(List<TSMember> members) {
@@ -90,7 +90,7 @@ public abstract class TSObjectType extends TSTypeBase implements TSExportedEleme
 
 	public List<TSField> getFields() {
 		List<TSField> fields = new ArrayList<>();
-		for (TSMember member : declaredMembers) {
+		for (TSMember member : getMembers()) {
 			if (member instanceof TSField) {
 				fields.add((TSField) member);
 			}

--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/transform/TSMetaDataObjectTransformation.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/transform/TSMetaDataObjectTransformation.java
@@ -30,6 +30,8 @@ public class TSMetaDataObjectTransformation implements TSMetaTransformation {
 
 	public static final String PRIVATE_DATA_RESOURCE_TYPE = "resourceType";
 
+	public static final String PRIVATE_DATA_META_ELEMENT_ID = "metaElement";
+
 
 	@Override
 	public boolean accepts(MetaElement element) {
@@ -49,6 +51,7 @@ public class TSMetaDataObjectTransformation implements TSMetaTransformation {
 			String resourceType = metaResource.getResourceType();
 			interfaceType.setPrivateData(TSMetaDataObjectTransformation.PRIVATE_DATA_RESOURCE_TYPE, resourceType);
 		}
+		interfaceType.setPrivateData(TSMetaDataObjectTransformation.PRIVATE_DATA_META_ELEMENT_ID, element.getId());
 
 		context.putMapping(metaDataObject, interfaceType);
 

--- a/crnk-gen-typescript/src/test/resources/expected_schedule_with_expressions.ts
+++ b/crnk-gen-typescript/src/test/resources/expected_schedule_with_expressions.ts
@@ -36,15 +36,16 @@ export interface ScheduleListResult extends ManyQueryResult {
 	meta?: ScheduleListResult.ScheduleListMeta;
 }
 export class QSchedule extends BeanPath<Schedule> {
+	metaId: string = 'io.crnk.test.mock.models.Schedule';
 	relationships: QSchedule.QRelationships = new QSchedule.QRelationships(this, 'relationships');
 	attributes: QSchedule.QAttributes = new QSchedule.QAttributes(this, 'attributes');
 }
 export module QSchedule {
 	export class QRelationships extends BeanPath<Schedule.Relationships> {
-		task: QTypedOneResourceRelationship<QTask, Task> = new QTypedOneResourceRelationship<QTask, Task>(this, 'task', new QTask(null, 'data'));
-		lazyTask: QTypedOneResourceRelationship<QTask, Task> = new QTypedOneResourceRelationship<QTask, Task>(this, 'lazyTask', new QTask(null, 'data'));
-		tasks: QTypedManyResourceRelationship<QTask, Task> = new QTypedManyResourceRelationship<QTask, Task>(this, 'tasks', new QTask(null, 'data'));
-		tasksList: QTypedManyResourceRelationship<QTask, Task> = new QTypedManyResourceRelationship<QTask, Task>(this, 'tasksList', new QTask(null, 'data'));
+		task: QTypedOneResourceRelationship<QTask, Task> = new QTypedOneResourceRelationship<QTask, Task>(this, 'task', QTask);
+		lazyTask: QTypedOneResourceRelationship<QTask, Task> = new QTypedOneResourceRelationship<QTask, Task>(this, 'lazyTask', QTask);
+		tasks: QTypedManyResourceRelationship<QTask, Task> = new QTypedManyResourceRelationship<QTask, Task>(this, 'tasks', QTask);
+		tasksList: QTypedManyResourceRelationship<QTask, Task> = new QTypedManyResourceRelationship<QTask, Task>(this, 'tasksList', QTask);
 	}
 	export class QAttributes extends BeanPath<Schedule.Attributes> {
 		name: StringExpression = this.createString('name');


### PR DESCRIPTION
- generated expression classes lazily initialize relationships to avoid cycles in initialization
- meta id added to expression classes
- default logback-test.xml provided with non provided by application
- inheritance support for expression classes by included inherited fields