### PR TITLE
Resource.equals fix

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/document/Resource.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/document/Resource.java
@@ -72,7 +72,7 @@ public class Resource extends ResourceIdentifier implements MetaContainer, Links
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(attributes, relationships, links, meta);
+		return Objects.hash(id, type, attributes, relationships, links, meta);
 	}
 
 	@Override
@@ -82,7 +82,8 @@ public class Resource extends ResourceIdentifier implements MetaContainer, Links
 		}
 		Resource other = (Resource) obj;
 		return Objects.equals(attributes, other.attributes) && Objects.equals(relationships, other.relationships) && Objects
-				.equals(meta, other.meta) && Objects.equals(links, other.links);
+				.equals(meta, other.meta) && Objects.equals(links, other.links)
+				&& Objects.equals(id, other.id) && Objects.equals(type, other.type);
 	}
 
 	public ResourceIdentifier toIdentifier() {

--- a/crnk-core/src/main/java/io/crnk/core/engine/document/ResourceIdentifier.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/document/ResourceIdentifier.java
@@ -4,9 +4,9 @@ import java.util.Objects;
 
 public class ResourceIdentifier implements Comparable<ResourceIdentifier> {
 
-	private String id;
+	protected String id;
 
-	private String type;
+	protected String type;
 
 	public ResourceIdentifier() {
 	}

--- a/crnk-core/src/test/java/io/crnk/core/resource/ResourceEqualsContractTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/resource/ResourceEqualsContractTest.java
@@ -1,5 +1,6 @@
 package io.crnk.core.resource;
 
+import io.crnk.core.engine.document.Resource;
 import io.crnk.core.engine.document.ResourceIdentifier;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
@@ -11,4 +12,10 @@ public class ResourceEqualsContractTest {
 	public void testResourceIdEqualsContract() throws NoSuchFieldException {
 		EqualsVerifier.forClass(ResourceIdentifier.class).usingGetClass().suppress(Warning.NONFINAL_FIELDS).verify();
 	}
+
+	@Test
+	public void testResourceEqualsContract() throws NoSuchFieldException {
+		EqualsVerifier.forClass(Resource.class).usingGetClass().suppress(Warning.NONFINAL_FIELDS).verify();
+	}
+
 }


### PR DESCRIPTION
fix for Resource.equals ignoring id and type inherited from ResourceIdentifier.