### PR TITLE
Support ExceptionMapper lookup with CDI #64

### DIFF
--- a/crnk-cdi/src/main/java/io/crnk/cdi/internal/CdiServiceDiscovery.java
+++ b/crnk-cdi/src/main/java/io/crnk/cdi/internal/CdiServiceDiscovery.java
@@ -1,5 +1,6 @@
 package io.crnk.cdi.internal;
 
+import io.crnk.core.engine.error.JsonApiExceptionMapper;
 import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.core.module.discovery.ServiceDiscovery;
 import io.crnk.core.utils.Optional;
@@ -8,7 +9,9 @@ import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.CDI;
+import javax.enterprise.util.TypeLiteral;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -22,11 +25,18 @@ public class CdiServiceDiscovery implements ServiceDiscovery {
 	@Override
 	public <T> List<T> getInstancesByType(Class<T> clazz) {
 		BeanManager beanManager = CDI.current().getBeanManager();
-		Set<Bean<?>> beans = beanManager.getBeans(clazz);
+
+		Type type = clazz;
+		if(clazz == JsonApiExceptionMapper.class){
+			TypeLiteral<JsonApiExceptionMapper<?>> typeLiteral = new TypeLiteral<JsonApiExceptionMapper<?>>() {};
+			type = typeLiteral.getType();
+		}
+
+		Set<Bean<?>> beans = beanManager.getBeans(type);
 		List<T> list = new ArrayList<>();
 		for (Bean<?> bean : beans) {
 			CreationalContext<?> creationalContext = beanManager.createCreationalContext(bean);
-			T object = (T) beanManager.getReference(bean, clazz, creationalContext);
+			T object = (T) beanManager.getReference(bean, type, creationalContext);
 			list.add(object);
 		}
 		return list;

--- a/crnk-cdi/src/test/java/io/crnk/internal/boot/cdi/CdiServiceDiscoveryTest.java
+++ b/crnk-cdi/src/test/java/io/crnk/internal/boot/cdi/CdiServiceDiscoveryTest.java
@@ -1,9 +1,13 @@
 package io.crnk.internal.boot.cdi;
 
 import io.crnk.cdi.internal.CdiServiceDiscovery;
+import io.crnk.core.boot.CrnkBoot;
+import io.crnk.core.engine.error.JsonApiExceptionMapper;
 import io.crnk.core.module.discovery.DefaultServiceDiscoveryFactory;
 import io.crnk.core.module.discovery.ServiceDiscovery;
 import io.crnk.core.repository.Repository;
+import io.crnk.core.utils.Optional;
+import io.crnk.internal.boot.cdi.model.CdiTestExceptionMapper;
 import io.crnk.internal.boot.cdi.model.ProjectRepository;
 import io.crnk.internal.boot.cdi.model.TaskRepository;
 import io.crnk.legacy.repository.annotations.JsonApiResourceRepository;
@@ -33,5 +37,15 @@ public class CdiServiceDiscoveryTest {
 		repositories = instance.getInstancesByAnnotation(JsonApiResourceRepository.class);
 		Assert.assertEquals(1, repositories.size());
 		Assert.assertTrue(repositories.get(0) instanceof TaskRepository);
+	}
+
+	@Test
+	public void testExceptionMapper() {
+		CrnkBoot boot = new CrnkBoot();
+		boot.boot();
+
+		Optional<JsonApiExceptionMapper> mapper = boot.getExceptionMapperRegistry().findMapperFor(IllegalStateException.class);
+		Assert.assertTrue(mapper.isPresent());
+		Assert.assertTrue(mapper.get() instanceof CdiTestExceptionMapper);
 	}
 }

--- a/crnk-cdi/src/test/java/io/crnk/internal/boot/cdi/model/CdiTestExceptionMapper.java
+++ b/crnk-cdi/src/test/java/io/crnk/internal/boot/cdi/model/CdiTestExceptionMapper.java
@@ -1,0 +1,26 @@
+package io.crnk.internal.boot.cdi.model;
+
+import io.crnk.core.engine.error.ErrorResponse;
+import io.crnk.core.engine.error.ExceptionMapper;
+
+import javax.enterprise.context.ApplicationScoped;
+
+
+@ApplicationScoped
+public class CdiTestExceptionMapper implements ExceptionMapper<IllegalStateException> {
+
+	@Override
+	public ErrorResponse toErrorResponse(IllegalStateException cve) {
+		throw new IllegalStateException();
+	}
+
+	@Override
+	public IllegalStateException fromErrorResponse(ErrorResponse errorResponse) {
+		throw new IllegalStateException();
+	}
+
+	@Override
+	public boolean accepts(ErrorResponse errorResponse) {
+		return false;
+	}
+}

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/exception/ExceptionMapperRegistryBuilder.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/exception/ExceptionMapperRegistryBuilder.java
@@ -30,7 +30,14 @@ public final class ExceptionMapperRegistryBuilder {
 	}
 
 	private void registerExceptionMapper(JsonApiExceptionMapper<? extends Throwable> exceptionMapper) {
-		Class<? extends Throwable> exceptionClass = getGenericType(exceptionMapper.getClass());
+		Class<? extends JsonApiExceptionMapper> mapperClass = exceptionMapper.getClass();
+		Class<? extends Throwable> exceptionClass = getGenericType(mapperClass);
+		if(exceptionClass == null && mapperClass.getName().contains("$$")){
+			// deal if dynamic proxies, like in CDI
+			mapperClass = (Class<? extends JsonApiExceptionMapper>) mapperClass.getSuperclass();
+			exceptionClass = getGenericType(mapperClass);
+		}
+
 		exceptionMappers.add(new ExceptionMapperType(exceptionClass, exceptionMapper));
 	}
 

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/exception/ExceptionMapperType.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/exception/ExceptionMapperType.java
@@ -1,7 +1,6 @@
 package io.crnk.core.engine.internal.exception;
 
 import io.crnk.core.engine.error.JsonApiExceptionMapper;
-import io.crnk.core.engine.internal.utils.PreconditionUtil;
 
 import java.util.Objects;
 
@@ -12,7 +11,6 @@ final class ExceptionMapperType {
 	public ExceptionMapperType(Class<? extends Throwable> exceptionClass, JsonApiExceptionMapper exceptionMapper) {
 		this.exceptionMapper = exceptionMapper;
 		this.exceptionClass = exceptionClass;
-		PreconditionUtil.assertNotNull("exceptionClass cannot be null", exceptionClass);
 	}
 
 	public Class<? extends Throwable> getExceptionClass() {

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/exception/ExceptionMapperType.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/exception/ExceptionMapperType.java
@@ -1,6 +1,7 @@
 package io.crnk.core.engine.internal.exception;
 
 import io.crnk.core.engine.error.JsonApiExceptionMapper;
+import io.crnk.core.engine.internal.utils.PreconditionUtil;
 
 import java.util.Objects;
 
@@ -11,6 +12,7 @@ final class ExceptionMapperType {
 	public ExceptionMapperType(Class<? extends Throwable> exceptionClass, JsonApiExceptionMapper exceptionMapper) {
 		this.exceptionMapper = exceptionMapper;
 		this.exceptionClass = exceptionClass;
+		PreconditionUtil.assertNotNull("exceptionClass cannot be null", exceptionClass);
 	}
 
 	public Class<? extends Throwable> getExceptionClass() {


### PR DESCRIPTION
adjusted implementation accordingly to make use of TypeLiteral to search for generic instead of raw type.