### PR TITLE
Crnk throws a ResourceException when requesting "/" #61

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/path/PathBuilder.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/path/PathBuilder.java
@@ -86,7 +86,7 @@ public class PathBuilder {
 	public JsonPath build(String path) {
 		String[] strings = splitPath(path);
 		if (strings.length == 0 || (strings.length == 1 && "".equals(strings[0]))) {
-			throw new ResourceException("Path is empty");
+			return null;
 		}
 
 		JsonPath previousJsonPath = null, currentJsonPath = null;

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/path/PathBuilderTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/path/PathBuilderTest.java
@@ -53,15 +53,15 @@ public class PathBuilderTest {
 	}
 
 	@Test
-	public void onEmptyPathShouldThrowResourceException() {
+	public void onEmptyPathReturnsNull() {
 		// GIVEN
 		String path = "/";
 
-		// THEN
-		expectedException.expect(ResourceException.class);
-
 		// WHEN
-		pathBuilder.build(path);
+		JsonPath jsonPath = pathBuilder.build(path);
+
+		// THEN
+		assertThat(jsonPath).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
updated PathBuilder to return null to signal no match as in all the other cases.