### PR TITLE
JpaModule: auto discovery of QueryDSL vs Criteria backend #74

### DIFF
--- a/crnk-jpa/src/main/java/io/crnk/jpa/JpaModule.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/JpaModule.java
@@ -27,7 +27,6 @@ import io.crnk.jpa.meta.MetaEntity;
 import io.crnk.jpa.meta.MetaJpaDataObject;
 import io.crnk.jpa.query.JpaQueryFactory;
 import io.crnk.jpa.query.JpaQueryFactoryContext;
-import io.crnk.jpa.query.criteria.JpaCriteriaQueryFactory;
 import io.crnk.jpa.query.querydsl.QuerydslQueryFactory;
 import io.crnk.jpa.query.querydsl.QuerydslRepositoryFilter;
 import io.crnk.jpa.query.querydsl.QuerydslTranslationContext;
@@ -133,7 +132,9 @@ public class JpaModule implements Module {
 		this.emFactory = emFactory;
 		this.em = em;
 		this.transactionRunner = transactionRunner;
-		setQueryFactory(JpaCriteriaQueryFactory.newInstance());
+
+		QueryFactoryDiscovery queryFactoryDiscovery = new QueryFactoryDiscovery();
+		setQueryFactory(queryFactoryDiscovery.discoverDefaultFactory());
 
 		if (emFactory != null) {
 			Set<ManagedType<?>> managedTypes = emFactory.getMetamodel().getManagedTypes();

--- a/crnk-jpa/src/main/java/io/crnk/jpa/internal/QueryFactoryDiscovery.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/internal/QueryFactoryDiscovery.java
@@ -1,0 +1,22 @@
+package io.crnk.jpa.internal;
+
+import io.crnk.core.engine.internal.utils.ClassUtils;
+import io.crnk.jpa.query.JpaQueryFactory;
+import io.crnk.jpa.query.criteria.JpaCriteriaQueryFactory;
+import io.crnk.jpa.query.querydsl.QuerydslQueryFactory;
+
+/**
+ * Checks for the presence of QueryDSL and makes use of it. Otherwise fallsback
+ * to Criteria aPI.
+ */
+public class QueryFactoryDiscovery {
+
+
+	public JpaQueryFactory discoverDefaultFactory() {
+		if (ClassUtils.existsClass("com.querydsl.jpa.impl.JPAQuery")) {
+			return QuerydslQueryFactory.newInstance();
+		} else {
+			return JpaCriteriaQueryFactory.newInstance();
+		}
+	}
+}

--- a/crnk-jpa/src/test/java/io/crnk/jpa/internal/QueryFactoryDiscoveryTest.java
+++ b/crnk-jpa/src/test/java/io/crnk/jpa/internal/QueryFactoryDiscoveryTest.java
@@ -1,0 +1,42 @@
+package io.crnk.jpa.internal;
+
+import io.crnk.core.engine.transaction.TransactionRunner;
+import io.crnk.jpa.JpaModule;
+import io.crnk.jpa.query.criteria.JpaCriteriaQueryFactory;
+import io.crnk.jpa.query.querydsl.QuerydslQueryFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.persistence.EntityManager;
+
+public class QueryFactoryDiscoveryTest {
+
+	@Test
+	public void checkDiscoverQueryDsl() {
+		QueryFactoryDiscovery discovery = new QueryFactoryDiscovery();
+		Assert.assertEquals(QuerydslQueryFactory.class, discovery.discoverDefaultFactory().getClass());
+	}
+
+	@Test
+	public void checkDiscoverCriteriaApi() {
+		QueryFactoryDiscovery discovery = new QueryFactoryDiscovery();
+
+		ClassLoader bootstrapClassLoader = ClassLoader.getSystemClassLoader().getParent();
+		ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+		Thread.currentThread().setContextClassLoader(bootstrapClassLoader);
+		try {
+			Assert.assertEquals(JpaCriteriaQueryFactory.class, discovery.discoverDefaultFactory().getClass());
+		} finally {
+			Thread.currentThread().setContextClassLoader(contextClassLoader);
+		}
+	}
+
+	@Test
+	public void checkJpaModuleIntegration() {
+		TransactionRunner transactionRunner = Mockito.mock(TransactionRunner.class);
+		EntityManager em = Mockito.mock(EntityManager.class);
+		JpaModule module = JpaModule.newServerModule(em, transactionRunner);
+		Assert.assertEquals(QuerydslQueryFactory.class, module.getQueryFactory().getClass());
+	}
+}


### PR DESCRIPTION
makes use of QueryDSL if available on classpath