### PR TITLE
Fix ordering of underlying and JSON names.  Fix logging message in ch…

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/AnnotationResourceInformationBuilder.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/AnnotationResourceInformationBuilder.java
@@ -223,7 +223,7 @@ public class AnnotationResourceInformationBuilder implements ResourceInformation
 			String underlyingName = ClassUtils.getGetterFieldName(getter);
 			PreconditionUtil.assertNotNull("not a valid getter", underlyingName);
 			String jsonName = resourceFieldNameTransformer.getName(getter);
-			fieldWrappers.add(getResourceField(resourceClass, getter, jsonName, underlyingName, getter.getReturnType(), getter.getGenericReturnType(), Arrays.asList(getter.getAnnotations())));
+			fieldWrappers.add(getResourceField(resourceClass, getter, underlyingName, jsonName, getter.getReturnType(), getter.getGenericReturnType(), Arrays.asList(getter.getAnnotations())));
 		}
 		return fieldWrappers;
 	}

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/utils/PropertyUtils.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/utils/PropertyUtils.java
@@ -209,11 +209,11 @@ public class PropertyUtils {
 		}
 	}
 
-	private void checkGetterNotNull(Method getter, Class<?> bean, String fieldName) {
+	private void checkGetterNotNull(Method getter, Class<?> beanClass, String fieldName) {
 		if (getter == null) {
 			String message = String
-					.format("Cannot find an getter for %s.%s", bean.getClass().getCanonicalName(), fieldName);
-			throw new PropertyException(message, bean, fieldName);
+					.format("Cannot find an getter for %s.%s", beanClass.getCanonicalName(), fieldName);
+			throw new PropertyException(message, beanClass, fieldName);
 		}
 	}
 


### PR DESCRIPTION
I was getting the following stack trace with a JSON name:

```
Caused by: io.crnk.core.engine.internal.utils.PropertyException: Cannot find an getter for java.lang.Class.delete-conflicts
	at io.crnk.core.engine.internal.utils.PropertyUtils.checkGetterNotNull(PropertyUtils.java:216)
	at io.crnk.core.engine.internal.utils.PropertyUtils.findPropertyClass(PropertyUtils.java:227)
	at io.crnk.core.engine.internal.utils.PropertyUtils.getPropertyClass(PropertyUtils.java:65)
	at io.crnk.core.engine.internal.information.resource.AnnotationResourceInformationBuilder.hasSetter(AnnotationResourceInformationBuilder.java:143)
	at io.crnk.core.engine.internal.information.resource.AnnotationResourceInformationBuilder.getResourceField(AnnotationResourceInformationBuilder.java:235)
	at io.crnk.core.engine.internal.information.resource.AnnotationResourceInformationBuilder.getGetterResourceFields(AnnotationResourceInformationBuilder.java:226)
	at io.crnk.core.engine.internal.information.resource.AnnotationResourceInformationBuilder.getResourceFields(AnnotationResourceInformationBuilder.java:206)
	at io.crnk.core.engine.internal.information.resource.AnnotationResourceInformationBuilder.build(AnnotationResourceInformationBuilder.java:159)
	at io.crnk.core.engine.internal.information.resource.AnnotationResourceInformationBuilder.build(AnnotationResourceInformationBuilder.java:155)
	at io.crnk.core.module.ModuleRegistry$CombinedResourceInformationBuilder.build(ModuleRegistry.java:465)
	at io.crnk.legacy.repository.information.DefaultResourceRepositoryInformationBuilder.build(DefaultResourceRepositoryInformationBuilder.java:57)
	at io.crnk.legacy.repository.information.DefaultResourceRepositoryInformationBuilder.build(DefaultResourceRepositoryInformationBuilder.java:46)
	at io.crnk.core.module.ModuleRegistry$CombinedRepositoryInformationBuilder.build(ModuleRegistry.java:516)
	at io.crnk.core.module.ModuleRegistry.mapRepositoryRegistrations(ModuleRegistry.java:294)
	at io.crnk.core.module.ModuleRegistry.applyRepositoryRegistrations(ModuleRegistry.java:236)
	at io.crnk.core.module.ModuleRegistry.init(ModuleRegistry.java:216)
	at io.crnk.core.boot.CrnkBoot.bootDiscovery(CrnkBoot.java:178)
	at io.crnk.core.boot.CrnkBoot.boot(CrnkBoot.java:159)
	at io.crnk.rs.CrnkFeature.configure(CrnkFeature.java:94)
	... 39 more

```

After digging in it turned out that the underlying name and json name were being swapped on the call to getResourceField causing failure of the Getter null check.  In addition, the checkGetterNotNull method was receiving a Class, calling getClass() and then writing that to the log.  In that case, the result was always java.lang.Class.
