### PR TITLE
ResourceFieldContributor for relationship repositories

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/information/contributor/ResourceFieldContributor.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/information/contributor/ResourceFieldContributor.java
@@ -1,0 +1,14 @@
+package io.crnk.core.engine.information.contributor;
+
+import java.util.List;
+
+import io.crnk.core.engine.information.resource.ResourceField;
+
+/**
+ * Can be implemented by RelationshipRepositoryV2 to contribute further (relationship) fields to a resource without
+ * modifying its source.
+ */
+public interface ResourceFieldContributor {
+
+	List<ResourceField> getResourceFields(ResourceFieldContributorContext context);
+}

--- a/crnk-core/src/main/java/io/crnk/core/engine/information/contributor/ResourceFieldContributorContext.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/information/contributor/ResourceFieldContributorContext.java
@@ -1,0 +1,9 @@
+package io.crnk.core.engine.information.contributor;
+
+import io.crnk.core.engine.information.InformationBuilder;
+
+public interface ResourceFieldContributorContext {
+
+	InformationBuilder getInformationBuilder();
+
+}

--- a/crnk-core/src/main/java/io/crnk/core/engine/information/resource/ResourceInformation.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/information/resource/ResourceInformation.java
@@ -5,11 +5,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import io.crnk.core.engine.document.Document;
 import io.crnk.core.engine.internal.information.resource.DefaultResourceInstanceBuilder;
@@ -31,30 +29,30 @@ public class ResourceInformation {
 	 * Found field of the id. Each resource has to contain a field marked by
 	 * JsonApiId annotation.
 	 */
-	private final ResourceField idField;
+	private ResourceField idField;
 
 	/**
 	 * A set of resource's attribute fields.
 	 */
-	private final ResourceAttributesBridge attributeFields;
+	private ResourceAttributesBridge attributeFields;
 
 	/**
 	 * A set of fields that contains non-standard Java types (List, Set, custom
 	 * classes, ...).
 	 */
-	private final List<ResourceField> relationshipFields;
+	private List<ResourceField> relationshipFields;
 
 	/**
 	 * An underlying field's name which contains meta information about for a
 	 * resource
 	 */
-	private final ResourceField metaField;
+	private ResourceField metaField;
 
 	/**
 	 * An underlying field's name which contain links information about for a
 	 * resource
 	 */
-	private final ResourceField linksField;
+	private ResourceField linksField;
 
 	/**
 	 * Type name of the resource. Corresponds to {@link JsonApiResource.type}
@@ -95,6 +93,13 @@ public class ResourceInformation {
 		this.instanceBuilder = instanceBuilder;
 		this.fields = fields;
 
+		initFields();
+		if (this.instanceBuilder == null) {
+			this.instanceBuilder = new DefaultResourceInstanceBuilder(resourceClass);
+		}
+	}
+
+	private void initFields() {
 		if (fields != null) {
 			List<ResourceField> idFields = ResourceFieldType.ID.filter(fields);
 			if (idFields.size() > 1) {
@@ -122,9 +127,12 @@ public class ResourceInformation {
 			this.linksField = null;
 			this.idField = null;
 		}
-		if (this.instanceBuilder == null) {
-			this.instanceBuilder = new DefaultResourceInstanceBuilder(resourceClass);
-		}
+	}
+
+	@Deprecated
+	public void setFields(List<ResourceField> fields){
+		this.fields = fields;
+		this.initFields();
 	}
 
 	private static <T> ResourceField getMetaField(Class<T> resourceClass, Collection<ResourceField> classFields) {
@@ -275,7 +283,7 @@ public class ResourceInformation {
 	}
 
 	public List<ResourceField> getFields() {
-		return fields;
+		return Collections.unmodifiableList(fields);
 	}
 
 }

--- a/crnk-core/src/test/java/io/crnk/core/engine/information/contributor/ResourceFieldContributorTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/information/contributor/ResourceFieldContributorTest.java
@@ -1,0 +1,168 @@
+package io.crnk.core.engine.information.contributor;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import io.crnk.core.boot.CrnkBoot;
+import io.crnk.core.engine.dispatcher.Response;
+import io.crnk.core.engine.document.Document;
+import io.crnk.core.engine.document.Relationship;
+import io.crnk.core.engine.document.Resource;
+import io.crnk.core.engine.document.ResourceIdentifier;
+import io.crnk.core.engine.http.HttpRequestContext;
+import io.crnk.core.engine.http.HttpRequestContextProvider;
+import io.crnk.core.engine.information.InformationBuilder;
+import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.information.resource.ResourceFieldAccessor;
+import io.crnk.core.engine.information.resource.ResourceFieldType;
+import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.internal.http.HttpRequestProcessorImpl;
+import io.crnk.core.engine.internal.utils.MultivaluedMap;
+import io.crnk.core.engine.registry.RegistryEntry;
+import io.crnk.core.engine.registry.ResourceRegistry;
+import io.crnk.core.mock.models.Project;
+import io.crnk.core.mock.models.Task;
+import io.crnk.core.mock.repository.MockRepositoryUtil;
+import io.crnk.core.mock.repository.ProjectRepository;
+import io.crnk.core.mock.repository.ProjectToTaskRepository;
+import io.crnk.core.mock.repository.TaskRepository;
+import io.crnk.core.module.SimpleModule;
+import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.queryspec.repository.TaskToProjectRelationshipRepository;
+import io.crnk.core.resource.annotations.LookupIncludeBehavior;
+import io.crnk.core.resource.annotations.SerializeType;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ResourceFieldContributorTest {
+
+	private CrnkBoot boot;
+
+	private ContributorRelationshipRepository contributedRepository;
+
+	@Before
+	public void setup() {
+		MockRepositoryUtil.clear();
+		contributedRepository = Mockito.spy(new ContributorRelationshipRepository());
+
+		SimpleModule testModule = new SimpleModule("test");
+		testModule.addRepository(new TaskRepository());
+		testModule.addRepository(new ProjectRepository());
+		testModule.addRepository(new ProjectToTaskRepository());
+		testModule.addRepository(contributedRepository);
+
+		boot = new CrnkBoot();
+		boot.addModule(testModule);
+		boot.boot();
+	}
+
+	@After
+	public void teardown() {
+		MockRepositoryUtil.clear();
+	}
+
+	@Test
+	public void checkFieldAddedToResourceInformation() {
+		ResourceRegistry resourceRegistry = boot.getResourceRegistry();
+		RegistryEntry entry = resourceRegistry.getEntry(Task.class);
+		ResourceInformation resourceInformation = entry.getResourceInformation();
+		ResourceField contributedField = resourceInformation.findFieldByName("contributedProject");
+		Assert.assertNotNull(contributedField);
+		Assert.assertEquals("projects", contributedField.getOppositeResourceType());
+		Assert.assertEquals(SerializeType.LAZY, contributedField.getSerializeType());
+	}
+
+	@Test
+	public void checkInclusionUponRequest() {
+		TaskRepository repo = new TaskRepository();
+		Task task = new Task();
+		task.setId(1L);
+		task.setName("someTask");
+		repo.save(task);
+
+		HttpRequestProcessorImpl requestDispatcher = boot.getRequestDispatcher();
+
+		HttpRequestContextProvider httpRequestContextProvider = boot.getModuleRegistry().getHttpRequestContextProvider();
+		HttpRequestContext request = Mockito.mock(HttpRequestContext.class);
+		httpRequestContextProvider.onRequestStarted(request);
+
+		Map<String, Set<String>> parameters = new HashMap<>();
+		parameters.put("include", Sets.newHashSet("contributedProject"));
+		Response response = requestDispatcher.dispatchRequest("tasks", "GET", parameters, null, null);
+
+		Document document = response.getDocument();
+		Resource resource = document.getCollectionData().get().get(0);
+		Assert.assertEquals("1", resource.getId());
+		Assert.assertEquals("tasks", resource.getType());
+		Assert.assertEquals("someTask", resource.getAttributes().get("name").asText());
+
+		Relationship relationship = resource.getRelationships().get("contributedProject");
+		Assert.assertNotNull(relationship);
+		ResourceIdentifier relationshipId = relationship.getSingleData().get();
+		Assert.assertEquals("projects", relationshipId.getType());
+		Assert.assertEquals("11", relationshipId.getId());
+
+		List<Resource> included = document.getIncluded();
+		Assert.assertEquals(1, included.size());
+		Resource includedResource = included.get(0);
+		Assert.assertEquals("projects", includedResource.getType());
+		Assert.assertEquals("11", includedResource.getId());
+		Assert.assertEquals("someProject", includedResource.getAttributes().get("name").asText());
+	}
+
+
+	class ContributorRelationshipRepository extends TaskToProjectRelationshipRepository implements ResourceFieldContributor {
+
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public MultivaluedMap<Long, Project> findTargets(Iterable<Long> sourceIds, String fieldName, QuerySpec querySpec) {
+			MultivaluedMap<Long, Project> map = new MultivaluedMap<>();
+
+			Iterator<Long> iterator = sourceIds.iterator();
+			while (iterator.hasNext()) {
+				Long sourceId = iterator.next();
+				if (fieldName.equals("contributedProject")) {
+					Project project = new Project();
+					project.setId(sourceId + 10);
+					project.setName("someProject");
+					map.add(sourceId, project);
+				}
+			}
+			return map;
+		}
+
+
+		@Override
+		public List<ResourceField> getResourceFields(ResourceFieldContributorContext context) {
+			InformationBuilder.Field fieldBuilder = context.getInformationBuilder().createResourceField();
+			fieldBuilder.jsonName("contributedProject");
+			fieldBuilder.underlyingName("contributedProject");
+			fieldBuilder.type(Project.class);
+			fieldBuilder.oppositeResourceType("projects");
+			fieldBuilder.lookupIncludeBehavior(LookupIncludeBehavior.AUTOMATICALLY_ALWAYS);
+			fieldBuilder.fieldType(ResourceFieldType.RELATIONSHIP);
+			fieldBuilder.accessor(new ResourceFieldAccessor() {
+				@Override
+				public Object getValue(Object resource) {
+					return null;
+				}
+
+				@Override
+				public void setValue(Object resource, Object fieldValue) {
+				}
+			});
+			return Arrays.asList(fieldBuilder.build());
+		}
+	}
+
+
+}

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/repository/TaskToProjectRelationshipRepository.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/repository/TaskToProjectRelationshipRepository.java
@@ -31,5 +31,4 @@ public class TaskToProjectRelationshipRepository extends RelationshipRepositoryB
 			public String name = "value";
 		};
 	}
-
 }


### PR DESCRIPTION
ResourceFieldContributor introduced that allows to introduce new fields on a resource without modifying the resources or having to implement an entire ResourceInformation builder. Provides an easy way
to attach new relationships to existing code base.