### PR TITLE
Relationship repository lookup behavior overrides the global setting

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/IncludeLookupSetter.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/IncludeLookupSetter.java
@@ -10,6 +10,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.crnk.core.boot.CrnkProperties;
 import io.crnk.core.engine.document.Document;
 import io.crnk.core.engine.document.Relationship;
@@ -31,16 +34,12 @@ import io.crnk.core.resource.annotations.SerializeType;
 import io.crnk.core.utils.Nullable;
 import io.crnk.legacy.internal.QueryParamsAdapter;
 import io.crnk.legacy.internal.RepositoryMethodParameterProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class IncludeLookupSetter {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(IncludeLookupSetter.class);
 
 	private final ResourceRegistry resourceRegistry;
-
-	private final LookupIncludeBehavior globalLookupIncludeBehavior;
 
 	private ResourceMapper resourceMapper;
 
@@ -54,7 +53,6 @@ public class IncludeLookupSetter {
 		this.resourceMapper = resourceMapper;
 		this.resourceRegistry = resourceRegistry;
 
-		this.globalLookupIncludeBehavior = IncludeLookupUtil.getDefaultLookupIncludeBehavior(propertiesProvider);
 		IncludeBehavior includeBehavior = IncludeLookupUtil.getIncludeBehavior(propertiesProvider);
 		this.util = new IncludeLookupUtil(resourceRegistry, includeBehavior);
 		this.allowPagination = propertiesProvider != null && Boolean.parseBoolean(propertiesProvider.getProperty(CrnkProperties
@@ -155,15 +153,13 @@ public class IncludeLookupSetter {
 				LookupIncludeBehavior fieldLookupIncludeBehavior = resourceField.getLookupIncludeAutomatically();
 
 				Set<Resource> populatedResources;
-				if (fieldLookupIncludeBehavior == LookupIncludeBehavior.AUTOMATICALLY_ALWAYS
-						|| globalLookupIncludeBehavior == LookupIncludeBehavior.AUTOMATICALLY_ALWAYS) {
+				if (fieldLookupIncludeBehavior == LookupIncludeBehavior.AUTOMATICALLY_ALWAYS) {
 					// lookup resources by making repository calls
 					populatedResources =
 							lookupRelationshipField(resourcesWithField, resourceField, queryAdapter, parameterProvider,
 									resourceMap, entityMap);
 				}
-				else if (fieldLookupIncludeBehavior == LookupIncludeBehavior.AUTOMATICALLY_WHEN_NULL
-						|| globalLookupIncludeBehavior == LookupIncludeBehavior.AUTOMATICALLY_WHEN_NULL) {
+				else if (fieldLookupIncludeBehavior == LookupIncludeBehavior.AUTOMATICALLY_WHEN_NULL) {
 					// try to populate from entities
 					Set<Resource> extractedResources =
 							extractRelationshipField(resourcesWithField, resourceField, queryAdapter, resourceMap, entityMap,

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/IncludeLookupUtil.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/IncludeLookupUtil.java
@@ -32,23 +32,28 @@ public class IncludeLookupUtil {
 	}
 
 
-	public static LookupIncludeBehavior getDefaultLookupIncludeBehavior(PropertiesProvider propertiesProvider) {
+	public static LookupIncludeBehavior getGlolbalLookupIncludeBehavior(PropertiesProvider propertiesProvider) {
 		if (propertiesProvider == null) {
-			return LookupIncludeBehavior.NONE;
+			return LookupIncludeBehavior.DEFAULT;
 		}
+		
 		// determine system property for include look up
 		String includeAutomaticallyString = propertiesProvider.getProperty(CrnkProperties.INCLUDE_AUTOMATICALLY);
-		boolean includeAutomatically = Boolean.parseBoolean(includeAutomaticallyString);
 		String includeAutomaticallyOverwriteString =
 				propertiesProvider.getProperty(CrnkProperties.INCLUDE_AUTOMATICALLY_OVERWRITE);
-		boolean includeAutomaticallyOverwrite = Boolean.parseBoolean(includeAutomaticallyOverwriteString);
-
-		if (includeAutomaticallyOverwrite) {
-			return LookupIncludeBehavior.AUTOMATICALLY_ALWAYS;
-		} else if (includeAutomatically) {
-			return LookupIncludeBehavior.AUTOMATICALLY_WHEN_NULL;
+		
+		if ((includeAutomaticallyString != null) || (includeAutomaticallyOverwriteString != null)) {
+			boolean includeAutomatically = Boolean.parseBoolean(includeAutomaticallyString);
+			boolean includeAutomaticallyOverwrite = Boolean.parseBoolean(includeAutomaticallyOverwriteString);
+	
+			if (includeAutomaticallyOverwrite) {
+				return LookupIncludeBehavior.AUTOMATICALLY_ALWAYS;
+			} else if (includeAutomatically) {
+				return LookupIncludeBehavior.AUTOMATICALLY_WHEN_NULL;
+			}
 		}
-		return LookupIncludeBehavior.NONE;
+		
+		return LookupIncludeBehavior.DEFAULT;
 	}
 
 	public static IncludeBehavior getIncludeBehavior(PropertiesProvider propertiesProvider) {

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/information/DefaultInformationBuilder.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/information/DefaultInformationBuilder.java
@@ -166,7 +166,7 @@ public class DefaultInformationBuilder implements InformationBuilder {
 
 		private String oppositeResourceType = null;
 
-		private LookupIncludeBehavior lookupIncludeBehavior = LookupIncludeBehavior.NONE;
+		private LookupIncludeBehavior lookupIncludeBehavior = LookupIncludeBehavior.DEFAULT;
 
 		private ResourceFieldType fieldType = ResourceFieldType.ATTRIBUTE;
 

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/DefaultResourceInformationProvider.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/DefaultResourceInformationProvider.java
@@ -6,6 +6,7 @@ import io.crnk.core.engine.information.resource.ResourceFieldInformationProvider
 import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.core.engine.internal.utils.FieldOrderedComparator;
+import io.crnk.core.engine.properties.PropertiesProvider;
 import io.crnk.core.exception.RepositoryAnnotationNotFoundException;
 import io.crnk.core.exception.ResourceIdNotFoundException;
 import io.crnk.core.resource.annotations.JsonApiResource;
@@ -25,13 +26,15 @@ public class DefaultResourceInformationProvider extends ResourceInformationProvi
 
 
 	public DefaultResourceInformationProvider(
+			PropertiesProvider propertiesProvider,
 			ResourceFieldInformationProvider... resourceFieldInformationProviders) {
-		this(Arrays.asList(resourceFieldInformationProviders));
+		this(propertiesProvider, Arrays.asList(resourceFieldInformationProviders));
 	}
 
 	public DefaultResourceInformationProvider(
+			PropertiesProvider propertiesProvider,
 			List<ResourceFieldInformationProvider> resourceFieldInformationProviders) {
-		super(resourceFieldInformationProviders);
+		super(propertiesProvider, resourceFieldInformationProviders);
 	}
 
 

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/jackson/JacksonModule.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/jackson/JacksonModule.java
@@ -32,7 +32,10 @@ public class JacksonModule implements Module {
 		ResourceFieldInformationProvider jacksonFieldProvider = new JacksonResourceFieldInformationProvider();
 
 		// TODO move somewhere else and make use of a SerializerExtension
-		context.addResourceInformationBuilder(new DefaultResourceInformationProvider(defaultFieldProvider, jacksonFieldProvider));
+		context.addResourceInformationBuilder(new DefaultResourceInformationProvider(
+			context.getPropertiesProvider(),
+			defaultFieldProvider, 
+			jacksonFieldProvider));
 	}
 
 

--- a/crnk-core/src/main/java/io/crnk/core/module/Module.java
+++ b/crnk-core/src/main/java/io/crnk/core/module/Module.java
@@ -13,6 +13,7 @@ import io.crnk.core.engine.information.resource.ResourceInformationProvider;
 import io.crnk.core.engine.internal.exception.ExceptionMapperLookup;
 import io.crnk.core.engine.internal.exception.ExceptionMapperRegistry;
 import io.crnk.core.engine.parser.TypeParser;
+import io.crnk.core.engine.properties.PropertiesProvider;
 import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.registry.RegistryEntryBuilder;
 import io.crnk.core.engine.registry.ResourceRegistry;
@@ -66,6 +67,13 @@ public interface Module {
 		 */
 		void addRegistryPart(String prefix, ResourceRegistryPart part);
 
+		/**
+		 * Return the {@link PropertiesProvider}.
+		 * 
+		 * @return {@link PropertiesProvider}
+		 */
+		PropertiesProvider getPropertiesProvider();
+		
 		/**
 		 * @return ServiceDiscovery
 		 */

--- a/crnk-core/src/main/java/io/crnk/core/module/ModuleRegistry.java
+++ b/crnk-core/src/main/java/io/crnk/core/module/ModuleRegistry.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.crnk.core.engine.dispatcher.RequestDispatcher;
 import io.crnk.core.engine.error.ExceptionMapper;
 import io.crnk.core.engine.error.JsonApiExceptionMapper;
@@ -886,6 +887,11 @@ public class ModuleRegistry {
 		public ResourceFilterDirectory getResourceFilterDirectory() {
 			checkState(InitializedState.INITIALIZING, InitializedState.INITIALIZED);
 			return filterBehaviorProvider;
+		}
+
+		@Override
+		public PropertiesProvider getPropertiesProvider() {
+			return propertiesProvider;
 		}
 	}
 }

--- a/crnk-core/src/main/java/io/crnk/core/resource/annotations/JsonApiRelation.java
+++ b/crnk-core/src/main/java/io/crnk/core/resource/annotations/JsonApiRelation.java
@@ -2,7 +2,9 @@ package io.crnk.core.resource.annotations;
 
 import java.lang.annotation.*;
 
-import static io.crnk.core.resource.annotations.LookupIncludeBehavior.NONE;
+import io.crnk.core.boot.CrnkProperties;
+
+import static io.crnk.core.resource.annotations.LookupIncludeBehavior.DEFAULT;
 import static io.crnk.core.resource.annotations.SerializeType.LAZY;
 
 /**
@@ -31,7 +33,11 @@ public @interface JsonApiRelation {
 	 * (Optional) This attribute is used to make automatic value assignment using a defined relationship resource if such resource
 	 * is available.
 	 * <p>
-	 * NONE (Default) - do not automatically call this fields relationship findManyTargets or findOneTarget.
+	 * DEFAULT (Default) - consults the global lookup behavior set by {@link CrnkProperties#INCLUDE_AUTOMATICALLY} and
+	 * {@link CrnkProperties#INCLUDE_AUTOMATICALLY_OVERWRITE} first, using the value set by these global settings.  If not
+	 * set globally, this setting will fall back to {@link LookupIncludeBehavior#NONE}.
+	 * <p>
+	 * NONE - do not automatically call this fields relationship findManyTargets or findOneTarget.
 	 * <p>
 	 * AUTOMATICALLY_WHEN_NULL - automatically perform a relationship findManyTargets or findOneTarget when this field's value
 	 * is null and it is either A. requested in an include query legacy B. SerializeType.ONLY_ID or SerializeType.EAGER
@@ -39,7 +45,7 @@ public @interface JsonApiRelation {
 	 * <p>
 	 * AUTOMATICALLY_ALWAYS - always automatically call a relationship's findManyTargets or findOneTarget and overwrite this field.
 	 */
-	LookupIncludeBehavior lookUp() default NONE;
+	LookupIncludeBehavior lookUp() default DEFAULT;
 
 	/**
 	 * @return opposite attribute name in case of a bidirectional association. Used by {@link io.crnk.core.repository.RelationshipRepositoryBase} to implement

--- a/crnk-core/src/main/java/io/crnk/core/resource/annotations/LookupIncludeBehavior.java
+++ b/crnk-core/src/main/java/io/crnk/core/resource/annotations/LookupIncludeBehavior.java
@@ -8,6 +8,12 @@ package io.crnk.core.resource.annotations;
  */
 public enum LookupIncludeBehavior {
 	/**
+	 * Defines that the relationship will be traversed by
+	 * consulting the global setting first and, if not
+	 * set, this value will fall back to {@link LookupIncludeBehavior#NONE} by default. 
+	 */
+	DEFAULT,
+	/**
 	 * Defines that relationship resource is never called.
 	 */
 	NONE,

--- a/crnk-core/src/test/java/io/crnk/core/module/SimpleModuleTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/module/SimpleModuleTest.java
@@ -1,7 +1,17 @@
 package io.crnk.core.module;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.crnk.core.engine.dispatcher.RequestDispatcher;
 import io.crnk.core.engine.error.ExceptionMapper;
 import io.crnk.core.engine.error.JsonApiExceptionMapper;
@@ -20,20 +30,18 @@ import io.crnk.core.engine.internal.exception.ExceptionMapperRegistry;
 import io.crnk.core.engine.internal.exception.ExceptionMapperRegistryTest.IllegalStateExceptionMapper;
 import io.crnk.core.engine.internal.registry.ResourceRegistryImpl;
 import io.crnk.core.engine.parser.TypeParser;
-import io.crnk.core.engine.registry.*;
+import io.crnk.core.engine.properties.NullPropertiesProvider;
+import io.crnk.core.engine.properties.PropertiesProvider;
+import io.crnk.core.engine.registry.DefaultResourceRegistryPart;
+import io.crnk.core.engine.registry.RegistryEntry;
+import io.crnk.core.engine.registry.RegistryEntryBuilder;
+import io.crnk.core.engine.registry.ResourceRegistry;
+import io.crnk.core.engine.registry.ResourceRegistryPart;
 import io.crnk.core.engine.security.SecurityProvider;
 import io.crnk.core.module.Module.ModuleContext;
 import io.crnk.core.module.discovery.ResourceLookup;
 import io.crnk.core.module.discovery.ServiceDiscovery;
 import io.crnk.core.repository.decorate.RepositoryDecoratorFactory;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 
 public class SimpleModuleTest {
 
@@ -356,6 +364,11 @@ public class SimpleModuleTest {
 		@Override
 		public ResourceFilterDirectory getResourceFilterDirectory() {
 			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public PropertiesProvider getPropertiesProvider() {
+			return new NullPropertiesProvider();
 		}
 	}
 }

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/AbstractQuerySpecTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/AbstractQuerySpecTest.java
@@ -11,6 +11,8 @@ import io.crnk.core.engine.internal.information.resource.DefaultResourceFieldInf
 import io.crnk.core.engine.internal.information.resource.DefaultResourceInformationProvider;
 import io.crnk.core.engine.internal.jackson.JacksonResourceFieldInformationProvider;
 import io.crnk.core.engine.parser.TypeParser;
+import io.crnk.core.engine.properties.NullPropertiesProvider;
+import io.crnk.core.engine.properties.PropertiesProvider;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.engine.url.ConstantServiceUrlProvider;
 import io.crnk.core.mock.models.Task;
@@ -42,7 +44,7 @@ public abstract class AbstractQuerySpecTest {
 
 	@Before
 	public void setup() {
-		ResourceInformationProvider resourceInformationProvider = new DefaultResourceInformationProvider(new DefaultResourceFieldInformationProvider(), new JacksonResourceFieldInformationProvider()) {
+		ResourceInformationProvider resourceInformationProvider = new DefaultResourceInformationProvider(new NullPropertiesProvider(), new DefaultResourceFieldInformationProvider(), new JacksonResourceFieldInformationProvider()) {
 
 			@Override
 			protected List<ResourceField> getResourceFields(Class<?> resourceClass) {

--- a/crnk-core/src/test/java/io/crnk/core/resource/internal/IncludeLookupUtilTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/resource/internal/IncludeLookupUtilTest.java
@@ -13,24 +13,24 @@ public class IncludeLookupUtilTest extends AbstractDocumentMapperTest {
 
 	@Test
 	public void checkDefaultLookupIncludeBehavior() {
-		Assert.assertEquals(LookupIncludeBehavior.NONE, IncludeLookupUtil.getDefaultLookupIncludeBehavior(null));
+		Assert.assertEquals(LookupIncludeBehavior.DEFAULT, IncludeLookupUtil.getGlolbalLookupIncludeBehavior(null));
 
 		PropertiesProvider propertiesProvider = Mockito.mock(PropertiesProvider.class);
-		Assert.assertEquals(LookupIncludeBehavior.NONE, IncludeLookupUtil.getDefaultLookupIncludeBehavior(propertiesProvider));
+		Assert.assertEquals(LookupIncludeBehavior.DEFAULT, IncludeLookupUtil.getGlolbalLookupIncludeBehavior(propertiesProvider));
 
 		Mockito.when(propertiesProvider.getProperty(CrnkProperties.INCLUDE_AUTOMATICALLY)).thenReturn("true");
 		Assert.assertEquals(LookupIncludeBehavior.AUTOMATICALLY_WHEN_NULL,
-				IncludeLookupUtil.getDefaultLookupIncludeBehavior(propertiesProvider));
+				IncludeLookupUtil.getGlolbalLookupIncludeBehavior(propertiesProvider));
 
 		Mockito.when(propertiesProvider.getProperty(CrnkProperties.INCLUDE_AUTOMATICALLY)).thenReturn("false");
-		Assert.assertEquals(LookupIncludeBehavior.NONE, IncludeLookupUtil.getDefaultLookupIncludeBehavior(propertiesProvider));
+		Assert.assertEquals(LookupIncludeBehavior.DEFAULT, IncludeLookupUtil.getGlolbalLookupIncludeBehavior(propertiesProvider));
 
 		Mockito.when(propertiesProvider.getProperty(CrnkProperties.INCLUDE_AUTOMATICALLY_OVERWRITE)).thenReturn("true");
 		Assert.assertEquals(LookupIncludeBehavior.AUTOMATICALLY_ALWAYS,
-				IncludeLookupUtil.getDefaultLookupIncludeBehavior(propertiesProvider));
+				IncludeLookupUtil.getGlolbalLookupIncludeBehavior(propertiesProvider));
 
 		Mockito.when(propertiesProvider.getProperty(CrnkProperties.INCLUDE_AUTOMATICALLY_OVERWRITE)).thenReturn("false");
-		Assert.assertEquals(LookupIncludeBehavior.NONE, IncludeLookupUtil.getDefaultLookupIncludeBehavior(propertiesProvider));
+		Assert.assertEquals(LookupIncludeBehavior.DEFAULT, IncludeLookupUtil.getGlolbalLookupIncludeBehavior(propertiesProvider));
 	}
 
 }

--- a/crnk-core/src/test/java/io/crnk/legacy/queryParams/AbstractQueryParamsTest.java
+++ b/crnk-core/src/test/java/io/crnk/legacy/queryParams/AbstractQueryParamsTest.java
@@ -10,6 +10,7 @@ import io.crnk.core.engine.information.resource.ResourceInformationProvider;
 import io.crnk.core.engine.internal.information.resource.DefaultResourceFieldInformationProvider;
 import io.crnk.core.engine.internal.information.resource.DefaultResourceInformationProvider;
 import io.crnk.core.engine.internal.jackson.JacksonResourceFieldInformationProvider;
+import io.crnk.core.engine.properties.NullPropertiesProvider;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.module.ModuleRegistry;
 import io.crnk.core.module.SimpleModule;
@@ -38,8 +39,10 @@ public abstract class AbstractQueryParamsTest {
 	public void setup() {
 		JsonServiceLocator jsonServiceLocator = new SampleJsonServiceLocator();
 		ResourceInformationProvider resourceInformationProvider =
-				new DefaultResourceInformationProvider(new DefaultResourceFieldInformationProvider(),
-						new JacksonResourceFieldInformationProvider());
+				new DefaultResourceInformationProvider(
+					new NullPropertiesProvider(),
+					new DefaultResourceFieldInformationProvider(),
+					new JacksonResourceFieldInformationProvider());
 
 		SimpleModule testModule = new SimpleModule("test");
 

--- a/crnk-core/src/test/java/io/crnk/legacy/queryParams/QueryParamsAdapterTest.java
+++ b/crnk-core/src/test/java/io/crnk/legacy/queryParams/QueryParamsAdapterTest.java
@@ -7,6 +7,7 @@ import io.crnk.core.engine.internal.information.resource.DefaultResourceFieldInf
 import io.crnk.core.engine.internal.information.resource.DefaultResourceInformationProvider;
 import io.crnk.core.engine.internal.jackson.JacksonResourceFieldInformationProvider;
 import io.crnk.core.engine.internal.registry.ResourceRegistryImpl;
+import io.crnk.core.engine.properties.NullPropertiesProvider;
 import io.crnk.core.engine.registry.DefaultResourceRegistryPart;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.engine.url.ConstantServiceUrlProvider;
@@ -26,7 +27,10 @@ public class QueryParamsAdapterTest {
 		ResourceRegistry resourceRegistry = new ResourceRegistryImpl(new DefaultResourceRegistryPart(), moduleRegistry);
 		QueryParams params = new QueryParams();
 
-		DefaultResourceInformationProvider builder = new DefaultResourceInformationProvider(new DefaultResourceFieldInformationProvider(), new JacksonResourceFieldInformationProvider());
+		DefaultResourceInformationProvider builder = new DefaultResourceInformationProvider(
+			new NullPropertiesProvider(),
+			new DefaultResourceFieldInformationProvider(), 
+			new JacksonResourceFieldInformationProvider());
 		builder.init(new DefaultResourceInformationProviderContext(builder, new DefaultInformationBuilder(moduleRegistry.getTypeParser()),  moduleRegistry.getTypeParser(), new ObjectMapper()));
 		ResourceInformation info = builder.build(Task.class);
 

--- a/crnk-jpa/src/main/java/io/crnk/jpa/JpaModule.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/JpaModule.java
@@ -9,6 +9,7 @@ import io.crnk.core.engine.information.resource.ResourceInformationProvider;
 import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.core.engine.internal.utils.ExceptionUtil;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
+import io.crnk.core.engine.properties.PropertiesProvider;
 import io.crnk.core.engine.transaction.TransactionRunner;
 import io.crnk.core.module.InitializingModule;
 import io.crnk.core.queryspec.QuerySpec;
@@ -279,7 +280,7 @@ public class JpaModule implements InitializingModule {
 		this.resourceMetaLookup.setModuleContext(context);
 		this.resourceMetaLookup.initialize();
 
-		context.addResourceInformationBuilder(getResourceInformationProvider());
+		context.addResourceInformationBuilder(getResourceInformationProvider(context.getPropertiesProvider()));
 		context.addExceptionMapper(new OptimisticLockExceptionMapper());
 		context.addExceptionMapper(new PersistenceExceptionMapper(context));
 		context.addExceptionMapper(new PersistenceRollbackExceptionMapper(context));
@@ -465,11 +466,12 @@ public class JpaModule implements InitializingModule {
 	}
 
 	/**
+	 * @param propertiesProvider 
 	 * @return ResourceInformationProvider used to describe JPA classes.
 	 */
-	public ResourceInformationProvider getResourceInformationProvider() {
+	public ResourceInformationProvider getResourceInformationProvider(PropertiesProvider propertiesProvider) {
 		if (resourceInformationProvider == null) {
-			resourceInformationProvider = new JpaResourceInformationProvider(jpaMetaLookup);
+			resourceInformationProvider = new JpaResourceInformationProvider(propertiesProvider, jpaMetaLookup);
 		}
 		return resourceInformationProvider;
 	}

--- a/crnk-jpa/src/main/java/io/crnk/jpa/internal/JpaResourceInformationProvider.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/internal/JpaResourceInformationProvider.java
@@ -13,6 +13,7 @@ import io.crnk.core.engine.internal.information.resource.ResourceInformationProv
 import io.crnk.core.engine.internal.jackson.JacksonResourceFieldInformationProvider;
 import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.core.engine.parser.TypeParser;
+import io.crnk.core.engine.properties.PropertiesProvider;
 import io.crnk.core.resource.annotations.LookupIncludeBehavior;
 import io.crnk.jpa.annotations.JpaResource;
 import io.crnk.jpa.meta.MetaEntity;
@@ -36,8 +37,10 @@ public class JpaResourceInformationProvider extends ResourceInformationProviderB
 
 	private final MetaLookup metaLookup;
 
-	public JpaResourceInformationProvider(MetaLookup metaLookup) {
-		super(Arrays.asList(new DefaultResourceFieldInformationProvider(), new JpaResourceFieldInformationProvider(), new JacksonResourceFieldInformationProvider()));
+	public JpaResourceInformationProvider(PropertiesProvider propertiesProvider, MetaLookup metaLookup) {
+		super(
+			propertiesProvider, 
+			Arrays.asList(new DefaultResourceFieldInformationProvider(), new JpaResourceFieldInformationProvider(), new JacksonResourceFieldInformationProvider()));
 		this.metaLookup = metaLookup;
 	}
 

--- a/crnk-jpa/src/test/java/io/crnk/jpa/JpaPartialEntityExposureTest.java
+++ b/crnk-jpa/src/test/java/io/crnk/jpa/JpaPartialEntityExposureTest.java
@@ -3,6 +3,7 @@ package io.crnk.jpa;
 import io.crnk.client.legacy.ResourceRepositoryStub;
 import io.crnk.core.engine.information.resource.ResourceField;
 import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.properties.NullPropertiesProvider;
 import io.crnk.jpa.internal.JpaResourceInformationProvider;
 import io.crnk.jpa.model.RelatedEntity;
 import io.crnk.jpa.model.TestEntity;
@@ -61,7 +62,7 @@ public class JpaPartialEntityExposureTest extends AbstractJpaJerseyTest {
 	@Test
 	public void testInformationBuilder() {
 		EntityManager em = null;
-		JpaResourceInformationProvider builder = new JpaResourceInformationProvider(module.getJpaMetaLookup());
+		JpaResourceInformationProvider builder = new JpaResourceInformationProvider(new NullPropertiesProvider(), module.getJpaMetaLookup());
 		ResourceInformation info = builder.build(TestEntity.class);
 		List<ResourceField> relationshipFields = info.getRelationshipFields();
 		Assert.assertEquals(0, relationshipFields.size());

--- a/crnk-jpa/src/test/java/io/crnk/jpa/JpaResourceInformationProviderTest.java
+++ b/crnk-jpa/src/test/java/io/crnk/jpa/JpaResourceInformationProviderTest.java
@@ -5,6 +5,7 @@ import io.crnk.core.engine.information.resource.ResourceField;
 import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.information.DefaultInformationBuilder;
 import io.crnk.core.engine.parser.TypeParser;
+import io.crnk.core.engine.properties.NullPropertiesProvider;
 import io.crnk.jpa.internal.JpaResourceInformationProvider;
 import io.crnk.jpa.meta.JpaMetaProvider;
 import io.crnk.jpa.model.*;
@@ -35,7 +36,7 @@ public class JpaResourceInformationProviderTest {
 		lookup = new MetaLookup();
 		lookup.addProvider(new JpaMetaProvider());
 		lookup.addProvider(new ResourceMetaProvider(false));
-		builder = new JpaResourceInformationProvider(lookup);
+		builder = new JpaResourceInformationProvider(new NullPropertiesProvider(), lookup);
 		builder.init(new DefaultResourceInformationProviderContext(builder, new DefaultInformationBuilder(new TypeParser()), new TypeParser(), new ObjectMapper()));
 	}
 

--- a/crnk-jpa/src/test/java/io/crnk/jpa/mapping/CustomResourceFieldTest.java
+++ b/crnk-jpa/src/test/java/io/crnk/jpa/mapping/CustomResourceFieldTest.java
@@ -5,6 +5,7 @@ import io.crnk.core.engine.information.resource.ResourceFieldAccess;
 import io.crnk.core.engine.information.resource.ResourceFieldAccessor;
 import io.crnk.core.engine.information.resource.ResourceFieldType;
 import io.crnk.core.engine.internal.information.resource.ResourceFieldImpl;
+import io.crnk.core.engine.properties.NullPropertiesProvider;
 import io.crnk.core.resource.annotations.LookupIncludeBehavior;
 import io.crnk.core.resource.annotations.SerializeType;
 import io.crnk.jpa.AbstractJpaJerseyTest;
@@ -92,7 +93,7 @@ public class CustomResourceFieldTest extends AbstractJpaJerseyTest {
 
 		if (server) {
 			MetaLookup metaLookup = module.getJpaMetaLookup();
-			module.setResourceInformationProvider(new JpaResourceInformationProvider(metaLookup) {
+			module.setResourceInformationProvider(new JpaResourceInformationProvider(new NullPropertiesProvider(), metaLookup) {
 
 				@Override
 				protected List<ResourceField> getResourceFields(Class clazz) {

--- a/crnk-meta/src/main/java/io/crnk/meta/MetaModule.java
+++ b/crnk-meta/src/main/java/io/crnk/meta/MetaModule.java
@@ -17,6 +17,7 @@ import io.crnk.core.engine.internal.information.DefaultInformationBuilder;
 import io.crnk.core.engine.internal.information.resource.DefaultResourceFieldInformationProvider;
 import io.crnk.core.engine.internal.information.resource.DefaultResourceInformationProvider;
 import io.crnk.core.engine.internal.jackson.JacksonResourceFieldInformationProvider;
+import io.crnk.core.engine.properties.PropertiesProvider;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.engine.registry.ResourceRegistryPartAdapter;
 import io.crnk.core.engine.registry.ResourceRegistryPartEvent;
@@ -126,7 +127,7 @@ public class MetaModule implements ModuleExtensionAware<MetaModuleExtension> {
 	public void setupModule(ModuleContext context) {
 		this.context = context;
 
-		informationBuilder = registerInformationBuilder();
+		informationBuilder = registerInformationBuilder(context.getPropertiesProvider());
 
 		if (context.isServer()) {
 			context.addFilter(new DocumentFilter() {
@@ -163,9 +164,10 @@ public class MetaModule implements ModuleExtensionAware<MetaModuleExtension> {
 		});
 	}
 
-	protected DefaultResourceInformationProvider registerInformationBuilder() {
+	protected DefaultResourceInformationProvider registerInformationBuilder(PropertiesProvider propertiesProvider) {
 		InformationBuilder informationBuilder = new DefaultInformationBuilder(context.getTypeParser());
 		DefaultResourceInformationProvider informationProvider = new DefaultResourceInformationProvider(
+				propertiesProvider,
 				new DefaultResourceFieldInformationProvider(),
 				new JacksonResourceFieldInformationProvider());
 		informationProvider.init(new DefaultResourceInformationProviderContext(informationProvider, informationBuilder,

--- a/crnk-rs/src/test/java/io/crnk/rs/JaxrsModuleTest.java
+++ b/crnk-rs/src/test/java/io/crnk/rs/JaxrsModuleTest.java
@@ -39,6 +39,7 @@ public class JaxrsModuleTest {
 		final ModuleRegistry moduleRegistry = new ModuleRegistry();
 		builder = new JaxrsModule.JaxrsResourceRepositoryInformationProvider();
 		final ResourceInformationProvider resourceInformationProvider = new DefaultResourceInformationProvider(
+				moduleRegistry.getPropertiesProvider(),
 				new DefaultResourceFieldInformationProvider(),
 				new JacksonResourceFieldInformationProvider());
 		resourceInformationProvider


### PR DESCRIPTION
As discussed via Gitter, this PR changes the handling of the lookup behavior so that relationship annotations can override the default global setting.  It introduces a new DEFAULT for lookup behavior and makes that the actual default if no other value is specified by the relationship annotation.  When the relationship lookup behavior is set to DEFAULT, it will look to the globally set value.  If the relationship lookup behavior is set to DEFAULT and the globally value is unset, the default will be up to the resource information provider in use (NONE, usually... although JPA does something different).  If the relationship lookup behavior is set to something other than DEFAULT, then that value will be used no matter what the value of the global behavior.
