### PR TITLE
Set the PropertiesProvider on to the ModuleRegistry at the beginning of boot

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/boot/CrnkBoot.java
+++ b/crnk-core/src/main/java/io/crnk/core/boot/CrnkBoot.java
@@ -148,6 +148,10 @@ public class CrnkBoot {
 		checkNotConfiguredYet();
 		configured = true;
 
+		// Set the properties provider into the registry early
+		// so that it is available to the modules being bootstrapped
+		moduleRegistry.setPropertiesProvider(propertiesProvider);
+
 		setupServiceUrlProvider();
 		setupServiceDiscovery();
 		bootDiscovery();
@@ -276,7 +280,6 @@ public class CrnkBoot {
 		}
 		moduleRegistry.addModule(module);
 		moduleRegistry.addModule(new CoreModule());
-		moduleRegistry.setPropertiesProvider(propertiesProvider);
 	}
 
 	private <T> List<T> getInstancesByType(Class<T> clazz) {


### PR DESCRIPTION
This PR changes the ordering of CrnkBoot bootstrapping to move setting of the PropertiesProvider on to the ModuleRegistry much earlier in the boot process.  With my last PR, I added the ability to retrieve the PropertiesProvider from within the ModuleContext where it could be used as necessary.  However, I didn't realize that the PropertiesProvider was not being set on the ModuleRegistry until the end of bootstrap.  This change allows for Module implementations to get the correct PropertiesProvider instance while they are in the midst of bootstrapping and fixes our use case of this functionality.
