### PR TITLE
Angular: avoid unncessary patchResource actions in FormBinding #121

### DIFF
--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/TSGeneratorExtension.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/TSGeneratorExtension.java
@@ -1,23 +1,19 @@
 package io.crnk.gen.typescript;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import groovy.lang.Closure;
-import io.crnk.gen.typescript.processor.TSEmptyObjectFactoryProcessor;
-import io.crnk.gen.typescript.processor.TSExpressionObjectProcessor;
-import io.crnk.gen.typescript.processor.TSImportProcessor;
-import io.crnk.gen.typescript.processor.TSIndexFileProcessor;
-import io.crnk.gen.typescript.processor.TSSourceProcessor;
+import io.crnk.gen.typescript.processor.*;
 import io.crnk.gen.typescript.transform.TSMetaDataObjectTransformation;
 import io.crnk.gen.typescript.transform.TSMetaEnumTypeTransformation;
 import io.crnk.gen.typescript.transform.TSMetaPrimitiveTypeTransformation;
 import io.crnk.gen.typescript.transform.TSMetaResourceRepositoryTransformation;
 import io.crnk.gen.typescript.writer.TSCodeStyle;
 import org.gradle.api.Project;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class TSGeneratorExtension {
 

--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/internal/TSGenerator.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/internal/TSGenerator.java
@@ -18,6 +18,8 @@ import io.crnk.meta.MetaLookup;
 import io.crnk.meta.internal.resource.ResourceMetaParitition;
 import io.crnk.meta.model.MetaElement;
 import io.crnk.meta.provider.resource.ResourceMetaProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -26,6 +28,8 @@ import java.util.*;
 import java.util.concurrent.Callable;
 
 public class TSGenerator {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(TSGenerator.class);
 
 	private ResourceMetaParitition resourveMetaPartition;
 
@@ -178,9 +182,15 @@ public class TSGenerator {
 
 	public void transformMetaToTypescript() {
 		Collection<MetaElement> elements = lookup.getMetaById().values();
+		LOGGER.debug("transforming {} elements", elements.size());
 		for (MetaElement element : elements) {
-			if (isRoot(element) && isGenerated(element)) {
+			boolean isRoot = isRoot(element);
+			boolean isGenerated = isGenerated(element);
+			if (isRoot && isGenerated) {
+				LOGGER.debug("transforming {}", element.getId());
 				transform(element, TSMetaTransformationOptions.EMPTY);
+			} else {
+				LOGGER.debug("ignoring {}, root={}, generated={}", element.getId(), isRoot, isGenerated);
 			}
 		}
 
@@ -271,7 +281,7 @@ public class TSGenerator {
 				int sep = prefix.lastIndexOf('.');
 				if (sep == -1) {
 					throw new IllegalStateException("failed to determine NPM package name for " + meta.getId()
-							+ ", configure plugin accordingly with typescriptGen.npmPackageMapping");
+							+ ", configure plugin accordingly with typescriptGen.npm.packageMapping for package '" + idPath + "' or above");
 				}
 				prefix = prefix.substring(0, sep);
 			}
@@ -291,9 +301,9 @@ public class TSGenerator {
 				}
 				int sep = prefix.lastIndexOf('.');
 				if (sep == -1) {
-					throw new IllegalStateException("failed to determine NPM package name for " + meta.getId() + " of type "
+					throw new IllegalStateException("failed to determine NPM package name for id " + meta.getId() + " of type "
 							+ meta.getClass().getSimpleName()
-							+ ", configure plugin accordingly with typescriptGen.npmPackageMapping");
+							+ ", configure plugin accordingly with typescriptGen.npm.packageMapping for package '" + idPath + "' or above");
 				}
 				prefix = prefix.substring(0, sep);
 			}

--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/processor/TSImportProcessor.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/processor/TSImportProcessor.java
@@ -60,6 +60,9 @@ public class TSImportProcessor implements TSSourceProcessor {
 	}
 
 	private static void addImport(TSSource refSource, TSSource source, TSNamedElement type) {
+		if (type instanceof TSAny) {
+			return;
+		}
 		String path = computeImportPath(refSource, source);
 		TSImport element = source.getImport(path);
 		if (element == null) {
@@ -72,6 +75,12 @@ public class TSImportProcessor implements TSSourceProcessor {
 
 	private static String computeImportPath(TSSource refSource, TSSource source) {
 		StringBuilder pathBuilder = new StringBuilder();
+		if (refSource.getNpmPackage() == null) {
+			throw new IllegalStateException(refSource.getName());
+		}
+		if (source.getNpmPackage() == null) {
+			throw new IllegalStateException(source.getName());
+		}
 		if (!source.getNpmPackage().equals(refSource.getNpmPackage())) {
 			appendThirdPartyImport(pathBuilder, refSource);
 		} else {

--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/transform/TSMetaPrimitiveTypeTransformation.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/transform/TSMetaPrimitiveTypeTransformation.java
@@ -1,9 +1,9 @@
 package io.crnk.gen.typescript.transform;
 
-import io.crnk.gen.typescript.model.TSAny;
-import io.crnk.gen.typescript.model.TSElement;
-import io.crnk.gen.typescript.model.TSPrimitiveType;
-import io.crnk.gen.typescript.model.TSType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.crnk.gen.typescript.model.*;
 import io.crnk.meta.model.MetaElement;
 import io.crnk.meta.model.MetaPrimitiveType;
 
@@ -21,6 +21,11 @@ public class TSMetaPrimitiveTypeTransformation implements TSMetaTransformation {
 
 	public TSMetaPrimitiveTypeTransformation() {
 		primitiveMapping = new HashMap<>();
+
+		primitiveMapping.put(ObjectNode.class, TSAny.INSTANCE);
+		primitiveMapping.put(ArrayNode.class, TSAny.INSTANCE);
+		primitiveMapping.put(JsonNode.class, TSAny.INSTANCE);
+
 		primitiveMapping.put(Object.class, TSAny.INSTANCE);
 		primitiveMapping.put(String.class, TSPrimitiveType.STRING);
 		primitiveMapping.put(Boolean.class, TSPrimitiveType.BOOLEAN);
@@ -66,7 +71,7 @@ public class TSMetaPrimitiveTypeTransformation implements TSMetaTransformation {
 		if (primitiveMapping.containsKey(implClass)) {
 			return primitiveMapping.get(implClass);
 		}
-		throw new IllegalStateException("unexpected element: " + element);
+		throw new IllegalStateException("unexpected element: " + element + " of type " + implClass.getName());
 	}
 
 	@Override


### PR DESCRIPTION
current store contents now gets compared with form value changes to avoid uncessary patch actions.