### PR TITLE
Handle 'Accept: application/json' messages as JSON-API requests by default

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/boot/CrnkProperties.java
+++ b/crnk-core/src/main/java/io/crnk/core/boot/CrnkProperties.java
@@ -143,5 +143,19 @@ public class CrnkProperties {
 	 */
 	public static final String SERIALIZE_LINKS_AS_OBJECTS = "crnk.config.serialize.object.links";
 
-
+	/**
+	 * <p>Set a boolean whether Crnk should reject <code>application/json</code> requests to JSON-API endpoints.
+	 * Defaults to <code>false</code>.
+	 * </p><p>The
+	 * JSON-API specification mandates the use of the <code>application/vnd.api+json</code> MIME-Type. In cases where frontends or
+	 * intermediate proxies prefer the <code>application/json</code> MIME-Type, that type can be sent in the <code>Accept</code>
+	 * header instead.</p>
+	 * <p>If an application wants to serve a different response depending on whether the client's <code>Accept</code> header
+	 * contains <code>application/vnd.api+json</code> or <code>application/json</code>, this option can be enabled.</p>
+	 * <p>This <strong>does not affect the <em>payload</em> <code>Content-Type</code></strong>. This means that the response will
+	 * still have <code>Content-Type: application/vnd.api+json</code> and that <code>POST/PATCH</code> requests, too, need to set
+	 * <code>Content-Type: application/vnd.api+json</code> to describe their request body.</p>
+	 * @since 2.4
+	 */
+	public static final String REJECT_PLAIN_JSON = "crnk.config.resource.request.rejectPlainJson";
 }

--- a/crnk-core/src/test/java/io/crnk/core/engine/http/JsonApiRequestProcessorTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/http/JsonApiRequestProcessorTest.java
@@ -67,10 +67,23 @@ public class JsonApiRequestProcessorTest {
 		Mockito.when(requestContextBase.getPath()).thenReturn("/tasks/");
 		Mockito.when(requestContextBase.getRequestHeader("Accept"))
 				.thenReturn("*");
-		Assert.assertTrue(JsonApiRequestProcessor.isJsonApiRequest(requestContext));
+		Assert.assertTrue(JsonApiRequestProcessor.isJsonApiRequest(requestContext, false));
 		Mockito.when(requestContextBase.getRequestHeader("Accept"))
 				.thenReturn("something");
-		Assert.assertFalse(JsonApiRequestProcessor.isJsonApiRequest(requestContext));
+		Assert.assertFalse(JsonApiRequestProcessor.isJsonApiRequest(requestContext, false));
+	}
+
+
+	@Test
+	public void acceptPlainJsonDependingOnFlag() throws IOException {
+		Mockito.when(requestContextBase.getMethod()).thenReturn("GET");
+		Mockito.when(requestContextBase.getPath()).thenReturn("/tasks/");
+		Mockito.when(requestContextBase.getRequestHeader("Accept"))
+				.thenReturn("application/json");
+		Assert.assertTrue(JsonApiRequestProcessor.isJsonApiRequest(requestContext, true));
+		Mockito.when(requestContextBase.getRequestHeader("Accept"))
+				.thenReturn("application/json");
+		Assert.assertFalse(JsonApiRequestProcessor.isJsonApiRequest(requestContext, false));
 	}
 
 	@Test
@@ -78,7 +91,7 @@ public class JsonApiRequestProcessorTest {
 		Mockito.when(requestContextBase.getMethod()).thenReturn("GET");
 		Mockito.when(requestContextBase.getPath()).thenReturn("/tasks/");
 		Mockito.when(requestContextBase.getRequestHeader("Accept")).thenReturn("*");
-		Assert.assertTrue(JsonApiRequestProcessor.isJsonApiRequest(requestContext));
+		Assert.assertTrue(JsonApiRequestProcessor.isJsonApiRequest(requestContext, false));
 	}
 
 	@Test
@@ -86,7 +99,7 @@ public class JsonApiRequestProcessorTest {
 		Mockito.when(requestContextBase.getMethod()).thenReturn("PATCH");
 		Mockito.when(requestContextBase.getPath()).thenReturn("/tasks/");
 		Mockito.when(requestContextBase.getRequestHeader("Accept")).thenReturn("*");
-		Assert.assertFalse(JsonApiRequestProcessor.isJsonApiRequest(requestContext));
+		Assert.assertFalse(JsonApiRequestProcessor.isJsonApiRequest(requestContext, false));
 
 		processor.process(requestContext);
 		Mockito.verify(requestContextBase, Mockito.times(0)).setResponse(Mockito.anyInt(), Mockito.any(byte[].class));
@@ -97,7 +110,7 @@ public class JsonApiRequestProcessorTest {
 		Mockito.when(requestContextBase.getMethod()).thenReturn("POST");
 		Mockito.when(requestContextBase.getPath()).thenReturn("/tasks/");
 		Mockito.when(requestContextBase.getRequestHeader("Accept")).thenReturn("*");
-		Assert.assertFalse(JsonApiRequestProcessor.isJsonApiRequest(requestContext));
+		Assert.assertFalse(JsonApiRequestProcessor.isJsonApiRequest(requestContext, false));
 
 		processor.process(requestContext);
 		Mockito.verify(requestContextBase, Mockito.times(0)).setResponse(Mockito.anyInt(), Mockito.any(byte[].class));
@@ -215,7 +228,7 @@ public class JsonApiRequestProcessorTest {
 				.thenReturn(HttpHeaders.JSONAPI_CONTENT_TYPE);
 		Mockito.when(requestContext.getRequestBody()).thenReturn("{ INVALID }".getBytes());
 
-		Assert.assertTrue(JsonApiRequestProcessor.isJsonApiRequest(requestContext));
+		Assert.assertTrue(JsonApiRequestProcessor.isJsonApiRequest(requestContext, false));
 
 		processor.process(requestContext);
 

--- a/crnk-servlet/src/test/java/io/crnk/servlet/CrnkServletRejectJsonTest.java
+++ b/crnk-servlet/src/test/java/io/crnk/servlet/CrnkServletRejectJsonTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.crnk.servlet;
+
+import static net.javacrumbs.jsonunit.JsonAssert.assertJsonPartEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletResponse;
+
+import io.crnk.core.boot.CrnkProperties;
+import io.crnk.core.engine.http.HttpHeaders;
+import io.crnk.servlet.resource.repository.NodeRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+public class CrnkServletRejectJsonTest {
+	private static final String SOME_TASK_ATTRIBUTES = "{\"name\":\"Some task\"}";
+
+	private static final String FIRST_TASK_LINKS = "{\"self\":\"http://localhost:8080/api/tasks/1\"}";
+
+	private static final String PROJECT1_RELATIONSHIP_LINKS =
+			"{\"self\":\"http://localhost:8080/api/tasks/1/relationships/project\","
+					+ "\"related\":\"http://localhost:8080/api/tasks/1/project\"}";
+
+	private static final String RESOURCE_SEARCH_PACKAGE = "io.crnk.servlet.resource";
+
+	private static final String RESOURCE_DEFAULT_DOMAIN = "http://localhost:8080/api";
+
+	private static Logger log = LoggerFactory.getLogger(CrnkServletRejectJsonTest.class);
+
+	private ServletContext servletContext;
+
+	private CrnkServlet servlet;
+
+	private NodeRepository nodeRepository;
+
+	@Before
+	public void before() throws Exception {
+		servlet = new CrnkServlet();
+
+		servletContext = new MockServletContext();
+		((MockServletContext) servletContext).setContextPath("");
+		MockServletConfig servletConfig = new MockServletConfig(servletContext);
+		servletConfig
+				.addInitParameter(CrnkProperties.RESOURCE_SEARCH_PACKAGE, RESOURCE_SEARCH_PACKAGE);
+		servletConfig
+				.addInitParameter(CrnkProperties.RESOURCE_DEFAULT_DOMAIN, RESOURCE_DEFAULT_DOMAIN);
+		servletConfig
+				.addInitParameter(CrnkProperties.REJECT_PLAIN_JSON, String.valueOf(true));
+
+		servlet.init(servletConfig);
+		nodeRepository = new NodeRepository();
+	}
+
+	@After
+	public void after() throws Exception {
+		servlet.destroy();
+		nodeRepository.clearRepo();
+	}
+
+	/** Option to reject plain JSON GET requests is enabled explicitly. */
+	@Test
+	public void testRejectPlainJson() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest(servletContext);
+		request.setMethod("GET");
+		request.setContextPath("");
+		request.setServletPath("/api");
+		request.setPathInfo("/tasks");
+		request.setRequestURI("/api/tasks");
+		request.setContentType(HttpHeaders.JSONAPI_CONTENT_TYPE);
+		request.addHeader("Accept", "application/json");
+		request.addParameter("filter[Task][name]", "John");
+		request.setQueryString(URLEncoder.encode("filter[Task][name]", StandardCharsets.UTF_8.name()) + "=John");
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		servlet.service(request, response);
+
+		assertEquals(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE, response.getStatus());
+		String responseContent = response.getContentAsString();
+		assertTrue(responseContent == null || "".equals(responseContent.trim()));
+	}
+
+	@Test
+	public void testAcceptJsonApi() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest(servletContext);
+		request.setMethod("GET");
+		request.setContextPath("");
+		request.setServletPath("/api");
+		request.setPathInfo("/tasks/1");
+		request.setRequestURI("/api/tasks/1");
+		request.addHeader("Accept", HttpHeaders.JSONAPI_CONTENT_TYPE);
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		servlet.service(request, response);
+
+		String responseContent = response.getContentAsString();
+
+		log.debug("responseContent: {}", responseContent);
+		assertNotNull(responseContent);
+
+		assertJsonPartEquals("tasks", responseContent, "data.type");
+		assertJsonPartEquals("\"1\"", responseContent, "data.id");
+		assertJsonPartEquals(SOME_TASK_ATTRIBUTES, responseContent, "data.attributes");
+		assertJsonPartEquals(FIRST_TASK_LINKS, responseContent, "data.links");
+		assertJsonPartEquals(PROJECT1_RELATIONSHIP_LINKS, responseContent, "data.relationships.project.links");
+	}
+
+	@Test
+	public void testAcceptWildcard() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest(servletContext);
+		request.setMethod("GET");
+		request.setContextPath("");
+		request.setServletPath("/api");
+		request.setPathInfo("/tasks/1");
+		request.setRequestURI("/api/tasks/1");
+		request.addHeader("Accept", "*/*");
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		servlet.service(request, response);
+
+		String responseContent = response.getContentAsString();
+
+		log.debug("responseContent: {}", responseContent);
+		assertNotNull(responseContent);
+
+		assertJsonPartEquals("tasks", responseContent, "data.type");
+		assertJsonPartEquals("\"1\"", responseContent, "data.id");
+		assertJsonPartEquals(SOME_TASK_ATTRIBUTES, responseContent, "data.attributes");
+		assertJsonPartEquals(FIRST_TASK_LINKS, responseContent, "data.links");
+		assertJsonPartEquals(PROJECT1_RELATIONSHIP_LINKS, responseContent, "data.relationships.project.links");
+	}
+}

--- a/crnk-servlet/src/test/java/io/crnk/servlet/CrnkServletTest.java
+++ b/crnk-servlet/src/test/java/io/crnk/servlet/CrnkServletTest.java
@@ -158,6 +158,33 @@ public class CrnkServletTest {
 		assertJsonPartEquals(PROJECT1_RELATIONSHIP_LINKS, responseContent, "data.relationships.project.links");
 	}
 
+
+	@Test
+	public void testAcceptPlainJson() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest(servletContext);
+		request.setMethod("GET");
+		request.setContextPath("");
+		request.setServletPath("/api");
+		request.setPathInfo("/tasks/1");
+		request.setRequestURI("/api/tasks/1");
+		request.addHeader("Accept", "application/json");
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		servlet.service(request, response);
+
+		String responseContent = response.getContentAsString();
+
+		log.debug("responseContent: {}", responseContent);
+		assertNotNull(responseContent);
+
+		assertJsonPartEquals("tasks", responseContent, "data.type");
+		assertJsonPartEquals("\"1\"", responseContent, "data.id");
+		assertJsonPartEquals(SOME_TASK_ATTRIBUTES, responseContent, "data.attributes");
+		assertJsonPartEquals(FIRST_TASK_LINKS, responseContent, "data.links");
+		assertJsonPartEquals(PROJECT1_RELATIONSHIP_LINKS, responseContent, "data.relationships.project.links");
+	}
+
 	@Test
 	public void onCollectionRequestWithParamsGetShouldReturnCollection() throws Exception {
 		MockHttpServletRequest request = new MockHttpServletRequest(servletContext);


### PR DESCRIPTION
Adapt the JsonApiRequestProcessor and the CrnkServlet to accept HTTP
requests with 'Accept: application/json' (instead of
'application/vnd.api+json') too. This makes it easier to integrate with
tools that are not aware of JSON-API specifically.

To revert to the old behaviour, enable the configuration property
'crnk.config.resource.request.rejectPlainJson'.

Motivation: Yes, the JSON-API standard mandates that both client and server use the `application/vnd.api+json` Accept/Content-Type headers. But for GET requests, we think it is fine to send back 'application/vnd.api+json' even when the client has requested 'application/json'. This makes working with tools/frontend that are not aware of JSON API specifically easier (generic REST client libraries; REST testing tools, etc.) Sure, all of them can be configured to send `Accept: application/vnd.api+json`), but it needs to be done every single time with no real benefit.

Does not affect POST/PATCH requests. There, we want to be sure that the client is aware that it needs to format its payload as a proper JSON-API response.