### PR TITLE
spring boot 2.x ErrorMvc workaround #195

### DIFF
--- a/crnk-spring/src/main/java/io/crnk/spring/boot/autoconfigure/CrnkErrorControllerAutoConfiguration.java
+++ b/crnk-spring/src/main/java/io/crnk/spring/boot/autoconfigure/CrnkErrorControllerAutoConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.web.servlet.DispatcherServlet;
 @Configuration
 @ConditionalOnProperty(prefix = "crnk.spring.mvc", name = "errorController", havingValue = "true", matchIfMissing = true)
 @ConditionalOnWebApplication
-@ConditionalOnClass({ Servlet.class, DispatcherServlet.class })
+@ConditionalOnClass({ Servlet.class, DispatcherServlet.class, ErrorMvcAutoConfiguration.class })
 // Load before the main ErrorMvcAutoConfiguration so that we override it
 @AutoConfigureBefore(ErrorMvcAutoConfiguration.class)
 @EnableConfigurationProperties({ CrnkSpringMvcProperties.class })


### PR DESCRIPTION
ignoring AutoConfiguration that does not exist in SpringBoot 2.x. Still needs to be properly implemented for the 2.x version.