### PR TITLE
make RelationshipRepository binding more flexible #216

### DIFF
--- a/crnk-activiti/src/test/java/io/crnk/activiti/example/ApprovalIntTest.java
+++ b/crnk-activiti/src/test/java/io/crnk/activiti/example/ApprovalIntTest.java
@@ -35,6 +35,8 @@ public class ApprovalIntTest extends JerseyTest {
 
 	protected CrnkClient client;
 
+	private RelationshipRepositoryV2<ScheduleApprovalProcessInstance, Serializable, ApproveTask, Serializable> processTaskRepo;
+
 	@Override
 	protected ApprovalTestApplication configure() {
 		return new ApprovalTestApplication();
@@ -53,6 +55,7 @@ public class ApprovalIntTest extends JerseyTest {
 
 		scheduleRepo = client.getRepositoryForInterface(ScheduleRepository.class);
 		approvalRepo = client.getRepositoryForType(ScheduleApprovalProcessInstance.class);
+		processTaskRepo = client.getRepositoryForType(ScheduleApprovalProcessInstance.class, ApproveTask.class);
 		taskRepo = client.getRepositoryForType(ApproveTask.class);
 		approvalRelRepo = client.getRepositoryForType(Schedule.class, ScheduleApprovalProcessInstance.class);
 		formRepo = client.getRepositoryForType(ApproveForm.class);
@@ -110,10 +113,15 @@ public class ApprovalIntTest extends JerseyTest {
 		Assert.assertEquals(1, scheduleApprovals.size());
 		checkOpenApproval(schedule, scheduleApprovals.get(0));
 
-		// check relationship
+		// check relationship from resource to approval process
 		ScheduleApprovalProcessInstance scheduleApproval = approvalRelRepo
 				.findOneTarget(schedule.getId().toString(), "approval", new QuerySpec(ScheduleApprovalProcessInstance.class));
 		checkOpenApproval(schedule, scheduleApproval);
+
+		// check relationship from approval process to task
+		ApproveTask approveTask =
+				processTaskRepo.findOneTarget(scheduleApprovals.get(0).getId(), "approveTask", new QuerySpec(ApproveTask.class));
+		Assert.assertNotNull(approveTask);
 
 		// check task created
 		QuerySpec taskQuery = new QuerySpec(ApproveTask.class);

--- a/crnk-client-angular-ngrx/meta/meta.element.ts
+++ b/crnk-client-angular-ngrx/meta/meta.element.ts
@@ -43,6 +43,9 @@ export class QMetaElement extends BeanPath<MetaElement> {
 	attributes: QMetaElement.QAttributes = new QMetaElement.QAttributes(this, 'attributes');
 }
 export module QMetaElement {
+	export class QAttributes extends BeanPath<MetaElement.Attributes> {
+		name: StringPath = this.createString('name');
+	}
 	export class QRelationships extends BeanPath<MetaElement.Relationships> {
 		private _parent: QTypedOneResourceRelationship<QMetaElement, MetaElement>;
 		get parent(): QTypedOneResourceRelationship<QMetaElement, MetaElement> {
@@ -60,9 +63,6 @@ export module QMetaElement {
 			}
 			return this._children;
 		};
-	}
-	export class QAttributes extends BeanPath<MetaElement.Attributes> {
-		name: StringPath = this.createString('name');
 	}
 }
 export let createEmptyMetaElement = function(id: string): MetaElement {

--- a/crnk-client-angular-ngrx/meta/meta.element.ts
+++ b/crnk-client-angular-ngrx/meta/meta.element.ts
@@ -43,9 +43,6 @@ export class QMetaElement extends BeanPath<MetaElement> {
 	attributes: QMetaElement.QAttributes = new QMetaElement.QAttributes(this, 'attributes');
 }
 export module QMetaElement {
-	export class QAttributes extends BeanPath<MetaElement.Attributes> {
-		name: StringPath = this.createString('name');
-	}
 	export class QRelationships extends BeanPath<MetaElement.Relationships> {
 		private _parent: QTypedOneResourceRelationship<QMetaElement, MetaElement>;
 		get parent(): QTypedOneResourceRelationship<QMetaElement, MetaElement> {
@@ -63,6 +60,9 @@ export module QMetaElement {
 			}
 			return this._children;
 		};
+	}
+	export class QAttributes extends BeanPath<MetaElement.Attributes> {
+		name: StringPath = this.createString('name');
 	}
 }
 export let createEmptyMetaElement = function(id: string): MetaElement {

--- a/crnk-client/src/main/java/io/crnk/client/CrnkClient.java
+++ b/crnk-client/src/main/java/io/crnk/client/CrnkClient.java
@@ -4,8 +4,10 @@ import java.io.Serializable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.ServiceLoader;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -140,8 +142,9 @@ public class CrnkClient {
 				documentMapper = new ClientDocumentMapper(moduleRegistry, objectMapper, new PropertiesProvider() {
 					@Override
 					public String getProperty(String key) {
-						if (key.equals(CrnkProperties.SERIALIZE_LINKS_AS_OBJECTS))
+						if (key.equals(CrnkProperties.SERIALIZE_LINKS_AS_OBJECTS)) {
 							return "true";
+						}
 						return null;
 					}
 				});
@@ -282,10 +285,9 @@ public class CrnkClient {
 		ResourceRepositoryInformation repositoryInformation =
 				new ResourceRepositoryInformationImpl(resourceInformation.getResourceType(),
 						resourceInformation, RepositoryMethodAccess.ALL);
-		ResourceEntry resourceEntry = new DirectResponseResourceEntry(repositoryInstanceBuilder);
-		List<ResponseRelationshipEntry> relationshipEntries = new ArrayList<>();
-		RegistryEntry registryEntry =
-				new RegistryEntry(resourceInformation, repositoryInformation, resourceEntry, relationshipEntries);
+		ResourceEntry resourceEntry = new DirectResponseResourceEntry(repositoryInstanceBuilder, repositoryInformation);
+		Map<ResourceField, ResponseRelationshipEntry> relationshipEntries = new HashMap<>();
+		RegistryEntry registryEntry = new RegistryEntry(resourceEntry, relationshipEntries);
 		registryEntry.initialize(moduleRegistry);
 		resourceRegistry.addEntry(resourceClass, registryEntry);
 
@@ -305,7 +307,7 @@ public class CrnkClient {
 		}
 	}
 
-	private void allocateRepositoryRelation(Class sourceClass, Class targetClass) {
+	private RelationshipRepositoryAdapter allocateRepositoryRelation(Class sourceClass, Class targetClass) {
 		// allocate relations as well
 		ClientResourceRegistry clientResourceRegistry = (ClientResourceRegistry) resourceRegistry;
 		if (!clientResourceRegistry.isInitialized(sourceClass)) {
@@ -317,11 +319,14 @@ public class CrnkClient {
 
 		RegistryEntry sourceEntry = resourceRegistry.getEntry(sourceClass);
 		final RegistryEntry targetEntry = resourceRegistry.getEntry(targetClass);
+		String targetResourceType = targetEntry.getResourceInformation().getResourceType();
 
-		final ResourceInformation targetResourceInformation = targetEntry.getResourceInformation();
-		Optional<ResponseRelationshipEntry> optRelationshipEntry =
-				sourceEntry.getRelationshipEntry(targetResourceInformation.getResourceType());
-		if (!optRelationshipEntry.isPresent()) {
+		Map relationshipEntries = sourceEntry.getRelationshipEntries();
+		DirectResponseRelationshipEntry relationshipEntry =
+				(DirectResponseRelationshipEntry) relationshipEntries.get(targetResourceType);
+
+		if (!relationshipEntries.containsKey(targetResourceType)) {
+
 			final RelationshipRepositoryStubImpl relationshipRepositoryStub =
 					new RelationshipRepositoryStubImpl(this, sourceClass, targetClass, sourceEntry.getResourceInformation(),
 							urlBuilder);
@@ -333,16 +338,19 @@ public class CrnkClient {
 							return relationshipRepositoryStub;
 						}
 					};
-			DirectResponseRelationshipEntry relationshipEntry =
+			relationshipEntry =
 					new DirectResponseRelationshipEntry(relationshipRepositoryInstanceBuilder) {
 
 						@Override
 						public String getTargetResourceType() {
-							return targetResourceInformation.getResourceType();
+							return targetEntry.getResourceInformation().getResourceType();
 						}
 					};
-			sourceEntry.getRelationshipEntries().add(relationshipEntry);
+			relationshipEntries.put(targetResourceType, relationshipEntry);
 		}
+		Object repoInstance = relationshipEntry.getRepositoryInstanceBuilder();
+
+		return new RelationshipRepositoryAdapter(sourceEntry.getResourceInformation(), moduleRegistry, repoInstance);
 	}
 
 	/**
@@ -448,11 +456,7 @@ public class CrnkClient {
 			Class<T> sourceClass, Class<D> targetClass) {
 		init();
 
-		RegistryEntry sourceEntry = resourceRegistry.findEntry(sourceClass);
-		RegistryEntry targetEntry = resourceRegistry.findEntry(targetClass);
-
-		RelationshipRepositoryAdapter repositoryAdapter =
-				sourceEntry.getRelationshipRepositoryForType(targetEntry.getResourceInformation().getResourceType(), null);
+		RelationshipRepositoryAdapter repositoryAdapter = allocateRepositoryRelation(sourceClass, targetClass);
 		return (RelationshipRepositoryStub<T, I, D, J>) repositoryAdapter.getRelationshipRepository();
 	}
 
@@ -467,12 +471,7 @@ public class CrnkClient {
 			Class<T> sourceClass, Class<D> targetClass) {
 		init();
 
-		RegistryEntry sourceEntry = resourceRegistry.findEntry(sourceClass);
-		RegistryEntry targetEntry = resourceRegistry.findEntry(targetClass);
-		allocateRepositoryRelation(sourceClass, targetClass);
-
-		RelationshipRepositoryAdapter repositoryAdapter =
-				sourceEntry.getRelationshipRepositoryForType(targetEntry.getResourceInformation().getResourceType(), null);
+		RelationshipRepositoryAdapter repositoryAdapter = allocateRepositoryRelation(sourceClass, targetClass);
 		return (RelationshipRepositoryV2<T, I, D, J>) repositoryAdapter.getRelationshipRepository();
 	}
 

--- a/crnk-client/src/main/java/io/crnk/client/internal/ClientResourceUpsert.java
+++ b/crnk-client/src/main/java/io/crnk/client/internal/ClientResourceUpsert.java
@@ -210,7 +210,7 @@ class ClientResourceUpsert extends ResourceUpsert {
 
 	@Override
 	protected boolean canModifyField(ResourceInformation resourceInformation, String fieldName, ResourceField field) {
-		// nothing to verify during deserialization on client-side
+		// nothing to validate during deserialization on client-side
 		// there is only a need to check field access when receiving resources
 		// on the server-side client needs all the data he gets from the server
 		return true;

--- a/crnk-client/src/test/java/io/crnk/client/AbstractClientTest.java
+++ b/crnk-client/src/test/java/io/crnk/client/AbstractClientTest.java
@@ -7,7 +7,7 @@ import javax.ws.rs.core.MultivaluedMap;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.crnk.client.action.JerseyActionStubFactory;
-import io.crnk.client.module.TestModule;
+import io.crnk.client.module.ClientTestModule;
 import io.crnk.core.boot.CrnkProperties;
 import io.crnk.core.queryspec.DefaultQuerySpecDeserializer;
 import io.crnk.legacy.locator.SampleJsonServiceLocator;
@@ -49,7 +49,7 @@ public abstract class AbstractClientTest extends JerseyTestBase {
 
 	protected void createClient() {
 		client = new CrnkClient(getBaseUri().toString());
-		client.addModule(new TestModule());
+		client.addModule(new ClientTestModule());
 		// tag::jerseyStubFactory[]
 		client.setActionStubFactory(JerseyActionStubFactory.newInstance());
 		// end::jerseyStubFactory[]
@@ -125,9 +125,7 @@ public abstract class AbstractClientTest extends JerseyTestBase {
 		}
 
 		public TestApplication(boolean querySpec, boolean jsonApiFilter, boolean serializeLinksAsObjects) {
-			property(CrnkProperties.RESOURCE_SEARCH_PACKAGE, "io.crnk.test.mock");
 			property(CrnkProperties.SERIALIZE_LINKS_AS_OBJECTS, Boolean.toString(serializeLinksAsObjects));
-
 			if (!querySpec) {
 				feature = new CrnkTestFeature(new ObjectMapper(), new QueryParamsBuilder(new DefaultQueryParamsParser()),
 						new SampleJsonServiceLocator());
@@ -137,7 +135,8 @@ public abstract class AbstractClientTest extends JerseyTestBase {
 						new SampleJsonServiceLocator());
 			}
 
-			feature.addModule(new TestModule());
+			feature.addModule(new io.crnk.test.mock.TestModule());
+			feature.addModule(new ClientTestModule());
 
 			if (jsonApiFilter) {
 				register(new JsonApiResponseFilter(feature));

--- a/crnk-client/src/test/java/io/crnk/client/ObjectLinkProxiedObjectsClientTest.java
+++ b/crnk-client/src/test/java/io/crnk/client/ObjectLinkProxiedObjectsClientTest.java
@@ -3,7 +3,7 @@ package io.crnk.client;
 import java.util.concurrent.TimeUnit;
 
 import io.crnk.client.action.JerseyActionStubFactory;
-import io.crnk.client.module.TestModule;
+import io.crnk.client.module.ClientTestModule;
 
 /**
  * Class creates a CrnkClient to serialize links as JSON objects.<br />
@@ -14,7 +14,7 @@ public class ObjectLinkProxiedObjectsClientTest extends AbstractProxiedObjectsCl
 	@Override
 	protected void createClient() {
 		client = new CrnkClient(getBaseUri().toString(), CrnkClient.ClientType.OBJECT_LINKS);
-		client.addModule(new TestModule());
+		client.addModule(new ClientTestModule());
 		// tag::jerseyStubFactory[]
 		client.setActionStubFactory(JerseyActionStubFactory.newInstance());
 		// end::jerseyStubFactory[]

--- a/crnk-client/src/test/java/io/crnk/client/module/ClientModuleFactoryTest.java
+++ b/crnk-client/src/test/java/io/crnk/client/module/ClientModuleFactoryTest.java
@@ -19,7 +19,7 @@ public class ClientModuleFactoryTest {
 		Assert.assertEquals(3, modules.size());
 		Assert.assertEquals(ClientModule.class, modules.get(0).getClass());
 		Assert.assertEquals(JacksonModule.class, modules.get(1).getClass());
-		Assert.assertEquals(TestModule.class, modules.get(2).getClass());
+		Assert.assertEquals(ClientTestModule.class, modules.get(2).getClass());
 	}
 
 	@Test
@@ -31,6 +31,6 @@ public class ClientModuleFactoryTest {
 		Assert.assertEquals(3, modules.size());
 		Assert.assertEquals(ClientModule.class, modules.get(0).getClass());
 		Assert.assertEquals(JacksonModule.class, modules.get(1).getClass());
-		Assert.assertEquals(TestModule.class, modules.get(2).getClass());
+		Assert.assertEquals(ClientTestModule.class, modules.get(2).getClass());
 	}
 }

--- a/crnk-client/src/test/java/io/crnk/client/module/ClientTestModule.java
+++ b/crnk-client/src/test/java/io/crnk/client/module/ClientTestModule.java
@@ -3,9 +3,9 @@ package io.crnk.client.module;
 import io.crnk.core.module.SimpleModule;
 import io.crnk.test.mock.TestExceptionMapper;
 
-public class TestModule extends SimpleModule {
+public class ClientTestModule extends SimpleModule {
 
-	public TestModule() {
+	public ClientTestModule() {
 		super("test");
 
 		addExceptionMapper(new TestExceptionMapper());

--- a/crnk-client/src/test/java/io/crnk/client/module/TestClientModuleFactory.java
+++ b/crnk-client/src/test/java/io/crnk/client/module/TestClientModuleFactory.java
@@ -3,7 +3,7 @@ package io.crnk.client.module;
 public class TestClientModuleFactory implements ClientModuleFactory {
 
 	@Override
-	public TestModule create() {
-		return new TestModule();
+	public ClientTestModule create() {
+		return new ClientTestModule();
 	}
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/dispatcher/RepositoryRequestSpec.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/dispatcher/RepositoryRequestSpec.java
@@ -26,7 +26,7 @@ public interface RepositoryRequestSpec {
 
 	/**
 	 * @param targetResourceClass to base the QuerySpec upon. Usually the requested resource,
-	 *                            but may also be the type of one of the relations.
+	 * but may also be the type of one of the relations.
 	 * @return issued query as QuerySpec
 	 */
 	QuerySpec getQuerySpec(ResourceInformation resourceInformation);
@@ -41,6 +41,22 @@ public interface RepositoryRequestSpec {
 	 * null.
 	 */
 	ResourceField getRelationshipField();
+
+	/**
+	 * @return QuerySpec applied to the return resources.
+	 */
+	QuerySpec getResponseQuerySpec();
+
+	/**
+	 * @return information about the returned resource
+	 */
+	ResourceInformation getResponseResourceInformation();
+
+	/**
+	 * @return information about the owning resource. In case of a relationship request, it will return the owner of the
+	 * relationship. In any other case it will match the result resource information.
+	 */
+	ResourceInformation getOwningResourceInformation();
 
 	/**
 	 * @return involved entity for push and patch operations or null otherwise.

--- a/crnk-core/src/main/java/io/crnk/core/engine/information/InformationBuilder.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/information/InformationBuilder.java
@@ -1,6 +1,7 @@
 package io.crnk.core.engine.information;
 
 import io.crnk.core.engine.internal.information.DefaultInformationBuilder;
+import io.crnk.core.repository.RelationshipMatcher;
 import io.crnk.core.resource.annotations.RelationshipRepositoryBehavior;
 import java.lang.reflect.Type;
 
@@ -29,6 +30,8 @@ public interface InformationBuilder {
 
 	interface ResourceRepository {
 
+		void from(ResourceRepositoryInformation information);
+
 		void setResourceInformation(ResourceInformation resourceInformation);
 
 		void setAccess(RepositoryMethodAccess access);
@@ -38,6 +41,8 @@ public interface InformationBuilder {
 	}
 
 	interface Resource {
+
+		void from(ResourceInformation information);
 
 		InformationBuilder.Field addField(String name, ResourceFieldType id1, Class<?> clazz);
 
@@ -54,6 +59,8 @@ public interface InformationBuilder {
 	interface Field {
 
 		ResourceField build();
+
+		void from(ResourceField field);
 
 		Field relationshipRepositoryBehavior(
 				RelationshipRepositoryBehavior relationshipRepositoryBehavior);
@@ -91,6 +98,8 @@ public interface InformationBuilder {
 	}
 
 	RelationshipRepository createRelationshipRepository(String sourceResourceType, String targeResourceType);
+
+	RelationshipRepository createRelationshipRepository(RelationshipMatcher matcher);
 
 	ResourceRepository createResourceRepository();
 

--- a/crnk-core/src/main/java/io/crnk/core/engine/information/repository/RelationshipRepositoryInformation.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/information/repository/RelationshipRepositoryInformation.java
@@ -1,19 +1,12 @@
 package io.crnk.core.engine.information.repository;
 
-import io.crnk.core.utils.Optional;
+import io.crnk.core.repository.RelationshipMatcher;
 
 /**
  * Holds information about the type of a relationship repository.
  */
 public interface RelationshipRepositoryInformation extends RepositoryInformation {
 
-	/**
-	 * @return resource class on source side. Used if no resource repository is available to
-	 * compute ResourceInformation with ResourceInformationProvider. Can be null otherwise
-	 */
-	Optional<Class> getSourceResourceClass();
+	RelationshipMatcher getMatcher();
 
-	String getSourceResourceType();
-
-	String getTargetResourceType();
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/information/repository/ResourceRepositoryInformation.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/information/repository/ResourceRepositoryInformation.java
@@ -12,9 +12,20 @@ public interface ResourceRepositoryInformation extends RepositoryInformation {
 
 	/**
 	 * @return information about the resources hold in this resource
+	 * @deprecated use getReosurce
 	 */
+	@Deprecated
 	Optional<ResourceInformation> getResourceInformation();
 
+	/**
+	 * @return information about the resources hold in this resource
+	 */
+	ResourceInformation getResource();
+
+	/**
+	 * @deprecated use getResource
+	 */
+	@Deprecated
 	String getResourceType();
 
 	/**

--- a/crnk-core/src/main/java/io/crnk/core/engine/information/resource/ResourceValidator.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/information/resource/ResourceValidator.java
@@ -1,0 +1,14 @@
+package io.crnk.core.engine.information.resource;
+
+import io.crnk.core.engine.document.Document;
+
+/**
+ * @deprecated
+ */
+@Deprecated
+public interface ResourceValidator {
+
+	void validate(Object entity, Document requestDocument);
+
+
+}

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/FieldResourceGet.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/FieldResourceGet.java
@@ -49,11 +49,12 @@ public class FieldResourceGet extends ResourceIncludeField {
 		Class<?> baseRelationshipFieldClass = relationshipField.getType();
 
 		RelationshipRepositoryAdapter relationshipRepositoryForClass = registryEntry
-				.getRelationshipRepositoryForType(relationshipField.getOppositeResourceType(), parameterProvider);
+				.getRelationshipRepository(relationshipField, parameterProvider);
 		JsonApiResponse entities;
 		if (Iterable.class.isAssignableFrom(baseRelationshipFieldClass)) {
 			entities = relationshipRepositoryForClass.findManyTargets(castedResourceId, relationshipField, queryAdapter);
-		} else {
+		}
+		else {
 			entities = relationshipRepositoryForClass.findOneTarget(castedResourceId, relationshipField, queryAdapter);
 		}
 		Document responseDocument = documentMapper.toDocument(entities, queryAdapter, parameterProvider);

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/FieldResourcePost.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/FieldResourcePost.java
@@ -35,9 +35,10 @@ import java.util.List;
  */
 public class FieldResourcePost extends ResourceUpsert {
 
-	public FieldResourcePost(ResourceRegistry resourceRegistry, PropertiesProvider propertiesProvider, TypeParser typeParser, @SuppressWarnings
-			("SameParameterValue") ObjectMapper objectMapper, DocumentMapper documentMapper,
-							 List<ResourceModificationFilter> modificationFilters) {
+	public FieldResourcePost(ResourceRegistry resourceRegistry, PropertiesProvider propertiesProvider, TypeParser typeParser,
+			@SuppressWarnings
+					("SameParameterValue") ObjectMapper objectMapper, DocumentMapper documentMapper,
+			List<ResourceModificationFilter> modificationFilters) {
 		super(resourceRegistry, propertiesProvider, typeParser, objectMapper, documentMapper, modificationFilters);
 	}
 
@@ -57,7 +58,7 @@ public class FieldResourcePost extends ResourceUpsert {
 
 	@Override
 	public Response handle(JsonPath jsonPath, QueryAdapter queryAdapter,
-						   RepositoryMethodParameterProvider parameterProvider, Document requestDocument) {
+			RepositoryMethodParameterProvider parameterProvider, Document requestDocument) {
 
 
 		RegistryEntry endpointRegistryEntry = getRegistryEntry(jsonPath);
@@ -80,13 +81,14 @@ public class FieldResourcePost extends ResourceUpsert {
 		Object newResource = buildNewResource(relationshipRegistryEntry, resourceBody, relationshipResourceType);
 		setAttributes(resourceBody, newResource, relationshipRegistryEntry.getResourceInformation());
 		ResourceRepositoryAdapter resourceRepository = relationshipRegistryEntry.getResourceRepository(parameterProvider);
-		Document savedResourceResponse = documentMapper.toDocument(resourceRepository.create(newResource, queryAdapter), queryAdapter, parameterProvider);
+		Document savedResourceResponse =
+				documentMapper.toDocument(resourceRepository.create(newResource, queryAdapter), queryAdapter, parameterProvider);
 		setRelations(newResource, bodyRegistryEntry, resourceBody, queryAdapter, parameterProvider, false);
 
 		ResourceIdentifier resourceId1 = savedResourceResponse.getSingleData().get();
 
 		RelationshipRepositoryAdapter relationshipRepositoryForClass = endpointRegistryEntry
-				.getRelationshipRepositoryForType(relationshipField.getOppositeResourceType(), parameterProvider);
+				.getRelationshipRepository(relationshipField, parameterProvider);
 
 		@SuppressWarnings("unchecked")
 		JsonApiResponse parent = endpointRegistryEntry.getResourceRepository(parameterProvider)
@@ -94,7 +96,8 @@ public class FieldResourcePost extends ResourceUpsert {
 		if (Iterable.class.isAssignableFrom(baseRelationshipFieldClass)) {
 			List<ResourceIdentifier> resourceIdList = Collections.singletonList(resourceId1);
 			for (ResourceModificationFilter filter : modificationFilters) {
-				resourceIdList = filter.modifyManyRelationship(parent.getEntity(), relationshipField, ResourceRelationshipModificationType.ADD, resourceIdList);
+				resourceIdList = filter.modifyManyRelationship(parent.getEntity(), relationshipField,
+						ResourceRelationshipModificationType.ADD, resourceIdList);
 			}
 			List<Serializable> parsedIds = new ArrayList<>();
 			for (ResourceIdentifier resourceId : resourceIdList) {
@@ -103,7 +106,8 @@ public class FieldResourcePost extends ResourceUpsert {
 
 			//noinspection unchecked
 			relationshipRepositoryForClass.addRelations(parent.getEntity(), parsedIds, relationshipField, queryAdapter);
-		} else {
+		}
+		else {
 			//noinspection unchecked
 			for (ResourceModificationFilter filter : modificationFilters) {
 				resourceId1 = filter.modifyOneRelationship(parent.getEntity(), relationshipField, resourceId1);

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/RelationshipsResourceGet.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/RelationshipsResourceGet.java
@@ -44,8 +44,7 @@ public class RelationshipsResourceGet extends ResourceIncludeField {
 
 		boolean isCollection = Iterable.class.isAssignableFrom(relationshipField.getType());
 
-
-		RelationshipRepositoryAdapter relationshipRepositoryForClass = registryEntry.getRelationshipRepositoryForType(relationshipField.getOppositeResourceType(), parameterProvider);
+		RelationshipRepositoryAdapter relationshipRepositoryForClass = registryEntry.getRelationshipRepository(relationshipField, parameterProvider);
 		JsonApiResponse entities;
 		if (isCollection) {
 			entities = relationshipRepositoryForClass.findManyTargets(castedResourceId, relationshipField, queryAdapter);

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/RelationshipsResourceUpsert.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/RelationshipsResourceUpsert.java
@@ -100,7 +100,7 @@ public abstract class RelationshipsResourceUpsert extends ResourceIncludeField {
 
 		@SuppressWarnings("unchecked")
 		RelationshipRepositoryAdapter relationshipRepositoryForClass = registryEntry
-				.getRelationshipRepositoryForType(relationshipField.getOppositeResourceType(), parameterProvider);
+				.getRelationshipRepository(relationshipField, parameterProvider);
 		if (Iterable.class.isAssignableFrom(relationshipField.getType())) {
 			Iterable<ResourceIdentifier> dataBodies = (Iterable<ResourceIdentifier>) (requestBody.isMultiple() ? requestBody.getData().get() : Collections.singletonList(requestBody.getData().get()));
 			processToManyRelationship(resource, targetInformation, relationshipField, dataBodies, queryAdapter,

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/IncludeLookupSetter.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/IncludeLookupSetter.java
@@ -389,7 +389,7 @@ public class IncludeLookupSetter {
 
 		@SuppressWarnings("rawtypes")
 		RelationshipRepositoryAdapter relationshipRepository =
-				registyEntry.getRelationshipRepositoryForType(relationshipField.getOppositeResourceType(), parameterProvider);
+				registyEntry.getRelationshipRepository(relationshipField, parameterProvider);
 		if (relationshipRepository != null) {
 			Map<Object, JsonApiResponse> responseMap;
 			if (isMany) {

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/information/repository/RelationshipRepositoryInformationImpl.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/information/repository/RelationshipRepositoryInformationImpl.java
@@ -2,44 +2,28 @@ package io.crnk.core.engine.internal.information.repository;
 
 import io.crnk.core.engine.information.repository.RelationshipRepositoryInformation;
 import io.crnk.core.engine.information.repository.RepositoryMethodAccess;
-import io.crnk.core.utils.Optional;
+import io.crnk.core.repository.RelationshipMatcher;
 
 public class RelationshipRepositoryInformationImpl implements
 		RelationshipRepositoryInformation {
 
-	private final String sourceResourceType;
-
-	private final String targetResourceType;
 
 	private final RepositoryMethodAccess access;
 
-	private Optional<Class> sourceResourceClass;
+	private final RelationshipMatcher matcher;
 
-	public RelationshipRepositoryInformationImpl(Class sourceResourceClass, String sourceResourceType,
-												 String targetResourceType, RepositoryMethodAccess access) {
-		this.sourceResourceClass = Optional.ofNullable(sourceResourceClass);
-		this.sourceResourceType = sourceResourceType;
-		this.targetResourceType = targetResourceType;
+	public RelationshipRepositoryInformationImpl(RelationshipMatcher matcher, RepositoryMethodAccess access) {
+		this.matcher = matcher;
 		this.access = access;
-	}
-
-	@Override
-	public Optional<Class> getSourceResourceClass() {
-		return sourceResourceClass;
-	}
-
-	@Override
-	public String getSourceResourceType() {
-		return sourceResourceType;
-	}
-
-	@Override
-	public String getTargetResourceType() {
-		return targetResourceType;
 	}
 
 	@Override
 	public RepositoryMethodAccess getAccess() {
 		return access;
+	}
+
+	@Override
+	public RelationshipMatcher getMatcher() {
+		return matcher;
 	}
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/information/repository/ResourceRepositoryInformationImpl.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/information/repository/ResourceRepositoryInformationImpl.java
@@ -11,35 +11,39 @@ import java.util.Map;
 
 public class ResourceRepositoryInformationImpl implements ResourceRepositoryInformation {
 
-	private Optional<ResourceInformation> resourceInformation;
+	private ResourceInformation resourceInformation;
+
 	private String resourceType;
+
 	private String path;
+
 	private Map<String, RepositoryAction> actions;
 
 	private RepositoryMethodAccess access;
 
 	@Deprecated
-	public ResourceRepositoryInformationImpl(String path, ResourceInformation resourceInformation, RepositoryMethodAccess access) {
+	public ResourceRepositoryInformationImpl(String path, ResourceInformation resourceInformation,
+			RepositoryMethodAccess access) {
 		this(path, resourceInformation, new HashMap<String, RepositoryAction>(), access);
 	}
 
 	@Deprecated
 	public ResourceRepositoryInformationImpl(String path,
-											 ResourceInformation resourceInformation, Map<String, RepositoryAction> actions, RepositoryMethodAccess access) {
-		this(path, resourceInformation.getResourceType(), actions, access);
-		this.resourceInformation = Optional.of(resourceInformation);
-	}
-
-	public ResourceRepositoryInformationImpl(String path, String resourceType, Map<String, RepositoryAction> actions, RepositoryMethodAccess access) {
+			ResourceInformation resourceInformation, Map<String, RepositoryAction> actions, RepositoryMethodAccess access) {
+		this.resourceInformation = resourceInformation;
 		this.path = path;
 		this.actions = actions;
-		this.resourceInformation = Optional.empty();
 		this.resourceType = resourceType;
 		this.access = access;
 	}
 
 	@Override
 	public Optional<ResourceInformation> getResourceInformation() {
+		return Optional.of(getResource());
+	}
+
+	@Override
+	public ResourceInformation getResource() {
 		return resourceInformation;
 	}
 

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/registry/DefaultRegistryEntryBuilder.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/registry/DefaultRegistryEntryBuilder.java
@@ -1,26 +1,62 @@
 package io.crnk.core.engine.internal.registry;
 
 import io.crnk.core.engine.information.InformationBuilder;
+import io.crnk.core.engine.information.contributor.ResourceFieldContributor;
+import io.crnk.core.engine.information.contributor.ResourceFieldContributorContext;
+import io.crnk.core.engine.information.repository.RelationshipRepositoryInformation;
+import io.crnk.core.engine.information.repository.RepositoryInformation;
+import io.crnk.core.engine.information.repository.RepositoryInformationProvider;
+import io.crnk.core.engine.information.repository.RepositoryInformationProviderContext;
+import io.crnk.core.engine.information.repository.RepositoryMethodAccess;
 import io.crnk.core.engine.information.repository.ResourceRepositoryInformation;
+import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.information.resource.ResourceFieldAccess;
 import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.information.resource.ResourceInformationProvider;
 import io.crnk.core.engine.internal.information.DefaultInformationBuilder;
+import io.crnk.core.engine.internal.information.repository.RelationshipRepositoryInformationImpl;
+import io.crnk.core.engine.internal.utils.ClassUtils;
+import io.crnk.core.engine.internal.utils.Decorator;
+import io.crnk.core.engine.internal.utils.PreconditionUtil;
+import io.crnk.core.engine.parser.TypeParser;
 import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.registry.RegistryEntryBuilder;
 import io.crnk.core.engine.registry.ResourceEntry;
+import io.crnk.core.engine.registry.ResourceRegistryAware;
 import io.crnk.core.engine.registry.ResponseRelationshipEntry;
+import io.crnk.core.exception.ResourceFieldNotFoundException;
 import io.crnk.core.module.ModuleRegistry;
+import io.crnk.core.module.internal.DefaultRepositoryInformationProviderContext;
+import io.crnk.core.repository.RelationshipMatcher;
+import io.crnk.core.repository.RelationshipRepositoryBase;
+import io.crnk.core.repository.RelationshipRepositoryV2;
+import io.crnk.core.repository.ResourceRepositoryV2;
+import io.crnk.core.repository.decorate.RepositoryDecoratorFactory;
+import io.crnk.core.repository.implicit.ImplicitOwnerBasedRelationshipRepository;
+import io.crnk.core.resource.annotations.LookupIncludeBehavior;
+import io.crnk.core.resource.annotations.RelationshipRepositoryBehavior;
 import io.crnk.legacy.internal.DirectResponseRelationshipEntry;
 import io.crnk.legacy.internal.DirectResponseResourceEntry;
+import io.crnk.legacy.registry.AnnotatedRelationshipEntryBuilder;
+import io.crnk.legacy.registry.AnnotatedResourceEntry;
 import io.crnk.legacy.registry.RepositoryInstanceBuilder;
-
+import io.crnk.legacy.repository.annotations.JsonApiRelationshipRepository;
+import io.crnk.legacy.repository.annotations.JsonApiResourceRepository;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultRegistryEntryBuilder implements RegistryEntryBuilder {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRegistryEntryBuilder.class);
+
 	private final DefaultInformationBuilder informationBuilder;
+
 	private ModuleRegistry moduleRegistry;
 
 	private DefaultResourceRepository resourceRepository;
@@ -58,16 +94,16 @@ public class DefaultRegistryEntryBuilder implements RegistryEntryBuilder {
 
 	class DefaultRelationshipRepository implements RelationshipRepository {
 
-		private final String targetResourceType;
+		private final String fieldName;
 
 		private InformationBuilder.RelationshipRepository information;
 
 		private Object instance;
 
 
-		public DefaultRelationshipRepository(String targetResourceType) {
-			this.targetResourceType = targetResourceType;
-			this.information = informationBuilder.createRelationshipRepository(targetResourceType);
+		public DefaultRelationshipRepository(String fieldName) {
+			this.fieldName = fieldName;
+			this.information = informationBuilder.createRelationshipRepository((RelationshipMatcher) null);
 		}
 
 		@Override
@@ -80,6 +116,21 @@ public class DefaultRegistryEntryBuilder implements RegistryEntryBuilder {
 			this.instance = instance;
 		}
 	}
+
+	@Override
+	public void fromImplemenation(Object repository) {
+		RepositoryInformationProvider repositoryInformationBuilder = moduleRegistry.getRepositoryInformationBuilder();
+
+		RepositoryInformationProviderContext builderContext = new DefaultRepositoryInformationProviderContext(moduleRegistry);
+		ResourceRepositoryInformation repositoryInformation =
+				(ResourceRepositoryInformation) repositoryInformationBuilder.build(repository, builderContext);
+		ResourceInformation resourceInformation = repositoryInformation.getResourceInformation().get();
+
+		resource().from(resourceInformation);
+		resourceRepository().information().from(repositoryInformation);
+		resourceRepository().instance(repository);
+	}
+
 
 	@Override
 	public ResourceRepository resourceRepository() {
@@ -98,57 +149,243 @@ public class DefaultRegistryEntryBuilder implements RegistryEntryBuilder {
 	}
 
 	@Override
-	public RelationshipRepository relationshipRepository(String targetResourceType) {
-		DefaultRelationshipRepository repository = relationshipRepositoryMap.get(targetResourceType);
+	public RelationshipRepository relationshipRepositoryForField(String fieldName) {
+		DefaultRelationshipRepository repository = relationshipRepositoryMap.get(fieldName);
 		if (repository == null) {
-			repository = new DefaultRelationshipRepository(targetResourceType);
-			relationshipRepositoryMap.put(targetResourceType, repository);
+			repository = new DefaultRelationshipRepository(null);
+			relationshipRepositoryMap.put(fieldName, repository);
 		}
 		return repository;
 	}
 
 	@Override
 	public RegistryEntry build() {
-		ResourceInformation resourceInformation = resource.build();
+		ResourceInformation resourceInformation = buildResource();
+		ResourceEntry resourceEntry = buildResourceRepository(resourceInformation);
+		Map<ResourceField, ResponseRelationshipEntry> relationshipEntries = buildRelationships(resourceInformation);
 
-		resourceRepository.information().setResourceInformation(resourceInformation);
-
-		ResourceRepositoryInformation repositoryInformation = resourceRepository.information().build();
-
-		final Object decoratedResourceRepository = moduleRegistry.decorateRepository(resourceRepository.instance);
-		RepositoryInstanceBuilder repositoryInstanceBuilder = new RepositoryInstanceBuilder(null, resourceRepository.instance.getClass()) {
-
-			@Override
-			public Object buildRepository() {
-				return decoratedResourceRepository;
-			}
-		};
-
-		ResourceEntry resourceEntry = new DirectResponseResourceEntry(repositoryInstanceBuilder);
-		List<ResponseRelationshipEntry> relationshipEntries = new ArrayList<>();
-		for (final DefaultRelationshipRepository relationshipRepository : relationshipRepositoryMap.values()) {
-			final Object decoratedRelationshipRepository = moduleRegistry.decorateRepository(relationshipRepository.instance);
-			Class repositoryClass = relationshipRepository.information.getClass();
-			RepositoryInstanceBuilder<Object> relationshipInstanceBuilder = new RepositoryInstanceBuilder<Object>(null, repositoryClass) {
-
-				@Override
-				public Object buildRepository() {
-					return decoratedRelationshipRepository;
-				}
-			};
-
-			ResponseRelationshipEntry relationshipEntry = new DirectResponseRelationshipEntry(relationshipInstanceBuilder) {
-
-				@Override
-				public String getTargetResourceType() {
-					return relationshipRepository.targetResourceType;
-				}
-			};
-			relationshipEntries.add(relationshipEntry);
-		}
-
-		RegistryEntry entry = new RegistryEntry(resourceInformation, repositoryInformation, resourceEntry, relationshipEntries);
+		RegistryEntry entry =
+				new RegistryEntry(resourceEntry, relationshipEntries);
 		entry.initialize(moduleRegistry);
 		return entry;
 	}
+
+
+	private Map<ResourceField, ResponseRelationshipEntry> buildRelationships(ResourceInformation resourceInformation) {
+		for(String relationshipName : relationshipRepositoryMap.keySet()){
+			if(resourceInformation.findFieldByUnderlyingName(relationshipName) == null){
+				throw new ResourceFieldNotFoundException("failed to find relationship field '" + relationshipName + "' to setup "
+						+ "registered relationship repository");
+			}
+
+		}
+
+
+		Map<ResourceField, ResponseRelationshipEntry> map = new HashMap<>();
+		for (ResourceField relationshipField : resourceInformation.getRelationshipFields()) {
+
+			ResponseRelationshipEntry relationshipEntry = null;
+
+			// check for local definition
+			DefaultRelationshipRepository repository = relationshipRepositoryMap.get(relationshipField.getUnderlyingName());
+			if (repository != null) {
+				RelationshipRepositoryInformation relationshipInformation = repository.information.build();
+				relationshipEntry = setupRelationship(relationshipField, relationshipInformation, repository.instance);
+			}
+
+			// check for match
+			if (relationshipEntry == null) {
+				relationshipEntry = findRelationshipMatch(relationshipField);
+			}
+
+			// check for implicit
+			if (relationshipEntry == null) {
+				relationshipEntry = setupImplicitRelationshipRepository(relationshipField);
+			}
+
+			if (relationshipEntry != null) {
+				map.put(relationshipField, relationshipEntry);
+			}
+			else {
+				LOGGER.warn("no relationship repository found for " + resourceInformation.getResourceType() + "." +
+						relationshipField.getUnderlyingName());
+			}
+		}
+		return map;
+	}
+
+	private ResponseRelationshipEntry findRelationshipMatch(ResourceField relationshipField) {
+		Collection<Object> repositories = moduleRegistry.getRepositories();
+		RepositoryInformationProvider repositoryInformationBuilder = moduleRegistry.getRepositoryInformationBuilder();
+
+		ResponseRelationshipEntry matchedEntry = null;
+
+
+		for (Object repository : repositories) {
+			RepositoryInformation repositoryInformation =
+					repositoryInformationBuilder.build(repository, new
+							DefaultRepositoryInformationProviderContext(moduleRegistry));
+
+			if (repositoryInformation instanceof RelationshipRepositoryInformation) {
+				RelationshipRepositoryInformation relationshipRepositoryInformation =
+						(RelationshipRepositoryInformation) repositoryInformation;
+				RelationshipMatcher matcher = relationshipRepositoryInformation.getMatcher();
+				if (matcher.matches(relationshipField)) {
+					if (matchedEntry != null) {
+						throw new IllegalStateException("multiple repositories for " + relationshipField + ": " + repository +
+								", " + matchedEntry);
+					}
+					matcher.matches(relationshipField);
+					matchedEntry = setupRelationship(relationshipField, relationshipRepositoryInformation, repository);
+				}
+			}
+		}
+		return matchedEntry;
+	}
+
+	private ResourceInformation buildResource() {
+		ResourceInformation resourceInformation = resource.build();
+		contributeFields(resourceInformation);
+		return resourceInformation;
+	}
+
+	private void contributeFields(ResourceInformation resourceInformation) {
+		// TODO make service discovery the primary target to resolve all objects => wrapped it with module
+		List<ResourceFieldContributor> contributors = new ArrayList<>();
+		contributors.addAll(moduleRegistry.getServiceDiscovery().getInstancesByType(ResourceFieldContributor.class));
+		moduleRegistry.getRepositories().stream()
+				.filter(it -> it instanceof ResourceFieldContributor && !contributors.contains(it))
+				.forEach(it -> contributors.add((ResourceFieldContributor) it));
+
+		for (ResourceFieldContributor contributor : contributors) {
+			List<ResourceField> contributedFields = contributor.getResourceFields(new ResourceFieldContributorContext() {
+				@Override
+				public InformationBuilder getInformationBuilder() {
+					return new DefaultInformationBuilder(moduleRegistry.getTypeParser());
+				}
+			});
+			List<ResourceField> fields = new ArrayList<>();
+			fields.addAll(resourceInformation.getFields());
+			fields.addAll(contributedFields);
+			resourceInformation.setFields(fields);
+		}
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private ResourceEntry buildResourceRepository(ResourceInformation resourceInformation) {
+		resourceRepository.information().setResourceInformation(resourceInformation);
+		ResourceRepositoryInformation repositoryInformation = resourceRepository.information().build();
+
+		Object instance = resourceRepository.instance;
+		final Object decoratedRepository = decorateRepository(instance);
+		RepositoryInstanceBuilder repositoryInstanceBuilder = new RepositoryInstanceBuilder(null, instance.getClass()) {
+
+			@Override
+			public Object buildRepository() {
+				return decoratedRepository;
+			}
+		};
+
+		if (ClassUtils.getAnnotation(decoratedRepository.getClass(), JsonApiResourceRepository.class).isPresent()) {
+			return new AnnotatedResourceEntry(repositoryInstanceBuilder, repositoryInformation);
+		}
+		else {
+			return new DirectResponseResourceEntry(repositoryInstanceBuilder, repositoryInformation);
+		}
+	}
+
+	private ResponseRelationshipEntry setupImplicitRelationshipRepository(ResourceField relationshipField) {
+		RelationshipRepositoryBehavior behavior = relationshipField.getRelationshipRepositoryBehavior();
+		if (behavior == RelationshipRepositoryBehavior.DEFAULT) {
+			if (relationshipField.hasIdField()
+					|| relationshipField.getLookupIncludeAutomatically() == LookupIncludeBehavior.NONE) {
+				behavior = RelationshipRepositoryBehavior.IMPLICIT_FROM_OWNER;
+			}
+			else {
+				behavior = RelationshipRepositoryBehavior.CUSTOM;
+			}
+		}
+
+		if (behavior != RelationshipRepositoryBehavior.CUSTOM) {
+			ResourceInformation sourceInformation = relationshipField.getParentResourceInformation();
+
+			ResourceFieldAccess fieldAccess = relationshipField.getAccess();
+
+			RepositoryMethodAccess access = new RepositoryMethodAccess(fieldAccess.isPostable(), fieldAccess.isPatchable(),
+					fieldAccess.isReadable(), fieldAccess.isPatchable());
+
+			RelationshipMatcher matcher = new RelationshipMatcher().rule().field(relationshipField).add();
+
+			RelationshipRepositoryInformationImpl implicitRepoInformation =
+					new RelationshipRepositoryInformationImpl(matcher, access);
+
+			RelationshipRepositoryBase repository;
+			if (behavior == RelationshipRepositoryBehavior.IMPLICIT_FROM_OWNER) {
+				repository = new ImplicitOwnerBasedRelationshipRepository(sourceInformation.getResourceType());
+			}
+			else {
+				PreconditionUtil.assertEquals("unknown behavior", RelationshipRepositoryBehavior
+						.IMPLICIT_GET_OPPOSITE_MODIFY_OWNER, behavior);
+				repository = new RelationshipRepositoryBase(sourceInformation.getResourceType());
+			}
+			repository.setResourceRegistry(moduleRegistry.getResourceRegistry());
+			return setupRelationship(relationshipField, implicitRepoInformation, repository);
+		}
+		else {
+			return null;
+		}
+	}
+
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public Object decorateRepository(Object repository) {
+		Object decoratedRepository = repository;
+		List<RepositoryDecoratorFactory> repositoryDecorators = moduleRegistry.getRepositoryDecoratorFactories();
+		for (RepositoryDecoratorFactory repositoryDecorator : repositoryDecorators) {
+			Decorator decorator = null;
+			if (decoratedRepository instanceof RelationshipRepositoryV2) {
+				decorator = repositoryDecorator.decorateRepository((RelationshipRepositoryV2) decoratedRepository);
+			}
+			else if (decoratedRepository instanceof ResourceRepositoryV2) {
+				decorator = repositoryDecorator.decorateRepository((ResourceRepositoryV2) decoratedRepository);
+			}
+			if (decorator != null) {
+				decorator.setDecoratedObject(decoratedRepository);
+				decoratedRepository = decorator;
+			}
+		}
+		return decoratedRepository;
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private ResponseRelationshipEntry setupRelationship(
+			final ResourceField relationshipField,
+			RelationshipRepositoryInformation relationshipRepositoryInformation,
+			Object relRepository) {
+
+		final Object decoratedRepository = decorateRepository(relRepository);
+		RepositoryInstanceBuilder<Object> relationshipInstanceBuilder =
+				new RepositoryInstanceBuilder<Object>(null, (Class) relRepository.getClass()) {
+
+					@Override
+					public Object buildRepository() {
+						return decoratedRepository;
+					}
+				};
+
+		if (ClassUtils.getAnnotation(relRepository.getClass(), JsonApiRelationshipRepository.class).isPresent()) {
+			return new AnnotatedRelationshipEntryBuilder(moduleRegistry, relationshipInstanceBuilder);
+		}
+		else {
+			final String targetResourceType = relationshipField.getOppositeResourceType();
+			return new DirectResponseRelationshipEntry(relationshipInstanceBuilder) {
+
+				@Override
+				public String getTargetResourceType() {
+					return targetResourceType;
+				}
+			};
+		}
+	}
+
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/repository/RelationshipRepositoryAdapter.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/repository/RelationshipRepositoryAdapter.java
@@ -178,9 +178,8 @@ public class RelationshipRepositoryAdapter<T, I extends Serializable, D, J exten
 				}
 				else if (relationshipRepository instanceof RelationshipRepositoryV2) {
 					RelationshipRepositoryV2 querySpecRepository = (RelationshipRepositoryV2) relationshipRepository;
-					Class<?> targetResourceClass = querySpecRepository.getTargetResourceClass();
 					ResourceInformation targetResourceInformation =
-							moduleRegistry.getResourceRegistry().findEntry(targetResourceClass).getResourceInformation();
+							moduleRegistry.getResourceRegistry().getEntry(field.getOppositeResourceType()).getResourceInformation();
 					resource = querySpecRepository
 							.findOneTarget(sourceId, field.getUnderlyingName(), request.getQuerySpec(targetResourceInformation));
 				}
@@ -214,9 +213,8 @@ public class RelationshipRepositoryAdapter<T, I extends Serializable, D, J exten
 				}
 				else if (relationshipRepository instanceof RelationshipRepositoryV2) {
 					RelationshipRepositoryV2 querySpecRepository = (RelationshipRepositoryV2) relationshipRepository;
-					Class<?> targetResourceClass = querySpecRepository.getTargetResourceClass();
 					ResourceInformation targetResourceInformation =
-							moduleRegistry.getResourceRegistry().findEntry(targetResourceClass).getResourceInformation();
+							moduleRegistry.getResourceRegistry().getEntry(field.getOppositeResourceType()).getResourceInformation();
 					resources = querySpecRepository.findManyTargets(sourceId, field.getUnderlyingName(),
 							request.getQuerySpec(targetResourceInformation));
 				}
@@ -245,9 +243,9 @@ public class RelationshipRepositoryAdapter<T, I extends Serializable, D, J exten
 					QueryAdapter queryAdapter = request.getQueryAdapter();
 
 					BulkRelationshipRepositoryV2 bulkRepository = (BulkRelationshipRepositoryV2) relationshipRepository;
-					Class<?> targetResourceClass = bulkRepository.getTargetResourceClass();
 					ResourceInformation targetResourceInformation =
-							moduleRegistry.getResourceRegistry().findEntry(targetResourceClass).getResourceInformation();
+							moduleRegistry.getResourceRegistry().getEntry(field.getOppositeResourceType())
+									.getResourceInformation();
 					QuerySpec querySpec = request.getQuerySpec(targetResourceInformation);
 					MultivaluedMap targetsMap = bulkRepository.findTargets(sourceIds, field.getUnderlyingName(), querySpec);
 					return toResponses(targetsMap, true, queryAdapter, field, HttpMethod.GET);
@@ -283,9 +281,9 @@ public class RelationshipRepositoryAdapter<T, I extends Serializable, D, J exten
 					QueryAdapter queryAdapter = request.getQueryAdapter();
 
 					BulkRelationshipRepositoryV2 bulkRepository = (BulkRelationshipRepositoryV2) relationshipRepository;
-					Class targetResourceClass = bulkRepository.getTargetResourceClass();
 					ResourceInformation targetResourceInformation =
-							moduleRegistry.getResourceRegistry().findEntry(targetResourceClass).getResourceInformation();
+							moduleRegistry.getResourceRegistry().getEntry(field.getOppositeResourceType())
+									.getResourceInformation();
 					MultivaluedMap<I, D> targetsMap = bulkRepository
 							.findTargets(sourceIds, field.getUnderlyingName(), request.getQuerySpec(targetResourceInformation));
 					return toResponses(targetsMap, false, queryAdapter, field, HttpMethod.GET);
@@ -328,11 +326,5 @@ public class RelationshipRepositoryAdapter<T, I extends Serializable, D, J exten
 
 	public Object getRelationshipRepository() {
 		return relationshipRepository;
-	}
-
-	@Override
-	protected ResourceInformation getResourceInformation(Object repository) {
-		Class<?> clazz = ((RelationshipRepositoryV2<?, ?, ?, ?>) repository).getTargetResourceClass();
-		return this.moduleRegistry.getResourceRegistry().findEntry(clazz).getResourceInformation();
 	}
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/repository/ResourceRepositoryAdapter.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/repository/ResourceRepositoryAdapter.java
@@ -1,5 +1,7 @@
 package io.crnk.core.engine.internal.repository;
 
+import java.io.Serializable;
+
 import io.crnk.core.boot.CrnkProperties;
 import io.crnk.core.engine.dispatcher.RepositoryRequestSpec;
 import io.crnk.core.engine.filter.RepositoryFilterContext;
@@ -14,8 +16,6 @@ import io.crnk.core.repository.response.JsonApiResponse;
 import io.crnk.legacy.internal.AnnotatedResourceRepositoryAdapter;
 import io.crnk.legacy.repository.ResourceRepository;
 
-import java.io.Serializable;
-
 /**
  * A repository adapter for resource repository
  */
@@ -25,13 +25,16 @@ public class ResourceRepositoryAdapter<T, I extends Serializable> extends Respon
 	private final Object resourceRepository;
 
 	private final boolean isAnnotated;
+
 	private boolean return404OnNull;
 
-	public ResourceRepositoryAdapter(ResourceInformation resourceInformation, ModuleRegistry moduleRegistry, Object resourceRepository) {
+	public ResourceRepositoryAdapter(ResourceInformation resourceInformation, ModuleRegistry moduleRegistry,
+			Object resourceRepository) {
 		super(resourceInformation, moduleRegistry);
 		this.resourceRepository = resourceRepository;
 		this.isAnnotated = resourceRepository instanceof AnnotatedResourceRepositoryAdapter;
-		return404OnNull = Boolean.parseBoolean(moduleRegistry.getPropertiesProvider().getProperty(CrnkProperties.RETURN_404_ON_NULL));
+		return404OnNull =
+				Boolean.parseBoolean(moduleRegistry.getPropertiesProvider().getProperty(CrnkProperties.RETURN_404_ON_NULL));
 	}
 
 	public JsonApiResponse findOne(I id, QueryAdapter queryAdapter) {
@@ -46,9 +49,12 @@ public class ResourceRepositoryAdapter<T, I extends Serializable> extends Respon
 				Object resource;
 				if (isAnnotated) {
 					resource = ((AnnotatedResourceRepositoryAdapter) resourceRepository).findOne(id, queryAdapter);
-				} else if (resourceRepository instanceof ResourceRepositoryV2) {
-					resource = ((ResourceRepositoryV2) resourceRepository).findOne(id, request.getQuerySpec(resourceInformation));
-				} else {
+				}
+				else if (resourceRepository instanceof ResourceRepositoryV2) {
+					resource = ((ResourceRepositoryV2) resourceRepository).findOne(id, request.getQuerySpec
+							(resourceInformation));
+				}
+				else {
 					resource = ((ResourceRepository) resourceRepository).findOne(id, request.getQueryParams());
 				}
 				if (resource == null && return404OnNull) {
@@ -58,7 +64,8 @@ public class ResourceRepositoryAdapter<T, I extends Serializable> extends Respon
 			}
 
 		};
-		RepositoryRequestSpec requestSpec = RepositoryRequestSpecImpl.forFindId(moduleRegistry, queryAdapter, id);
+		RepositoryRequestSpec requestSpec = RepositoryRequestSpecImpl.forFindId(moduleRegistry, resourceInformation,
+				queryAdapter, id);
 		return chain.doFilter(newRepositoryFilterContext(requestSpec));
 	}
 
@@ -73,17 +80,20 @@ public class ResourceRepositoryAdapter<T, I extends Serializable> extends Respon
 				Object resources;
 				if (isAnnotated) {
 					resources = ((AnnotatedResourceRepositoryAdapter) resourceRepository).findAll(queryAdapter);
-				} else if (resourceRepository instanceof ResourceRepositoryV2) {
+				}
+				else if (resourceRepository instanceof ResourceRepositoryV2) {
 					QuerySpec querySpec = request.getQuerySpec(resourceInformation);
 					resources = ((ResourceRepositoryV2) resourceRepository).findAll(querySpec);
-				} else {
+				}
+				else {
 					resources = ((ResourceRepository) resourceRepository).findAll(request.getQueryParams());
 				}
 				return getResponse(resourceRepository, resources, request);
 			}
 
 		};
-		RepositoryRequestSpec requestSpec = RepositoryRequestSpecImpl.forFindAll(moduleRegistry, queryAdapter);
+		RepositoryRequestSpec requestSpec = RepositoryRequestSpecImpl.forFindAll(moduleRegistry, resourceInformation,
+				queryAdapter);
 		return chain.doFilter(newRepositoryFilterContext(requestSpec));
 	}
 
@@ -99,16 +109,20 @@ public class ResourceRepositoryAdapter<T, I extends Serializable> extends Respon
 				Object resources;
 				if (isAnnotated) {
 					resources = ((AnnotatedResourceRepositoryAdapter) resourceRepository).findAll(ids, queryAdapter);
-				} else if (resourceRepository instanceof ResourceRepositoryV2) {
-					resources = ((ResourceRepositoryV2) resourceRepository).findAll(ids, request.getQuerySpec(resourceInformation));
-				} else {
+				}
+				else if (resourceRepository instanceof ResourceRepositoryV2) {
+					resources =
+							((ResourceRepositoryV2) resourceRepository).findAll(ids, request.getQuerySpec(resourceInformation));
+				}
+				else {
 					resources = ((ResourceRepository) resourceRepository).findAll(ids, request.getQueryParams());
 				}
 				return getResponse(resourceRepository, resources, request);
 			}
 
 		};
-		RepositoryRequestSpec requestSpec = RepositoryRequestSpecImpl.forFindIds(moduleRegistry, queryAdapter, ids);
+		RepositoryRequestSpec requestSpec =
+				RepositoryRequestSpecImpl.forFindIds(moduleRegistry, resourceInformation, queryAdapter, ids);
 		return chain.doFilter(newRepositoryFilterContext(requestSpec));
 	}
 
@@ -132,20 +146,24 @@ public class ResourceRepositoryAdapter<T, I extends Serializable> extends Respon
 				Object resource;
 				if (isAnnotated) {
 					resource = ((AnnotatedResourceRepositoryAdapter) resourceRepository).save(entity);
-				} else if (resourceRepository instanceof ResourceRepositoryV2) {
+				}
+				else if (resourceRepository instanceof ResourceRepositoryV2) {
 					if (method == HttpMethod.POST) {
 						resource = ((ResourceRepositoryV2) resourceRepository).create(entity);
-					} else {
+					}
+					else {
 						resource = ((ResourceRepositoryV2) resourceRepository).save(entity);
 					}
-				} else {
+				}
+				else {
 					resource = ((ResourceRepository) resourceRepository).save(entity);
 				}
 				return getResponse(resourceRepository, resource, request);
 			}
 
 		};
-		RepositoryRequestSpec requestSpec = RepositoryRequestSpecImpl.forSave(moduleRegistry, method, queryAdapter, entity);
+		RepositoryRequestSpec requestSpec =
+				RepositoryRequestSpecImpl.forSave(moduleRegistry, method, resourceInformation, queryAdapter, entity);
 		return chain.doFilter(newRepositoryFilterContext(requestSpec));
 	}
 
@@ -160,25 +178,23 @@ public class ResourceRepositoryAdapter<T, I extends Serializable> extends Respon
 				Serializable id = request.getId();
 				if (isAnnotated) {
 					((AnnotatedResourceRepositoryAdapter) resourceRepository).delete(id, queryAdapter);
-				} else if (resourceRepository instanceof ResourceRepositoryV2) {
+				}
+				else if (resourceRepository instanceof ResourceRepositoryV2) {
 					((ResourceRepositoryV2) resourceRepository).delete(id);
-				} else {
+				}
+				else {
 					((ResourceRepository) resourceRepository).delete(id);
 				}
 				return new JsonApiResponse();
 			}
 		};
-		RepositoryRequestSpec requestSpec = RepositoryRequestSpecImpl.forDelete(moduleRegistry, queryAdapter, id);
+		RepositoryRequestSpec requestSpec =
+				RepositoryRequestSpecImpl.forDelete(moduleRegistry, resourceInformation, queryAdapter, id);
 		return chain.doFilter(newRepositoryFilterContext(requestSpec));
 	}
 
 	public Object getResourceRepository() {
 		return resourceRepository;
-	}
-
-	@Override
-	protected ResourceInformation getResourceInformation(Object repository) {
-		return resourceInformation;
 	}
 
 	public Class<?> getResourceClass() {

--- a/crnk-core/src/main/java/io/crnk/core/engine/parser/StringMapper.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/parser/StringMapper.java
@@ -1,0 +1,7 @@
+package io.crnk.core.engine.parser;
+
+public interface StringMapper<T> extends StringParser<T> {
+
+	String toString(T input);
+
+}

--- a/crnk-core/src/main/java/io/crnk/core/engine/registry/RegistryEntry.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/registry/RegistryEntry.java
@@ -1,22 +1,21 @@
 package io.crnk.core.engine.registry;
 
 import io.crnk.core.engine.information.repository.ResourceRepositoryInformation;
+import io.crnk.core.engine.information.resource.ResourceField;
 import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.repository.RelationshipRepositoryAdapter;
 import io.crnk.core.engine.internal.repository.ResourceRepositoryAdapter;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.exception.RelationshipRepositoryNotFoundException;
+import io.crnk.core.exception.ResourceFieldNotFoundException;
 import io.crnk.core.module.ModuleRegistry;
-import io.crnk.core.utils.Optional;
 import io.crnk.legacy.internal.DirectResponseRelationshipEntry;
 import io.crnk.legacy.internal.DirectResponseResourceEntry;
 import io.crnk.legacy.internal.RepositoryMethodParameterProvider;
 import io.crnk.legacy.registry.AnnotatedRelationshipEntryBuilder;
 import io.crnk.legacy.registry.AnnotatedResourceEntry;
-
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Objects;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Holds information about a resource of type <i>T</i> and its repositories. It
@@ -24,33 +23,24 @@ import java.util.Objects;
  * information about the resource, - ResourceEntry instance, - List of all
  * repositories for relationships defined in resource class. - Parent
  * RegistryEntry if a resource inherits from another resource
- *
- * @param <T> resource type
  */
 public class RegistryEntry {
 
-	private final ResourceInformation resourceInformation;
-
 	private final ResourceEntry resourceEntry;
 
-	private final List<ResponseRelationshipEntry> relationshipEntries;
+	private final Map<ResourceField, ResponseRelationshipEntry> relationshipEntries;
 
 	private RegistryEntry parentRegistryEntry = null;
 
 	private ModuleRegistry moduleRegistry;
 
-	private ResourceRepositoryInformation repositoryInformation;
-
-	public RegistryEntry(ResourceRepositoryInformation repositoryInformation, @SuppressWarnings("SameParameterValue") ResourceEntry resourceEntry) {
-		this(repositoryInformation.getResourceInformation().get(), repositoryInformation, resourceEntry, new LinkedList<ResponseRelationshipEntry>());
+	public RegistryEntry(ResourceEntry resourceEntry) {
+		this(resourceEntry, new HashMap<>());
 	}
 
-	public RegistryEntry(ResourceInformation resourceInformation, ResourceRepositoryInformation repositoryInformation, ResourceEntry resourceEntry, List<ResponseRelationshipEntry> relationshipEntries) {
-		this.repositoryInformation = repositoryInformation;
-		this.resourceInformation = resourceInformation;
+	public RegistryEntry(ResourceEntry resourceEntry, Map<ResourceField, ResponseRelationshipEntry> relationshipEntries) {
 		this.resourceEntry = resourceEntry;
 		this.relationshipEntries = relationshipEntries;
-		PreconditionUtil.assertNotNull("no resourceInformation", resourceInformation);
 	}
 
 	public void initialize(ModuleRegistry moduleRegistry) {
@@ -63,7 +53,8 @@ public class RegistryEntry {
 		Object repoInstance = null;
 		if (resourceEntry instanceof DirectResponseResourceEntry) {
 			repoInstance = ((DirectResponseResourceEntry) resourceEntry).getResourceRepository();
-		} else if (resourceEntry instanceof AnnotatedResourceEntry) {
+		}
+		else if (resourceEntry instanceof AnnotatedResourceEntry) {
 			repoInstance = ((AnnotatedResourceEntry) resourceEntry).build(parameterProvider);
 		}
 
@@ -71,34 +62,33 @@ public class RegistryEntry {
 			((ResourceRegistryAware) repoInstance).setResourceRegistry(moduleRegistry.getResourceRegistry());
 		}
 
+		ResourceInformation resourceInformation = getResourceInformation();
 		return new ResourceRepositoryAdapter(resourceInformation, moduleRegistry, repoInstance);
 	}
 
-	public List<ResponseRelationshipEntry> getRelationshipEntries() {
-		return relationshipEntries;
-	}
-
-	public Optional<ResponseRelationshipEntry> getRelationshipEntry(String targetResourceType){
-		for (ResponseRelationshipEntry relationshipEntry : relationshipEntries) {
-			if (relationshipEntry.getTargetResourceType() == null || targetResourceType.equals(relationshipEntry.getTargetResourceType())) {
-				return Optional.of(relationshipEntry);
-			}
+	public RelationshipRepositoryAdapter getRelationshipRepository(String fieldName, RepositoryMethodParameterProvider
+			parameterProvider) {
+		ResourceField field = getResourceInformation().findFieldByUnderlyingName(fieldName);
+		if (field == null) {
+			throw new ResourceFieldNotFoundException("field=" + fieldName);
 		}
-		return Optional.empty();
+		return getRelationshipRepository(field, parameterProvider);
 	}
 
 	@SuppressWarnings("unchecked")
-	public RelationshipRepositoryAdapter getRelationshipRepositoryForType(String targetResourceType, RepositoryMethodParameterProvider parameterProvider) {
-		Optional<ResponseRelationshipEntry> optRelationshipEntry = getRelationshipEntry(targetResourceType);
-		if (!optRelationshipEntry.isPresent()) {
-			throw new RelationshipRepositoryNotFoundException(resourceInformation.getResourceType(), targetResourceType);
+	public RelationshipRepositoryAdapter getRelationshipRepository(ResourceField field, RepositoryMethodParameterProvider
+			parameterProvider) {
+		ResponseRelationshipEntry relationshipEntry = relationshipEntries.get(field);
+		if (relationshipEntry == null) {
+			throw new RelationshipRepositoryNotFoundException(getResourceInformation().getResourceType(),
+					field.getUnderlyingName());
 		}
-		ResponseRelationshipEntry relationshipEntry = optRelationshipEntry.get();
 
 		Object repoInstance;
 		if (relationshipEntry instanceof AnnotatedRelationshipEntryBuilder) {
 			repoInstance = ((AnnotatedRelationshipEntryBuilder) relationshipEntry).build(parameterProvider);
-		} else {
+		}
+		else {
 			repoInstance = ((DirectResponseRelationshipEntry) relationshipEntry).getRepositoryInstanceBuilder();
 		}
 
@@ -106,18 +96,19 @@ public class RegistryEntry {
 			((ResourceRegistryAware) repoInstance).setResourceRegistry(moduleRegistry.getResourceRegistry());
 		}
 
-		return new RelationshipRepositoryAdapter(resourceInformation, moduleRegistry, repoInstance);
+		return new RelationshipRepositoryAdapter(getResourceInformation(), moduleRegistry, repoInstance);
 	}
 
 	public ResourceInformation getResourceInformation() {
-		return resourceInformation;
+		return resourceEntry.getRepositoryInformation().getResourceInformation().get();
 	}
 
 	public ResourceRepositoryInformation getRepositoryInformation() {
-		return repositoryInformation;
+		return resourceEntry.getRepositoryInformation();
 	}
 
 	public RegistryEntry getParentRegistryEntry() {
+		ResourceInformation resourceInformation = getResourceInformation();
 		String superResourceType = resourceInformation.getSuperResourceType();
 		if (superResourceType != null) {
 			ResourceRegistry resourceRegistry = moduleRegistry.getResourceRegistry();
@@ -152,26 +143,11 @@ public class RegistryEntry {
 		return false;
 	}
 
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || !(o instanceof RegistryEntry)) {
-			return false;
-		}
-		RegistryEntry that = (RegistryEntry) o;
-		return Objects.equals(resourceInformation, that.resourceInformation) && // NOSONAR
-				Objects.equals(repositoryInformation, that.repositoryInformation) && Objects.equals(resourceEntry, that.resourceEntry) && Objects.equals(moduleRegistry, that.moduleRegistry)
-				&& Objects.equals(relationshipEntries, that.relationshipEntries) && Objects.equals(parentRegistryEntry, that.parentRegistryEntry);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(repositoryInformation, resourceInformation, resourceEntry, relationshipEntries, moduleRegistry, parentRegistryEntry);
-	}
-
 	public ResourceRepositoryAdapter getResourceRepository() {
 		return getResourceRepository(null);
+	}
+
+	public Map<ResourceField, ResponseRelationshipEntry> getRelationshipEntries() {
+		return relationshipEntries;
 	}
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/registry/RegistryEntryBuilder.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/registry/RegistryEntryBuilder.java
@@ -1,9 +1,14 @@
 package io.crnk.core.engine.registry;
 
 import io.crnk.core.engine.information.InformationBuilder;
+import io.crnk.core.repository.RelationshipMatcher;
 
 public interface RegistryEntryBuilder {
 
+	/**
+	 * Builds up the entry from the provided implementation
+	 */
+	void fromImplemenation(Object repository);
 
 	interface ResourceRepository {
 
@@ -23,7 +28,7 @@ public interface RegistryEntryBuilder {
 
 	InformationBuilder.Resource resource();
 
-	RelationshipRepository relationshipRepository(String targetResourceType);
+	RelationshipRepository relationshipRepositoryForField(String fieldName);
 
 	RegistryEntry build();
 

--- a/crnk-core/src/main/java/io/crnk/core/engine/registry/ResourceEntry.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/registry/ResourceEntry.java
@@ -1,7 +1,11 @@
 package io.crnk.core.engine.registry;
 
+import io.crnk.core.engine.information.repository.ResourceRepositoryInformation;
+
 /**
  * A marker interface that identifies a entry
  */
 public interface ResourceEntry {
+
+	ResourceRepositoryInformation getRepositoryInformation();
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/registry/ResponseRelationshipEntry.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/registry/ResponseRelationshipEntry.java
@@ -5,6 +5,7 @@ package io.crnk.core.engine.registry;
  */
 public interface ResponseRelationshipEntry {
 
+
 	/**
 	 * @return target resource type. null to accept any target
 	 */

--- a/crnk-core/src/main/java/io/crnk/core/module/ModuleRegistry.java
+++ b/crnk-core/src/main/java/io/crnk/core/module/ModuleRegistry.java
@@ -4,14 +4,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.crnk.core.engine.dispatcher.RequestDispatcher;
 import io.crnk.core.engine.error.ExceptionMapper;
 import io.crnk.core.engine.error.JsonApiExceptionMapper;
-import io.crnk.core.engine.filter.*;
+import io.crnk.core.engine.filter.DocumentFilter;
+import io.crnk.core.engine.filter.RepositoryFilter;
+import io.crnk.core.engine.filter.ResourceFilter;
+import io.crnk.core.engine.filter.ResourceFilterDirectory;
+import io.crnk.core.engine.filter.ResourceModificationFilter;
 import io.crnk.core.engine.http.HttpRequestContextProvider;
 import io.crnk.core.engine.http.HttpRequestProcessor;
 import io.crnk.core.engine.information.InformationBuilder;
-import io.crnk.core.engine.information.contributor.ResourceFieldContributor;
-import io.crnk.core.engine.information.contributor.ResourceFieldContributorContext;
-import io.crnk.core.engine.information.repository.*;
-import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.information.repository.RepositoryInformation;
+import io.crnk.core.engine.information.repository.RepositoryInformationProvider;
+import io.crnk.core.engine.information.repository.RepositoryInformationProviderContext;
 import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.information.resource.ResourceInformationProvider;
 import io.crnk.core.engine.information.resource.ResourceInformationProviderContext;
@@ -19,44 +22,40 @@ import io.crnk.core.engine.internal.exception.ExceptionMapperLookup;
 import io.crnk.core.engine.internal.exception.ExceptionMapperRegistry;
 import io.crnk.core.engine.internal.exception.ExceptionMapperRegistryBuilder;
 import io.crnk.core.engine.internal.information.DefaultInformationBuilder;
-import io.crnk.core.engine.internal.information.repository.RelationshipRepositoryInformationImpl;
 import io.crnk.core.engine.internal.registry.DefaultRegistryEntryBuilder;
-import io.crnk.core.repository.RelationshipRepositoryBase;
-import io.crnk.core.repository.implicit.ImplicitOwnerBasedRelationshipRepository;
-import io.crnk.core.engine.internal.utils.ClassUtils;
-import io.crnk.core.engine.internal.utils.Decorator;
 import io.crnk.core.engine.internal.utils.MultivaluedMap;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.engine.parser.TypeParser;
 import io.crnk.core.engine.properties.NullPropertiesProvider;
 import io.crnk.core.engine.properties.PropertiesProvider;
-import io.crnk.core.engine.registry.*;
+import io.crnk.core.engine.registry.RegistryEntry;
+import io.crnk.core.engine.registry.RegistryEntryBuilder;
+import io.crnk.core.engine.registry.ResourceRegistry;
+import io.crnk.core.engine.registry.ResourceRegistryPart;
 import io.crnk.core.engine.security.SecurityProvider;
 import io.crnk.core.module.Module.ModuleContext;
 import io.crnk.core.module.discovery.MultiResourceLookup;
 import io.crnk.core.module.discovery.ResourceLookup;
 import io.crnk.core.module.discovery.ServiceDiscovery;
-import io.crnk.core.module.internal.DefaultRepositoryInformationProviderContext;
 import io.crnk.core.module.internal.ResourceFilterDirectoryImpl;
-import io.crnk.core.repository.RelationshipRepositoryV2;
 import io.crnk.core.repository.ResourceRepositoryV2;
 import io.crnk.core.repository.decorate.RelationshipRepositoryDecorator;
 import io.crnk.core.repository.decorate.RepositoryDecoratorFactory;
 import io.crnk.core.repository.decorate.ResourceRepositoryDecorator;
-import io.crnk.core.resource.annotations.LookupIncludeBehavior;
-import io.crnk.core.resource.annotations.RelationshipRepositoryBehavior;
 import io.crnk.core.utils.Optional;
 import io.crnk.core.utils.Prioritizable;
-import io.crnk.legacy.internal.DirectResponseRelationshipEntry;
-import io.crnk.legacy.internal.DirectResponseResourceEntry;
-import io.crnk.legacy.registry.AnnotatedRelationshipEntryBuilder;
-import io.crnk.legacy.registry.AnnotatedResourceEntry;
 import io.crnk.legacy.registry.DefaultResourceInformationProviderContext;
-import io.crnk.legacy.registry.RepositoryInstanceBuilder;
-import io.crnk.legacy.repository.annotations.JsonApiRelationshipRepository;
+import io.crnk.legacy.repository.ResourceRepository;
 import io.crnk.legacy.repository.annotations.JsonApiResourceRepository;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Container for setting up and holding {@link Module} instances;
@@ -83,6 +82,10 @@ public class ModuleRegistry {
 
 	public List<ResourceModificationFilter> getResourceModificationFilters() {
 		return prioritze(aggregatedModule.getResourceModificationFilters());
+	}
+
+	public Collection<Object> getRepositories() {
+		return aggregatedModule.getRepositories();
 	}
 
 	enum InitializedState {
@@ -331,250 +334,26 @@ public class ModuleRegistry {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	private void applyRepositoryRegistrations() {
-		List<Object> repositories = aggregatedModule.getRepositories();
-
-		MultivaluedMap<String, RepositoryInformation> typeInfoMapping = new MultivaluedMap<>();
-		Map<Object, Object> infoRepositoryMapping = new HashMap<>();
-		mapRepositoryRegistrations(repositories, typeInfoMapping, infoRepositoryMapping);
-
-		for (String resourceType : typeInfoMapping.keySet()) {
-			applyRepositoryRegistration(resourceType, typeInfoMapping, infoRepositoryMapping);
-		}
-	}
-
-	private void applyRepositoryRegistration(String resourceType,
-			MultivaluedMap<String, RepositoryInformation> typeInfoMapping, Map<Object, Object> infoRepositoryMapping) {
-
-		// TODO align if RegistryEntryBuilder
-
-		ResourceInformation resourceInformation = null;
-
-		ResourceRepositoryInformation resourceRepositoryInformation = null;
-		List<ResponseRelationshipEntry> relationshipEntries = new ArrayList<>();
-		ResourceEntry resourceEntry = null;
-		Class resourceClass = null;
-		List<RepositoryInformation> repositoryInformations = typeInfoMapping.getList(resourceType);
-		List<Object> unwrappedRelationshipRepositories = new ArrayList<>();
-		for (RepositoryInformation repositoryInformation : repositoryInformations) {
-			if (repositoryInformation instanceof ResourceRepositoryInformation) {
-				resourceRepositoryInformation = (ResourceRepositoryInformation) repositoryInformation;
-				Object repository = infoRepositoryMapping.get(resourceRepositoryInformation);
-				resourceEntry = setupResourceRepository(repository);
-			}
-			else {
-				RelationshipRepositoryInformation relationshipRepositoryInformation =
-						(RelationshipRepositoryInformation) repositoryInformation;
-				Object repository = infoRepositoryMapping.get(repositoryInformation);
-
-				unwrappedRelationshipRepositories.add(repository);
-
-				setupRelationship(relationshipEntries, relationshipRepositoryInformation, repository);
-
-				if (resourceClass == null) {
-					resourceClass = relationshipRepositoryInformation.getSourceResourceClass().get();
-				}
-			}
-		}
-
-		if (resourceRepositoryInformation != null) {
-			resourceInformation = resourceRepositoryInformation.getResourceInformation().get();
-		}
-
-		if (resourceInformation == null) {
-			ResourceInformationProvider resourceInformationProvider = getResourceInformationBuilder();
-			PreconditionUtil.assertNotNull("resource class cannot be determined", resourceClass);
-			resourceInformation = resourceInformationProvider.build(resourceClass);
-		}
-
-		setupImplicitRelationshipRepositories(resourceInformation, resourceRepositoryInformation, repositoryInformations,
-				relationshipEntries);
-
-		contributeFields(resourceInformation, unwrappedRelationshipRepositories);
-
-		RegistryEntry registryEntry =
-				new RegistryEntry(resourceInformation, resourceRepositoryInformation, resourceEntry, relationshipEntries);
-		registryEntry.initialize(this);
-		resourceRegistry.addEntry(registryEntry);
-	}
-
-	private void setupImplicitRelationshipRepositories(ResourceInformation resourceInformation,
-			ResourceRepositoryInformation resourceRepositoryInformation,
-			List<RepositoryInformation> repositoryInformations,
-			List<ResponseRelationshipEntry> relationshipEntries) {
-		for (ResourceField relationshipField : resourceInformation.getRelationshipFields()) {
-
-			RelationshipRepositoryBehavior behavior = relationshipField.getRelationshipRepositoryBehavior();
-			if (behavior == RelationshipRepositoryBehavior.DEFAULT) {
-				if (resourceRepositoryInformation != null && relationshipField.hasIdField()
-						|| relationshipField.getLookupIncludeAutomatically() == LookupIncludeBehavior.NONE) {
-					behavior = RelationshipRepositoryBehavior.IMPLICIT_FROM_OWNER;
-				}
-				else {
-					behavior = RelationshipRepositoryBehavior.CUSTOM;
-				}
-			}
-
-
-			if (behavior != RelationshipRepositoryBehavior.CUSTOM && !hasRepository(relationshipField, repositoryInformations)) {
-				ResourceInformation sourceInformation = relationshipField.getParentResourceInformation();
-				RepositoryMethodAccess access = resourceRepositoryInformation.getAccess();
-
-				RelationshipRepositoryInformationImpl implicitRepoInformation =
-						new RelationshipRepositoryInformationImpl(sourceInformation.getResourceClass(),
-								sourceInformation.getResourceType(), relationshipField.getOppositeResourceType(), access);
-
-				repositoryInformations.add(implicitRepoInformation);
-				RelationshipRepositoryBase repository;
-				if (behavior == RelationshipRepositoryBehavior.IMPLICIT_FROM_OWNER) {
-					repository = new ImplicitOwnerBasedRelationshipRepository(
-							sourceInformation.getResourceType(), relationshipField.getOppositeResourceType());
-				}
-				else {
-					PreconditionUtil.assertEquals("unknown behavior", RelationshipRepositoryBehavior
-							.IMPLICIT_GET_OPPOSITE_MODIFY_OWNER, behavior);
-					repository = new RelationshipRepositoryBase(
-							sourceInformation.getResourceType(), relationshipField.getOppositeResourceType());
-				}
-				repository.setResourceRegistry(resourceRegistry);
-				setupRelationship(relationshipEntries, implicitRepoInformation, repository);
-			}
-		}
-	}
-
-	private boolean hasRepository(ResourceField relationshipField, List<RepositoryInformation> repositoryInformations) {
-		for (RepositoryInformation repositoryInformation : repositoryInformations) {
-			if (repositoryInformation instanceof RelationshipRepositoryInformation) {
-				RelationshipRepositoryInformation relInformation = (RelationshipRepositoryInformation) repositoryInformation;
-
-				// TODO add field matching: boolean fieldMatch =
-				boolean targetMatch = Objects.equals(relationshipField.getParentResourceInformation().getResourceType(),
-						relInformation.getSourceResourceType());
-				boolean sourceMatch = Objects.equals(relationshipField.getOppositeResourceType(), relInformation
-						.getTargetResourceType());
-				if (sourceMatch && targetMatch) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
-	private void contributeFields(ResourceInformation resourceInformation, List<Object> unwrappedRelationshipRepositories) {
-
-		for (Object relRepository : unwrappedRelationshipRepositories) {
-			if (relRepository instanceof ResourceFieldContributor) {
-				ResourceFieldContributor contributor = (ResourceFieldContributor) relRepository;
-				List<ResourceField> contributedFields = contributor.getResourceFields(new ResourceFieldContributorContext() {
-					@Override
-					public InformationBuilder getInformationBuilder() {
-						return new DefaultInformationBuilder(typeParser);
-					}
-				});
-				List<ResourceField> fields = new ArrayList<>();
-				fields.addAll(resourceInformation.getFields());
-				fields.addAll(contributedFields);
-				resourceInformation.setFields(fields);
-			}
-		}
-
-	}
-
-	private void mapRepositoryRegistrations(List<Object> repositories,
-			MultivaluedMap<String, RepositoryInformation> resourceTypeMap,
-			Map<Object, Object> resourceInformationMap) {
-
-		RepositoryInformationProvider repositoryInformationProvider = getRepositoryInformationBuilder();
-		RepositoryInformationProviderContext builderContext = new DefaultRepositoryInformationProviderContext(this);
-
+		Collection<Object> repositories = filterDecorators(aggregatedModule.getRepositories());
 		for (Object repository : repositories) {
-			if (!(repository instanceof ResourceRepositoryDecorator)
-					&& !(repository instanceof RelationshipRepositoryDecorator)) {
-				RepositoryInformation repositoryInformation = repositoryInformationProvider.build(repository, builderContext);
-				if (repositoryInformation instanceof ResourceRepositoryInformation) {
-					ResourceRepositoryInformation info = (ResourceRepositoryInformation) repositoryInformation;
-					resourceInformationMap.put(info, repository);
-					resourceTypeMap.add(info.getResourceType(), repositoryInformation);
-				}
-				else {
-					RelationshipRepositoryInformation info = (RelationshipRepositoryInformation) repositoryInformation;
-					resourceInformationMap.put(info, repository);
-					resourceTypeMap.add(info.getSourceResourceType(), repositoryInformation);
-				}
+			if (repository instanceof ResourceRepositoryV2 || repository instanceof ResourceRepository || repository.getClass()
+					.getAnnotation(JsonApiResourceRepository.class) != null) {
+				applyRepositoryRegistration(repository, repositories);
 			}
-		}
-
-	}
-
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	private ResourceEntry setupResourceRepository(Object repository) {
-		final Object decoratedRepository = decorateRepository(repository);
-		RepositoryInstanceBuilder repositoryInstanceBuilder = new RepositoryInstanceBuilder(null, repository.getClass()) {
-
-			@Override
-			public Object buildRepository() {
-				return decoratedRepository;
-			}
-		};
-
-		if (ClassUtils.getAnnotation(decoratedRepository.getClass(), JsonApiResourceRepository.class).isPresent()) {
-			return new AnnotatedResourceEntry(repositoryInstanceBuilder);
-		}
-		else {
-			return new DirectResponseResourceEntry(repositoryInstanceBuilder);
 		}
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public Object decorateRepository(Object repository) {
-		Object decoratedRepository = repository;
-		List<RepositoryDecoratorFactory> repositoryDecorators = getRepositoryDecoratorFactories();
-		for (RepositoryDecoratorFactory repositoryDecorator : repositoryDecorators) {
-			Decorator decorator = null;
-			if (decoratedRepository instanceof RelationshipRepositoryV2) {
-				decorator = repositoryDecorator.decorateRepository((RelationshipRepositoryV2) decoratedRepository);
-			}
-			else if (decoratedRepository instanceof ResourceRepositoryV2) {
-				decorator = repositoryDecorator.decorateRepository((ResourceRepositoryV2) decoratedRepository);
-			}
-			if (decorator != null) {
-				decorator.setDecoratedObject(decoratedRepository);
-				decoratedRepository = decorator;
-			}
-		}
-		if (decoratedRepository instanceof ResourceRegistryAware) {
-			((ResourceRegistryAware) decoratedRepository).setResourceRegistry(resourceRegistry);
-		}
-		return decoratedRepository;
+	private List<Object> filterDecorators(List<Object> repositories) {
+		return repositories.stream()
+				.filter(it -> !(it instanceof ResourceRepositoryDecorator || it instanceof RelationshipRepositoryDecorator))
+				.collect(Collectors.toList());
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	private void setupRelationship(List<ResponseRelationshipEntry> relationshipEntries,
-			final RelationshipRepositoryInformation relationshipRepositoryInformation, final Object relRepository) {
-
-		final Object decoratedRepository = decorateRepository(relRepository);
-		RepositoryInstanceBuilder<Object> relationshipInstanceBuilder =
-				new RepositoryInstanceBuilder<Object>(null, (Class) relRepository.getClass()) {
-
-					@Override
-					public Object buildRepository() {
-						return decoratedRepository;
-					}
-				};
-
-		final String targetResourceType = relationshipRepositoryInformation.getTargetResourceType();
-		if (ClassUtils.getAnnotation(relRepository.getClass(), JsonApiRelationshipRepository.class).isPresent()) {
-			relationshipEntries.add(new AnnotatedRelationshipEntryBuilder(this, relationshipInstanceBuilder));
-		}
-		else {
-			ResponseRelationshipEntry relationshipEntry = new DirectResponseRelationshipEntry(relationshipInstanceBuilder) {
-
-				@Override
-				public String getTargetResourceType() {
-					return targetResourceType;
-				}
-			};
-			relationshipEntries.add(relationshipEntry);
-		}
+	private void applyRepositoryRegistration(Object repository, Collection<Object> repositories) {
+		RegistryEntryBuilder entryBuilder = getContext().newRegistryEntryBuilder();
+		entryBuilder.fromImplemenation(repository);
+		RegistryEntry entry = entryBuilder.build();
+		resourceRegistry.addEntry(entry);
 	}
 
 	/**

--- a/crnk-core/src/main/java/io/crnk/core/module/SimpleModule.java
+++ b/crnk-core/src/main/java/io/crnk/core/module/SimpleModule.java
@@ -1,5 +1,14 @@
 package io.crnk.core.module;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import io.crnk.core.engine.error.JsonApiExceptionMapper;
 import io.crnk.core.engine.filter.DocumentFilter;
 import io.crnk.core.engine.filter.RepositoryFilter;
@@ -14,8 +23,6 @@ import io.crnk.core.engine.registry.ResourceRegistryPart;
 import io.crnk.core.engine.security.SecurityProvider;
 import io.crnk.core.module.discovery.ResourceLookup;
 import io.crnk.core.repository.decorate.RepositoryDecoratorFactory;
-
-import java.util.*;
 
 /**
  * Vanilla {@link Module} implementation that allows registration of extensions.
@@ -258,12 +265,18 @@ public class SimpleModule implements Module {
 		repositories.add(repository);
 	}
 
+	/**
+	 * @deprecated use addRepository(repository)
+	 */
 	@Deprecated
 	public void addRepository(Class<?> resourceClass, Object repository) {
 		checkInitialized();
 		repositories.add(repository);
 	}
 
+	/**
+	 * @deprecated use addRepository(repository)
+	 */
 	@Deprecated
 	public void addRepository(Class<?> sourceType, Class<?> targetType, Object repository) {
 		checkInitialized();

--- a/crnk-core/src/main/java/io/crnk/core/repository/ReadOnlyRelationshipRepositoryBase.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/ReadOnlyRelationshipRepositoryBase.java
@@ -10,6 +10,16 @@ public abstract class ReadOnlyRelationshipRepositoryBase<S, I extends Serializab
 
 
 	@Override
+	public Class<S> getSourceResourceClass() {
+		throw new UnsupportedOperationException("implement getMatcher() or this method");
+	}
+
+	@Override
+	public Class<T> getTargetResourceClass() {
+		throw new UnsupportedOperationException("implement getMatcher() or this method");
+	}
+
+	@Override
 	public T findOneTarget(I sourceId, String fieldName, QuerySpec querySpec) {
 		throw new UnsupportedOperationException();
 	}

--- a/crnk-core/src/main/java/io/crnk/core/repository/RelationshipMatcher.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/RelationshipMatcher.java
@@ -1,0 +1,22 @@
+package io.crnk.core.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.crnk.core.engine.information.resource.ResourceField;
+
+/**
+ * specifies to which relationships a relationship repository should be applied to.
+ */
+public class RelationshipMatcher {
+
+	protected List<RelationshipMatcherRule> rules = new ArrayList<>();
+
+	public RelationshipMatcherRule rule() {
+		return new RelationshipMatcherRule(this);
+	}
+
+	public boolean matches(ResourceField field) {
+		return rules.stream().filter(it -> it.matches(field)).findAny().isPresent();
+	}
+}

--- a/crnk-core/src/main/java/io/crnk/core/repository/RelationshipMatcherRule.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/RelationshipMatcherRule.java
@@ -15,13 +15,18 @@ public class RelationshipMatcherRule {
 
 	private Class<?> sourceResourceClass;
 
+	private boolean sourceMatchSubTypes;
+
 	private String sourceField;
 
 	private String targetResourceType;
 
 	private Class<?> targetResourceClass;
 
+	private boolean targetMatchSubTypes;
+
 	private String targetField;
+
 
 	protected RelationshipMatcherRule(RelationshipMatcher matcher) {
 		this.matcher = matcher;
@@ -33,12 +38,23 @@ public class RelationshipMatcherRule {
 	}
 
 	public RelationshipMatcherRule source(Class<?> sourceResourceClass) {
+		return source(sourceResourceClass, false);
+	}
+
+	public RelationshipMatcherRule source(Class<?> sourceResourceClass, boolean sourceMatchSubTypes) {
 		this.sourceResourceClass = sourceResourceClass;
+		this.sourceMatchSubTypes = sourceMatchSubTypes;
 		return this;
 	}
 
 	public RelationshipMatcherRule field(String sourceField) {
 		this.sourceField = sourceField;
+		return this;
+	}
+
+	public RelationshipMatcherRule field(ResourceField sourceField) {
+		field(sourceField.getUnderlyingName());
+		source(sourceField.getParentResourceInformation().getResourceType());
 		return this;
 	}
 
@@ -48,9 +64,15 @@ public class RelationshipMatcherRule {
 	}
 
 	public RelationshipMatcherRule target(Class<?> targetResourceClass) {
+		return target(targetResourceClass, false);
+	}
+
+	public RelationshipMatcherRule target(Class<?> targetResourceClass, boolean targetMatchSubTypes) {
 		this.targetResourceClass = targetResourceClass;
+		this.targetMatchSubTypes = targetMatchSubTypes;
 		return this;
 	}
+
 
 	public RelationshipMatcherRule oppositeField(String targetField) {
 		this.targetField = targetField;
@@ -64,10 +86,11 @@ public class RelationshipMatcherRule {
 
 	public boolean matches(ResourceField field) {
 		boolean matchesSourceType = nullOrMatch(sourceResourceType, field.getParentResourceInformation().getResourceType());
-		boolean matchesSourceClass = nullOrMatch(sourceResourceClass, field.getParentResourceInformation().getResourceClass());
+		boolean matchesSourceClass = nullOrMatch(sourceResourceClass, field.getParentResourceInformation().getResourceClass(),
+				sourceMatchSubTypes);
 		boolean matchesSourceField = nullOrMatch(sourceField, field.getUnderlyingName());
 		boolean matchesTargetType = nullOrMatch(targetResourceType, field.getOppositeResourceType());
-		boolean matchesTargetClass = nullOrMatch(targetResourceClass, field.getElementType());
+		boolean matchesTargetClass = nullOrMatch(targetResourceClass, field.getElementType(), targetMatchSubTypes);
 		boolean matchesTargetField = nullOrMatch(targetField, field.getOppositeName());
 		return matchesSourceType && matchesSourceClass && matchesSourceField && matchesTargetType && matchesTargetClass &&
 				matchesTargetField;
@@ -77,8 +100,8 @@ public class RelationshipMatcherRule {
 		return expected == null || Objects.equals(expected, actual);
 	}
 
-	private boolean nullOrMatch(Class expected, Class actual) {
-		return expected == null || expected.isAssignableFrom(actual);
+	private boolean nullOrMatch(Class expected, Class actual, boolean matchSubTypes) {
+		return expected == null || Objects.equals(expected, actual) || matchSubTypes && expected.isAssignableFrom(actual);
 	}
 
 }

--- a/crnk-core/src/main/java/io/crnk/core/repository/RelationshipMatcherRule.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/RelationshipMatcherRule.java
@@ -9,23 +9,23 @@ import io.crnk.core.engine.information.resource.ResourceField;
  */
 public class RelationshipMatcherRule {
 
-	private final RelationshipMatcher matcher;
+	protected final RelationshipMatcher matcher;
 
-	private String sourceResourceType;
+	protected String sourceResourceType;
 
-	private Class<?> sourceResourceClass;
+	protected Class<?> sourceResourceClass;
 
-	private boolean sourceMatchSubTypes;
+	protected boolean sourceMatchSubTypes;
 
-	private String sourceField;
+	protected String sourceField;
 
-	private String targetResourceType;
+	protected String targetResourceType;
 
-	private Class<?> targetResourceClass;
+	protected Class<?> targetResourceClass;
 
-	private boolean targetMatchSubTypes;
+	protected boolean targetMatchSubTypes;
 
-	private String targetField;
+	protected String targetField;
 
 
 	protected RelationshipMatcherRule(RelationshipMatcher matcher) {

--- a/crnk-core/src/main/java/io/crnk/core/repository/RelationshipMatcherRule.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/RelationshipMatcherRule.java
@@ -1,0 +1,84 @@
+package io.crnk.core.repository;
+
+import java.util.Objects;
+
+import io.crnk.core.engine.information.resource.ResourceField;
+
+/**
+ * see {@link RelationshipMatcher}
+ */
+public class RelationshipMatcherRule {
+
+	private final RelationshipMatcher matcher;
+
+	private String sourceResourceType;
+
+	private Class<?> sourceResourceClass;
+
+	private String sourceField;
+
+	private String targetResourceType;
+
+	private Class<?> targetResourceClass;
+
+	private String targetField;
+
+	protected RelationshipMatcherRule(RelationshipMatcher matcher) {
+		this.matcher = matcher;
+	}
+
+	public RelationshipMatcherRule source(String sourceResourceType) {
+		this.sourceResourceType = sourceResourceType;
+		return this;
+	}
+
+	public RelationshipMatcherRule source(Class<?> sourceResourceClass) {
+		this.sourceResourceClass = sourceResourceClass;
+		return this;
+	}
+
+	public RelationshipMatcherRule field(String sourceField) {
+		this.sourceField = sourceField;
+		return this;
+	}
+
+	public RelationshipMatcherRule target(String targetResourceType) {
+		this.targetResourceType = targetResourceType;
+		return this;
+	}
+
+	public RelationshipMatcherRule target(Class<?> targetResourceClass) {
+		this.targetResourceClass = targetResourceClass;
+		return this;
+	}
+
+	public RelationshipMatcherRule oppositeField(String targetField) {
+		this.targetField = targetField;
+		return this;
+	}
+
+	public RelationshipMatcher add() {
+		matcher.rules.add(this);
+		return matcher;
+	}
+
+	public boolean matches(ResourceField field) {
+		boolean matchesSourceType = nullOrMatch(sourceResourceType, field.getParentResourceInformation().getResourceType());
+		boolean matchesSourceClass = nullOrMatch(sourceResourceClass, field.getParentResourceInformation().getResourceClass());
+		boolean matchesSourceField = nullOrMatch(sourceField, field.getUnderlyingName());
+		boolean matchesTargetType = nullOrMatch(targetResourceType, field.getOppositeResourceType());
+		boolean matchesTargetClass = nullOrMatch(targetResourceClass, field.getElementType());
+		boolean matchesTargetField = nullOrMatch(targetField, field.getOppositeName());
+		return matchesSourceType && matchesSourceClass && matchesSourceField && matchesTargetType && matchesTargetClass &&
+				matchesTargetField;
+	}
+
+	private boolean nullOrMatch(String expected, String actual) {
+		return expected == null || Objects.equals(expected, actual);
+	}
+
+	private boolean nullOrMatch(Class expected, Class actual) {
+		return expected == null || expected.isAssignableFrom(actual);
+	}
+
+}

--- a/crnk-core/src/main/java/io/crnk/core/repository/RelationshipRepositoryBase.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/RelationshipRepositoryBase.java
@@ -59,13 +59,14 @@ import java.util.Set;
 public class RelationshipRepositoryBase<T, I extends Serializable, D, J extends Serializable>
 		implements BulkRelationshipRepositoryV2<T, I, D, J>, ResourceRegistryAware {
 
-	protected ResourceRegistry resourceRegistry;
 
-	private Class<D> targetResourceClass;
+	protected ResourceRegistry resourceRegistry;
 
 	private Class<T> sourceResourceClass;
 
 	private String sourceResourceType;
+
+	private Class targetResourceClass;
 
 	private String targetResourceType;
 
@@ -77,13 +78,29 @@ public class RelationshipRepositoryBase<T, I extends Serializable, D, J extends 
 	}
 
 	public RelationshipRepositoryBase(Class<T> sourceResourceClass, Class<D> targetResourceClass) {
-		this.sourceResourceClass = sourceResourceClass;
+		this(sourceResourceClass);
 		this.targetResourceClass = targetResourceClass;
 	}
 
 	public RelationshipRepositoryBase(String sourceResourceType, String targetResourceType) {
-		this.sourceResourceType = sourceResourceType;
+		this(sourceResourceType);
 		this.targetResourceType = targetResourceType;
+	}
+
+	public RelationshipRepositoryBase(Class<T> sourceResourceClass) {
+		this.sourceResourceClass = sourceResourceClass;
+	}
+
+	public RelationshipRepositoryBase(String sourceResourceType) {
+		this.sourceResourceType = sourceResourceType;
+	}
+
+	@Override
+	public RelationshipMatcher getMatcher() {
+		RelationshipMatcher matcher = new RelationshipMatcher();
+		matcher.rule().source(sourceResourceType).source(sourceResourceClass).target(targetResourceType)
+				.target(targetResourceClass).add();
+		return matcher;
 	}
 
 
@@ -345,10 +362,6 @@ public class RelationshipRepositoryBase<T, I extends Serializable, D, J extends 
 
 	@Override
 	public Class<D> getTargetResourceClass() {
-		if (targetResourceClass == null) {
-			RegistryEntry targetEntry = resourceRegistry.getEntry(targetResourceType);
-			return (Class) targetEntry.getResourceInformation().getResourceClass();
-		}
 		return targetResourceClass;
 	}
 

--- a/crnk-core/src/main/java/io/crnk/core/repository/RelationshipRepositoryV2.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/RelationshipRepositoryV2.java
@@ -48,6 +48,13 @@ public interface RelationshipRepositoryV2<T, I extends Serializable, D, J extend
 
 
 	default RelationshipMatcher getMatcher() {
+		if (this instanceof UntypedRelationshipRepository) {
+			UntypedRelationshipRepository untyped = (UntypedRelationshipRepository) this;
+			RelationshipMatcher matcher = new RelationshipMatcher();
+			matcher.rule().source(untyped.getSourceResourceType()).target(untyped.getTargetResourceType()).add();
+			return matcher;
+		}
+
 		Class<T> sourceResourceClass = getSourceResourceClass();
 		Class<D> targetResourceClass = getTargetResourceClass();
 		if (sourceResourceClass != null && targetResourceClass != null) {

--- a/crnk-core/src/main/java/io/crnk/core/repository/RelationshipRepositoryV2.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/RelationshipRepositoryV2.java
@@ -1,9 +1,9 @@
 package io.crnk.core.repository;
 
+import java.io.Serializable;
+
 import io.crnk.core.queryspec.QuerySpec;
 import io.crnk.core.resource.list.ResourceList;
-
-import java.io.Serializable;
 
 /**
  * <p>
@@ -37,21 +37,33 @@ public interface RelationshipRepositoryV2<T, I extends Serializable, D, J extend
 		extends Repository {
 
 	/**
-	 * @return the class that specifies the relation.
+	 * @return the class that specifies the relation. Can be null if getMatcher() is implemented.
 	 */
 	Class<T> getSourceResourceClass();
 
 	/**
-	 * @return the related resource class returned by this repository
+	 * @return the related resource class returned by this repository. Can be null if getMatcher() is implemented.
 	 */
 	Class<D> getTargetResourceClass();
+
+
+	default RelationshipMatcher getMatcher() {
+		Class<T> sourceResourceClass = getSourceResourceClass();
+		Class<D> targetResourceClass = getTargetResourceClass();
+		if (sourceResourceClass != null && targetResourceClass != null) {
+			RelationshipMatcher matcher = new RelationshipMatcher();
+			matcher.rule().source(getSourceResourceClass()).target(targetResourceClass).add();
+			return matcher;
+		}
+		throw new IllegalStateException("implement getMatcher()");
+	}
 
 	/**
 	 * Set a relation defined by a field. targetId legacy can be either in a form of an object or null value,
 	 * which means that if there's a relation, it should be removed. It is used only for To-One relationship.
 	 *
-	 * @param source    instance of a source class
-	 * @param targetId  id of a target repository
+	 * @param source instance of a source class
+	 * @param targetId id of a target repository
 	 * @param fieldName name of target's filed
 	 */
 	void setRelation(T source, J targetId, String fieldName);
@@ -60,7 +72,7 @@ public interface RelationshipRepositoryV2<T, I extends Serializable, D, J extend
 	 * Set a relation defined by a field. TargetIds legacy can be either in a form of an object or null value,
 	 * which means that if there's a relation, it should be removed. It is used only for To-Many relationship.
 	 *
-	 * @param source    instance of a source class
+	 * @param source instance of a source class
 	 * @param targetIds ids of a target repository
 	 * @param fieldName name of target's filed
 	 */
@@ -70,7 +82,7 @@ public interface RelationshipRepositoryV2<T, I extends Serializable, D, J extend
 	 * Add a relation to a field. It is used only for To-Many relationship, that is if this method is called, a new
 	 * relationship should be added to the set of the relationships.
 	 *
-	 * @param source    instance of source class
+	 * @param source instance of source class
 	 * @param targetIds ids of the target resource
 	 * @param fieldName name of target's field
 	 */
@@ -79,7 +91,7 @@ public interface RelationshipRepositoryV2<T, I extends Serializable, D, J extend
 	/**
 	 * Removes a relationship from a set of relationships. It is used only for To-Many relationship.
 	 *
-	 * @param source    instance of source class
+	 * @param source instance of source class
 	 * @param targetIds ids of the target repository
 	 * @param fieldName name of target's field
 	 */
@@ -88,7 +100,7 @@ public interface RelationshipRepositoryV2<T, I extends Serializable, D, J extend
 	/**
 	 * Find a relation's target identifier. It is used only for To-One relationship.
 	 *
-	 * @param sourceId  an identifier of a source
+	 * @param sourceId an identifier of a source
 	 * @param fieldName name of target's filed
 	 * @param querySpec querySpec sent along with the request as parameters
 	 * @return an identifier of a target of a relation
@@ -98,7 +110,7 @@ public interface RelationshipRepositoryV2<T, I extends Serializable, D, J extend
 	/**
 	 * Find a relation's target identifiers. It is used only for To-Many relationship.
 	 *
-	 * @param sourceId  an identifier of a source
+	 * @param sourceId an identifier of a source
 	 * @param fieldName name of target's filed
 	 * @param querySpec querySpec sent along with the request as parameters
 	 * @return identifiers of targets of a relation

--- a/crnk-core/src/main/java/io/crnk/core/repository/UntypedRelationshipRepository.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/UntypedRelationshipRepository.java
@@ -2,7 +2,12 @@ package io.crnk.core.repository;
 
 import java.io.Serializable;
 
-public interface UntypedRelationshipRepository<T, I extends Serializable, D, J extends Serializable> extends RelationshipRepositoryV2<T, I, D, J> {
+/**
+ * @Deprecated make use of RelationshipRepositoryV2.getMatcher()
+ */
+@Deprecated
+public interface UntypedRelationshipRepository<T, I extends Serializable, D, J extends Serializable>
+		extends RelationshipRepositoryV2<T, I, D, J> {
 
 	String getSourceResourceType();
 

--- a/crnk-core/src/main/java/io/crnk/core/repository/decorate/RelationshipRepositoryDecoratorBase.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/decorate/RelationshipRepositoryDecoratorBase.java
@@ -1,12 +1,13 @@
 package io.crnk.core.repository.decorate;
 
+import java.io.Serializable;
+
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.engine.registry.ResourceRegistryAware;
 import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.repository.RelationshipMatcher;
 import io.crnk.core.repository.RelationshipRepositoryV2;
 import io.crnk.core.resource.list.ResourceList;
-
-import java.io.Serializable;
 
 public abstract class RelationshipRepositoryDecoratorBase<T, I extends Serializable, D, J extends Serializable>
 		implements RelationshipRepositoryDecorator<T, I, D, J>, ResourceRegistryAware {
@@ -21,6 +22,11 @@ public abstract class RelationshipRepositoryDecoratorBase<T, I extends Serializa
 	@Override
 	public Class<D> getTargetResourceClass() {
 		return decoratedObject.getTargetResourceClass();
+	}
+
+	@Override
+	public RelationshipMatcher getMatcher() {
+		return decoratedObject.getMatcher();
 	}
 
 	@Override

--- a/crnk-core/src/main/java/io/crnk/core/repository/implicit/ImplicitOwnerBasedRelationshipRepository.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/implicit/ImplicitOwnerBasedRelationshipRepository.java
@@ -135,8 +135,11 @@ public class ImplicitOwnerBasedRelationshipRepository<T, I extends Serializable,
 					addResult(bulkResult, field, sourceId, targetElementId, targetMap);
 				}
 			}
-			else {
+			else if (targetId != null) {
 				addResult(bulkResult, field, sourceId, targetId, targetMap);
+			}
+			else {
+				bulkResult.add(sourceId, null);
 			}
 		}
 		return bulkResult;

--- a/crnk-core/src/main/java/io/crnk/core/repository/implicit/ImplicitOwnerBasedRelationshipRepository.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/implicit/ImplicitOwnerBasedRelationshipRepository.java
@@ -1,5 +1,6 @@
 package io.crnk.core.repository.implicit;
 
+import io.crnk.core.repository.RelationshipMatcher;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
@@ -41,6 +42,15 @@ public class ImplicitOwnerBasedRelationshipRepository<T, I extends Serializable,
 	public ImplicitOwnerBasedRelationshipRepository(String sourceResourceType, String targetResourceType) {
 		super(sourceResourceType, targetResourceType);
 	}
+
+	public ImplicitOwnerBasedRelationshipRepository(Class sourceResourceClass) {
+		super(sourceResourceClass);
+	}
+
+	public ImplicitOwnerBasedRelationshipRepository(String sourceResourceType) {
+		super(sourceResourceType);
+	}
+
 
 	@SuppressWarnings("unchecked")
 	public MultivaluedMap<I, D> findTargets(Iterable<I> sourceIds, String fieldName, QuerySpec querySpec) {

--- a/crnk-core/src/main/java/io/crnk/core/repository/implicit/ImplicitOwnerBasedRelationshipRepository.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/implicit/ImplicitOwnerBasedRelationshipRepository.java
@@ -1,27 +1,24 @@
 package io.crnk.core.repository.implicit;
 
-import io.crnk.core.engine.information.resource.ResourceField;
-import io.crnk.core.engine.information.resource.ResourceInformation;
-import io.crnk.core.engine.internal.repository.ResourceRepositoryAdapter;
-import io.crnk.core.engine.internal.utils.MultivaluedMap;
-import io.crnk.core.engine.registry.RegistryEntry;
-import io.crnk.core.exception.ResourceNotFoundException;
-import io.crnk.core.queryspec.FilterOperator;
-import io.crnk.core.queryspec.FilterSpec;
-import io.crnk.core.queryspec.QuerySpec;
-import io.crnk.core.queryspec.internal.QuerySpecAdapter;
-import io.crnk.core.repository.RelationshipRepositoryBase;
-import io.crnk.core.repository.response.JsonApiResponse;
-import io.crnk.core.resource.list.DefaultResourceList;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.internal.repository.ResourceRepositoryAdapter;
+import io.crnk.core.engine.internal.utils.MultivaluedMap;
+import io.crnk.core.engine.registry.RegistryEntry;
+import io.crnk.core.exception.ResourceNotFoundException;
+import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.queryspec.internal.QuerySpecAdapter;
+import io.crnk.core.repository.RelationshipRepositoryBase;
+import io.crnk.core.repository.response.JsonApiResponse;
+import io.crnk.core.resource.list.DefaultResourceList;
 
 /**
  * Implements RelationshipRepository for relationships making use of @JsonApiRelationId

--- a/crnk-core/src/main/java/io/crnk/legacy/internal/DirectResponseRelationshipEntry.java
+++ b/crnk-core/src/main/java/io/crnk/legacy/internal/DirectResponseRelationshipEntry.java
@@ -13,7 +13,7 @@ public class DirectResponseRelationshipEntry implements ResponseRelationshipEntr
 
 	private static final int TARGET_TYPE_GENERIC_PARAMETER_IDX = 2;
 
-	private RepositoryInstanceBuilder<RelationshipRepository> repositoryInstanceBuilder;
+	private RepositoryInstanceBuilder repositoryInstanceBuilder;
 
 	public DirectResponseRelationshipEntry(RepositoryInstanceBuilder repositoryInstanceBuilder) {
 		this.repositoryInstanceBuilder = repositoryInstanceBuilder;
@@ -39,8 +39,6 @@ public class DirectResponseRelationshipEntry implements ResponseRelationshipEntr
 
 	@Override
 	public String toString() {
-		return "DirectResponseRelationshipEntry{" +
-				"repositoryInstanceBuilder=" + repositoryInstanceBuilder +
-				'}';
+		return repositoryInstanceBuilder.buildRepository().toString();
 	}
 }

--- a/crnk-core/src/main/java/io/crnk/legacy/internal/DirectResponseResourceEntry.java
+++ b/crnk-core/src/main/java/io/crnk/legacy/internal/DirectResponseResourceEntry.java
@@ -1,14 +1,20 @@
 package io.crnk.legacy.internal;
 
+import io.crnk.core.engine.information.repository.ResourceRepositoryInformation;
 import io.crnk.core.engine.registry.ResourceEntry;
 import io.crnk.legacy.registry.RepositoryInstanceBuilder;
 import io.crnk.legacy.repository.ResourceRepository;
 
 public class DirectResponseResourceEntry implements ResourceEntry {
+
 	private final RepositoryInstanceBuilder<ResourceRepository> repositoryInstanceBuilder;
 
-	public DirectResponseResourceEntry(RepositoryInstanceBuilder<ResourceRepository> repositoryInstanceBuilder) {
+	private ResourceRepositoryInformation information;
+
+	public DirectResponseResourceEntry(RepositoryInstanceBuilder<ResourceRepository> repositoryInstanceBuilder,
+			ResourceRepositoryInformation information) {
 		this.repositoryInstanceBuilder = repositoryInstanceBuilder;
+		this.information = information;
 	}
 
 	public Object getResourceRepository() {
@@ -17,8 +23,11 @@ public class DirectResponseResourceEntry implements ResourceEntry {
 
 	@Override
 	public String toString() {
-		return "DirectResponseResourceEntry{" +
-				"repositoryInstanceBuilder=" + repositoryInstanceBuilder +
-				'}';
+		return repositoryInstanceBuilder.buildRepository().toString();
+	}
+
+	@Override
+	public ResourceRepositoryInformation getRepositoryInformation() {
+		return information;
 	}
 }

--- a/crnk-core/src/main/java/io/crnk/legacy/registry/AnnotatedResourceEntry.java
+++ b/crnk-core/src/main/java/io/crnk/legacy/registry/AnnotatedResourceEntry.java
@@ -1,15 +1,20 @@
 package io.crnk.legacy.registry;
 
+import io.crnk.core.engine.information.repository.ResourceRepositoryInformation;
 import io.crnk.core.engine.registry.ResourceEntry;
 import io.crnk.legacy.internal.AnnotatedResourceRepositoryAdapter;
 import io.crnk.legacy.internal.ParametersFactory;
 import io.crnk.legacy.internal.RepositoryMethodParameterProvider;
 
 public class AnnotatedResourceEntry implements ResourceEntry {
+
 	private final RepositoryInstanceBuilder repositoryInstanceBuilder;
 
-	public AnnotatedResourceEntry(RepositoryInstanceBuilder RepositoryInstanceBuilder) {
-		this.repositoryInstanceBuilder = RepositoryInstanceBuilder;
+	private ResourceRepositoryInformation information;
+
+	public AnnotatedResourceEntry(RepositoryInstanceBuilder instanceBuilder, ResourceRepositoryInformation information) {
+		this.repositoryInstanceBuilder = instanceBuilder;
+		this.information = information;
 	}
 
 	public AnnotatedResourceRepositoryAdapter build(RepositoryMethodParameterProvider parameterProvider) {
@@ -22,5 +27,10 @@ public class AnnotatedResourceEntry implements ResourceEntry {
 		return "AnnotatedResourceEntryBuilder{" +
 				"repositoryInstanceBuilder=" + repositoryInstanceBuilder +
 				'}';
+	}
+
+	@Override
+	public ResourceRepositoryInformation getRepositoryInformation() {
+		return information;
 	}
 }

--- a/crnk-core/src/main/java/io/crnk/legacy/repository/information/DefaultRelationshipRepositoryInformationProvider.java
+++ b/crnk-core/src/main/java/io/crnk/legacy/repository/information/DefaultRelationshipRepositoryInformationProvider.java
@@ -7,6 +7,7 @@ import io.crnk.core.engine.information.repository.RepositoryMethodAccess;
 import io.crnk.core.engine.internal.information.repository.RelationshipRepositoryInformationImpl;
 import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
+import io.crnk.core.repository.RelationshipMatcher;
 import io.crnk.core.repository.RelationshipRepositoryV2;
 import io.crnk.core.repository.UntypedRelationshipRepository;
 import io.crnk.core.utils.Optional;
@@ -25,7 +26,8 @@ public class DefaultRelationshipRepositoryInformationProvider implements Reposit
 	@Override
 	public boolean accept(Class<?> repositoryClass) {
 		return !UntypedRelationshipRepository.class.isAssignableFrom(repositoryClass) && (
-				RelationshipRepository.class.isAssignableFrom(repositoryClass) || RelationshipRepositoryV2.class.isAssignableFrom(repositoryClass)
+				RelationshipRepository.class.isAssignableFrom(repositoryClass) || RelationshipRepositoryV2.class
+						.isAssignableFrom(repositoryClass)
 						|| ClassUtils.getAnnotation(repositoryClass, JsonApiRelationshipRepository.class).isPresent());
 	}
 
@@ -39,18 +41,27 @@ public class DefaultRelationshipRepositoryInformationProvider implements Reposit
 		return buildInformation(null, repositoryClass, context);
 	}
 
-	private RepositoryInformation buildInformation(Object repository, Class<? extends Object> repositoryClass, RepositoryInformationProviderContext context) {
-		Class<?> sourceResourceClass = getSourceResourceClass(repository, repositoryClass);
-		Class<?> targetResourceClass = getTargetResourceClass(repository, repositoryClass);
+	private RepositoryInformation buildInformation(Object repository, Class<? extends Object> repositoryClass,
+			RepositoryInformationProviderContext context) {
+		RelationshipMatcher matcher;
+		if (repository instanceof RelationshipRepositoryV2) {
+			matcher = ((RelationshipRepositoryV2) repository).getMatcher();
+		}
+		else {
+			Class<?> sourceResourceClass = getSourceResourceClass(repository, repositoryClass);
+			Class<?> targetResourceClass = getTargetResourceClass(repository, repositoryClass);
 
-		PreconditionUtil.assertNotNull("no sourceResourceClass", sourceResourceClass);
-		PreconditionUtil.assertNotNull("no targetResourceClass", targetResourceClass);
+			PreconditionUtil.assertNotNull("no sourceResourceClass", sourceResourceClass);
+			PreconditionUtil.assertNotNull("no targetResourceClass", targetResourceClass);
 
-		String sourceResourceType = context.getResourceInformationBuilder().getResourceType(sourceResourceClass);
-		String targetResourceType = context.getResourceInformationBuilder().getResourceType(targetResourceClass);
+			String sourceResourceType = context.getResourceInformationBuilder().getResourceType(sourceResourceClass);
+			String targetResourceType = context.getResourceInformationBuilder().getResourceType(targetResourceClass);
+			matcher = new RelationshipMatcher();
+			matcher.rule().source(sourceResourceType).target(targetResourceType).add();
+		}
 
 		RepositoryMethodAccess access = getAccess(repository);
-		return new RelationshipRepositoryInformationImpl(sourceResourceClass, sourceResourceType, targetResourceType, access);
+		return new RelationshipRepositoryInformationImpl(matcher, access);
 	}
 
 	// FIXME
@@ -59,34 +70,42 @@ public class DefaultRelationshipRepositoryInformationProvider implements Reposit
 	}
 
 	public Class<?> getSourceResourceClass(Object repository, Class<?> repositoryClass) {
-		Optional<JsonApiRelationshipRepository> annotation = ClassUtils.getAnnotation(repositoryClass, JsonApiRelationshipRepository.class);
+		Optional<JsonApiRelationshipRepository> annotation =
+				ClassUtils.getAnnotation(repositoryClass, JsonApiRelationshipRepository.class);
 
 		if (annotation.isPresent()) {
 			return annotation.get().source();
-		} else if (RelationshipRepository.class.isAssignableFrom(repositoryClass)) {
+		}
+		else if (RelationshipRepository.class.isAssignableFrom(repositoryClass)) {
 			Class<?>[] typeArgs = TypeResolver.resolveRawArguments(RelationshipRepository.class, repositoryClass);
 			return typeArgs[0];
-		} else if (repository != null) {
+		}
+		else if (repository != null) {
 			RelationshipRepositoryV2<?, ?, ?, ?> querySpecRepo = (RelationshipRepositoryV2<?, ?, ?, ?>) repository;
 			return querySpecRepo.getSourceResourceClass();
-		} else {
+		}
+		else {
 			Class<?>[] typeArgs = TypeResolver.resolveRawArguments(RelationshipRepositoryV2.class, repositoryClass);
 			return typeArgs[0];
 		}
 	}
 
 	protected Class<?> getTargetResourceClass(Object repository, Class<?> repositoryClass) {
-		Optional<JsonApiRelationshipRepository> annotation = ClassUtils.getAnnotation(repositoryClass, JsonApiRelationshipRepository.class);
+		Optional<JsonApiRelationshipRepository> annotation =
+				ClassUtils.getAnnotation(repositoryClass, JsonApiRelationshipRepository.class);
 
 		if (annotation.isPresent()) {
 			return annotation.get().target();
-		} else if (RelationshipRepository.class.isAssignableFrom(repositoryClass)) {
+		}
+		else if (RelationshipRepository.class.isAssignableFrom(repositoryClass)) {
 			Class<?>[] typeArgs = TypeResolver.resolveRawArguments(RelationshipRepository.class, repositoryClass);
 			return typeArgs[2];
-		} else if (repository != null) {
+		}
+		else if (repository != null) {
 			RelationshipRepositoryV2<?, ?, ?, ?> querySpecRepo = (RelationshipRepositoryV2<?, ?, ?, ?>) repository;
 			return querySpecRepo.getTargetResourceClass();
-		} else {
+		}
+		else {
 			Class<?>[] typeArgs = TypeResolver.resolveRawArguments(RelationshipRepositoryV2.class, repositoryClass);
 			return typeArgs[2];
 		}

--- a/crnk-core/src/test/java/io/crnk/core/engine/filter/RepositoryFilterTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/filter/RepositoryFilterTest.java
@@ -25,6 +25,7 @@ import io.crnk.core.queryspec.QuerySpec;
 import io.crnk.core.queryspec.internal.QuerySpecAdapter;
 import io.crnk.core.resource.registry.ResourceRegistryTest;
 import io.crnk.legacy.internal.AnnotatedRelationshipRepositoryAdapter;
+import java.util.List;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -65,6 +66,7 @@ public class RepositoryFilterTest {
 	private ResourceInformation userInfo;
 
 	private ResourceInformation scheduleInfo;
+
 	private CrnkBoot boot;
 
 	@Before
@@ -93,8 +95,8 @@ public class RepositoryFilterTest {
 		scheduleInfo = resourceRegistry.getEntry(Schedule.class).getResourceInformation();
 		RegistryEntry userEntry = resourceRegistry.getEntry(User.class);
 		resourceAdapter = userEntry.getResourceRepository(null);
-		projectRelationAdapter = userEntry.getRelationshipRepositoryForType("projects", null);
-		taskRelationAdapter = userEntry.getRelationshipRepositoryForType("tasks", null);
+		projectRelationAdapter = userEntry.getRelationshipRepository("assignedProjects", null);
+		taskRelationAdapter = userEntry.getRelationshipRepository("assignedTasks", null);
 		userInfo = userEntry.getResourceInformation();
 
 		UserRepository resourceRepository = (UserRepository) resourceAdapter.getResourceRepository();
@@ -105,19 +107,23 @@ public class RepositoryFilterTest {
 		user2.setId(2L);
 		resourceRepository.save(user2);
 
-		UserToProjectRepository userProjectRepository = (UserToProjectRepository) ((AnnotatedRelationshipRepositoryAdapter<?, ?, ?, ?>) projectRelationAdapter.getRelationshipRepository()).getImplementationObject();
+		UserToProjectRepository userProjectRepository =
+				(UserToProjectRepository) ((AnnotatedRelationshipRepositoryAdapter<?, ?, ?, ?>) projectRelationAdapter
+						.getRelationshipRepository()).getImplementationObject();
 		userProjectRepository.setRelation(user1, 11L, "assignedProjects");
 
-		UserToTaskRepository userTaskRepository = (UserToTaskRepository) taskRelationAdapter.getRelationshipRepository();
+		UserToTaskRepository userTaskRepository = new UserToTaskRepository();
 		userTaskRepository.addRelations(user1, Arrays.asList(21L), "assignedTasks");
 		userTaskRepository.addRelations(user2, Arrays.asList(22L), "assignedTasks");
 
-		assignedTasksField = resourceRegistry.getEntry(User.class).getResourceInformation().findRelationshipFieldByName("assignedTasks");
-		assignedProjectsField = resourceRegistry.getEntry(User.class).getResourceInformation().findRelationshipFieldByName("assignedProjects");
+		assignedTasksField =
+				resourceRegistry.getEntry(User.class).getResourceInformation().findRelationshipFieldByName("assignedTasks");
+		assignedProjectsField =
+				resourceRegistry.getEntry(User.class).getResourceInformation().findRelationshipFieldByName("assignedProjects");
 
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void findAllWithResourceListResult() throws Exception {
 
@@ -132,10 +138,15 @@ public class RepositoryFilterTest {
 		ArgumentCaptor<Iterable> metaResources = ArgumentCaptor.forClass(Iterable.class);
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(1)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), linksResources.capture(), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), metaResources.capture(), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), linksResources
+						.capture(),
+				Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), metaResources.capture(),
+				Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, linksResources.getAllValues().size());
 		Assert.assertEquals(1, metaResources.getAllValues().size());
@@ -149,7 +160,7 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, actualQuerySpec);
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void findAllWithResourceList() throws Exception {
 		resourceAdapter.findAll(queryAdapter);
@@ -158,10 +169,15 @@ public class RepositoryFilterTest {
 		ArgumentCaptor<Iterable> metaResources = ArgumentCaptor.forClass(Iterable.class);
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(1)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), linksResources.capture(), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), metaResources.capture(), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), linksResources
+						.capture(),
+				Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), metaResources.capture(),
+				Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, linksResources.getAllValues().size());
 		Assert.assertEquals(1, metaResources.getAllValues().size());
@@ -174,7 +190,7 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void findOne() throws Exception {
 
@@ -184,10 +200,15 @@ public class RepositoryFilterTest {
 		ArgumentCaptor<Iterable> metaResources = ArgumentCaptor.forClass(Iterable.class);
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(1)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), linksResources.capture(), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), metaResources.capture(), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), linksResources
+						.capture(),
+				Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), metaResources.capture(),
+				Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, linksResources.getAllValues().size());
 		Assert.assertEquals(1, metaResources.getAllValues().size());
@@ -200,7 +221,7 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void findAllById() throws Exception {
 		resourceAdapter.findAll(Arrays.asList(2L), queryAdapter);
@@ -209,10 +230,15 @@ public class RepositoryFilterTest {
 		ArgumentCaptor<Iterable> metaResources = ArgumentCaptor.forClass(Iterable.class);
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(1)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), linksResources.capture(), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), metaResources.capture(), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), linksResources
+						.capture(),
+				Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), metaResources.capture(),
+				Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, linksResources.getAllValues().size());
 		Assert.assertEquals(1, metaResources.getAllValues().size());
@@ -226,7 +252,7 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void create() throws Exception {
 		User user = new User();
@@ -237,10 +263,15 @@ public class RepositoryFilterTest {
 		ArgumentCaptor<Iterable> metaResources = ArgumentCaptor.forClass(Iterable.class);
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(1)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), linksResources.capture(), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), metaResources.capture(), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), linksResources
+						.capture(),
+				Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), metaResources.capture(),
+				Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, linksResources.getAllValues().size());
 		Assert.assertEquals(1, metaResources.getAllValues().size());
@@ -254,7 +285,7 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void save() throws Exception {
 		User user = new User();
@@ -265,10 +296,15 @@ public class RepositoryFilterTest {
 		ArgumentCaptor<Iterable> metaResources = ArgumentCaptor.forClass(Iterable.class);
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(1)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), linksResources.capture(), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), metaResources.capture(), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), linksResources
+						.capture(),
+				Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), metaResources.capture(),
+				Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, linksResources.getAllValues().size());
 		Assert.assertEquals(1, metaResources.getAllValues().size());
@@ -282,17 +318,23 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void delete() throws Exception {
 		resourceAdapter.delete(2L, queryAdapter);
 
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(1)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, contexts.getAllValues().size());
 		RepositoryFilterContext context = contexts.getAllValues().iterator().next();
@@ -304,17 +346,23 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void findOneTarget() throws Exception {
 		projectRelationAdapter.findOneTarget(1L, assignedProjectsField, queryAdapter);
 
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(1)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, contexts.getAllValues().size());
 		RepositoryFilterContext context = contexts.getAllValues().iterator().next();
@@ -326,17 +374,23 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void findManyTarget() throws Exception {
 		projectRelationAdapter.findManyTargets(1L, assignedProjectsField, queryAdapter);
 
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(1)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, contexts.getAllValues().size());
 		RepositoryFilterContext context = contexts.getAllValues().iterator().next();
@@ -349,17 +403,23 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void setRelation() throws Exception {
 		projectRelationAdapter.setRelation(user1, 13L, assignedProjectsField, queryAdapter);
 
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(1)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, contexts.getAllValues().size());
 		RepositoryFilterContext context = contexts.getAllValues().iterator().next();
@@ -373,17 +433,23 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void setRelations() throws Exception {
 		projectRelationAdapter.setRelations(user1, Arrays.asList(13L, 14L), assignedProjectsField, queryAdapter);
 
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(1)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, contexts.getAllValues().size());
 		RepositoryFilterContext context = contexts.getAllValues().iterator().next();
@@ -396,17 +462,23 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void addRelations() throws Exception {
 		projectRelationAdapter.addRelations(user1, Arrays.asList(13L, 14L), assignedProjectsField, queryAdapter);
 
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(1)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, contexts.getAllValues().size());
 		RepositoryFilterContext context = contexts.getAllValues().iterator().next();
@@ -418,17 +490,23 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void removeRelations() throws Exception {
 		projectRelationAdapter.removeRelations(user1, Arrays.asList(13L, 14L), assignedProjectsField, queryAdapter);
 
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(1)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, contexts.getAllValues().size());
 		RepositoryFilterContext context = contexts.getAllValues().iterator().next();
@@ -441,18 +519,25 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void findBulkOneTargetsNoBulkImpl() throws Exception {
 		projectRelationAdapter.findBulkOneTargets(Arrays.asList(13L, 14L), assignedProjectsField, queryAdapter);
 
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(2)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterBulkRequest(contexts.capture(), Mockito.any(RepositoryBulkRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(2)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(2)).filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(2)).filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(2))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterBulkRequest(contexts.capture(), Mockito.any(RepositoryBulkRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(2))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(2))
+				.filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(2))
+				.filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(2, contexts.getAllValues().size());
 		RepositoryFilterContext context1 = contexts.getAllValues().get(0);
@@ -468,18 +553,25 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec1.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void findBulkManyTargetsNoBulkImpl() throws Exception {
 		projectRelationAdapter.findBulkManyTargets(Arrays.asList(13L, 14L), assignedProjectsField, queryAdapter);
 
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(2)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(0)).filterBulkRequest(contexts.capture(), Mockito.any(RepositoryBulkRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(2)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(2)).filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(2)).filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(2))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterBulkRequest(contexts.capture(), Mockito.any(RepositoryBulkRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(2))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(2))
+				.filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(2))
+				.filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(2, contexts.getAllValues().size());
 		RepositoryFilterContext context1 = contexts.getAllValues().get(0);
@@ -495,18 +587,25 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec1.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void findBulkOneTargetsBulkImpl() throws Exception {
 		taskRelationAdapter.findBulkManyTargets(Arrays.asList(1L), assignedTasksField, queryAdapter);
 
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(0)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterBulkRequest(contexts.capture(), Mockito.any(RepositoryBulkRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterBulkRequest(contexts.capture(), Mockito.any(RepositoryBulkRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, contexts.getAllValues().size());
 		RepositoryFilterContext context1 = contexts.getAllValues().get(0);
@@ -519,18 +618,26 @@ public class RepositoryFilterTest {
 		Assert.assertSame(querySpec, requestSpec1.getQuerySpec(userInfo));
 	}
 
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void findBulkManyTargetsBulkImpl() throws Exception {
-		taskRelationAdapter.findBulkManyTargets(Arrays.asList(1L, 2L), assignedTasksField, queryAdapter);
+		List<Long> ids = Arrays.asList(1L, 2L);
+		taskRelationAdapter.findBulkManyTargets(ids, assignedTasksField, queryAdapter);
 
 		ArgumentCaptor<RepositoryFilterContext> contexts = ArgumentCaptor.forClass(RepositoryFilterContext.class);
 
-		Mockito.verify(filter, Mockito.times(0)).filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(1)).filterBulkRequest(contexts.capture(), Mockito.any(RepositoryBulkRequestFilterChain.class));
-		Mockito.verify(filter, Mockito.times(2)).filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
-		Mockito.verify(filter, Mockito.times(2)).filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryLinksFilterChain.class));
-		Mockito.verify(filter, Mockito.times(2)).filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class), Mockito.any(RepositoryMetaFilterChain.class));
+		Mockito.verify(filter, Mockito.times(0))
+				.filterRequest(contexts.capture(), Mockito.any(RepositoryRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(1))
+				.filterBulkRequest(contexts.capture(), Mockito.any(RepositoryBulkRequestFilterChain.class));
+		Mockito.verify(filter, Mockito.times(2))
+				.filterResult(Mockito.any(RepositoryFilterContext.class), Mockito.any(RepositoryResultFilterChain.class));
+		Mockito.verify(filter, Mockito.times(2))
+				.filterLinks(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryLinksFilterChain.class));
+		Mockito.verify(filter, Mockito.times(2))
+				.filterMeta(Mockito.any(RepositoryFilterContext.class), Mockito.any(Iterable.class),
+						Mockito.any(RepositoryMetaFilterChain.class));
 
 		Assert.assertEquals(1, contexts.getAllValues().size());
 		RepositoryFilterContext context1 = contexts.getAllValues().get(0);

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/resource/FieldResourceGetTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/resource/FieldResourceGetTest.java
@@ -108,8 +108,8 @@ public class FieldResourceGetTest extends BaseControllerTest {
 		ResourceRepositoryAdapter projectRepo = resourceRegistry.getEntry(Project.class).getResourceRepository(null);
 		ResourceRepositoryAdapter taskRepo = resourceRegistry.getEntry(Task.class).getResourceRepository(null);
 
-		RelationshipRepositoryAdapter relRepositoryUserToProject = resourceRegistry.getEntry(User.class).getRelationshipRepositoryForType("projects", null);
-		RelationshipRepositoryAdapter relRepositoryProjectToTask = resourceRegistry.getEntry(Project.class).getRelationshipRepositoryForType("tasks", null);
+		RelationshipRepositoryAdapter relRepositoryUserToProject = resourceRegistry.getEntry(User.class).getRelationshipRepository("assignedProjects", null);
+		RelationshipRepositoryAdapter relRepositoryProjectToTask = resourceRegistry.getEntry(Project.class).getRelationshipRepository("tasks", null);
 
 		ResourceInformation userInfo = resourceRegistry.getEntry(User.class).getResourceInformation();
 		ResourceInformation projectInfo = resourceRegistry.getEntry(Project.class).getResourceInformation();

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/resource/RelationshipsResourcePostTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/resource/RelationshipsResourcePostTest.java
@@ -163,7 +163,7 @@ public class RelationshipsResourcePostTest extends BaseControllerTest {
 
 		ResourceIdentifier projectResourceId = new ResourceIdentifier(projectId.toString(), "projects");
 		// TODO properly implement ResourceIdentifier vs Resource in relationship repositories
-		// Mockito.verify(modificationFilter, Mockito.times(1)).modifyOneRelationship(Mockito.any(), Mockito.any(ResourceField.class), Mockito.eq(projectResourceId));
+		// Mockito.validate(modificationFilter, Mockito.times(1)).modifyOneRelationship(Mockito.any(), Mockito.any(ResourceField.class), Mockito.eq(projectResourceId));
 	}
 
 	@Test

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/resource/ResourceIdControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/resource/ResourceIdControllerTest.java
@@ -119,7 +119,7 @@ public class ResourceIdControllerTest extends BaseControllerTest {
 		Assert.assertTrue(relationship.getData().isPresent());
 		Assert.assertEquals(schedule3Id, relationship.getData().get());
 
-		// verify relationship not accessed, only id set => performance
+		// validate relationship not accessed, only id set => performance
 		RelationIdTestResource entity = repository.findOne(1L, new QuerySpec(RelationIdTestResource.class));
 		Assert.assertEquals(schedule3.getId(), entity.getTestLookupAlwaysId());
 		Assert.assertNull(entity.getTestLookupAlways());
@@ -152,7 +152,7 @@ public class ResourceIdControllerTest extends BaseControllerTest {
 		Assert.assertTrue(relationship.getData().isPresent());
 		Assert.assertEquals(schedule2Id, relationship.getData().get());
 
-		// verify relationship not accessed, only id set => performance
+		// validate relationship not accessed, only id set => performance
 		RelationIdTestResource entity = repository.findOne(1L, new QuerySpec(RelationIdTestResource.class));
 		Assert.assertEquals(schedule2.getId(), entity.getTestLookupAlwaysId());
 		Assert.assertNull(entity.getTestLookupAlways());
@@ -173,7 +173,7 @@ public class ResourceIdControllerTest extends BaseControllerTest {
 		// THEN PATCH
 		assertThat(taskResponse.getHttpStatus()).isEqualTo(HttpStatus.NO_CONTENT_204);
 
-		// verify relationship not accessed, only id set => performance
+		// validate relationship not accessed, only id set => performance
 		RelationIdTestResource entity = repository.findOne(1L, new QuerySpec(RelationIdTestResource.class));
 		Assert.assertEquals(scheduleId != null ? Long.parseLong(scheduleId.getId()) : null, entity.getTestLookupAlwaysId());
 		Assert.assertNull(entity.getTestLookupAlways());

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/document/mapper/lookup/IncludeLookupSetterBaseTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/document/mapper/lookup/IncludeLookupSetterBaseTest.java
@@ -48,15 +48,17 @@ public class IncludeLookupSetterBaseTest extends AbstractDocumentMapperTest {
 	private PropertiesProvider propertiesProvider = Mockito.mock(PropertiesProvider.class);
 
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Before
 	public void setup() {
 		super.setup();
 
 		// get repositories
 		ResourceRepositoryAdapter taskRepository = resourceRegistry.findEntry(Task.class).getResourceRepository(null);
-		RelationshipRepositoryAdapter relRepositoryTaskToProject = resourceRegistry.findEntry(Task.class).getRelationshipRepositoryForType("projects", null);
-		RelationshipRepositoryAdapter relRepositoryProjectToTask = resourceRegistry.findEntry(Project.class).getRelationshipRepositoryForType("tasks", null);
+		RelationshipRepositoryAdapter relRepositoryTaskToProject =
+				resourceRegistry.findEntry(Task.class).getRelationshipRepository("projects", null);
+		RelationshipRepositoryAdapter relRepositoryProjectToTask =
+				resourceRegistry.findEntry(Project.class).getRelationshipRepository("tasks", null);
 		ResourceRepositoryAdapter projectRepository = resourceRegistry.findEntry(Project.class).getResourceRepository(null);
 		ResourceRepositoryAdapter hierarchicalTaskRepository =
 				resourceRegistry.findEntry(HierarchicalTask.class).getResourceRepository(null);
@@ -81,7 +83,8 @@ public class IncludeLookupSetterBaseTest extends AbstractDocumentMapperTest {
 		taskRepository.create(task, taskQuery);
 		relRepositoryTaskToProject.setRelation(task, project.getId(), includedProjectField, projectQuey);
 		relRepositoryTaskToProject.setRelation(task, project.getId(), projectField, projectQuey);
-		relRepositoryTaskToProject.addRelations(task, Collections.singletonList(project.getId()), includedProjectsField, projectQuey);
+		relRepositoryTaskToProject
+				.addRelations(task, Collections.singletonList(project.getId()), includedProjectsField, projectQuey);
 
 		// setup deep nested relationship
 		Task includedTask = new Task();

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/document/mapper/lookup/IncludeLookupSetterInheritanceTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/document/mapper/lookup/IncludeLookupSetterInheritanceTest.java
@@ -40,7 +40,7 @@ public class IncludeLookupSetterInheritanceTest extends AbstractDocumentMapperTe
 		// get repositories
 		ResourceRepositoryAdapter taskRepository = resourceRegistry.getEntry(Task.class).getResourceRepository(null);
 		RelationshipRepositoryAdapter relRepositoryTaskToProject =
-				resourceRegistry.getEntry(Task.class).getRelationshipRepositoryForType("projects", null);
+				resourceRegistry.getEntry(Task.class).getRelationshipRepository("projects", null);
 		ResourceRepositoryAdapter projectRepository = resourceRegistry.getEntry(Project.class).getResourceRepository(null);
 
 		// setup test data

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/repository/ImplicitOwnerBasedRelationshipRepositoryTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/repository/ImplicitOwnerBasedRelationshipRepositoryTest.java
@@ -64,7 +64,7 @@ public class ImplicitOwnerBasedRelationshipRepositoryTest {
 
 		RegistryEntry entry = resourceRegistry.getEntry(RelationIdTestResource.class);
 		relRepository =
-				(ImplicitOwnerBasedRelationshipRepository) entry.getRelationshipRepositoryForType("schedules", null)
+				(ImplicitOwnerBasedRelationshipRepository) entry.getRelationshipRepository("testSerializeEager", null)
 						.getRelationshipRepository();
 
 		taskProjectRepository = new ImplicitOwnerBasedRelationshipRepository(Task.class, Project.class);

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/repository/RelationshipRepositoryBehaviorTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/repository/RelationshipRepositoryBehaviorTest.java
@@ -31,7 +31,7 @@ public class RelationshipRepositoryBehaviorTest {
 	@Test
 	public void checkRelationIdTriggersImplicitOwnerRepo() {
 		RegistryEntry entry = resourceRegistry.getEntry(RelationshipBehaviorTestResource.class);
-		Object relRepository = entry.getRelationshipRepositoryForType("schedules", null)
+		Object relRepository = entry.getRelationshipRepository("testRelationId", null)
 				.getRelationshipRepository();
 		Assert.assertEquals(ImplicitOwnerBasedRelationshipRepository.class, relRepository.getClass());
 	}
@@ -39,7 +39,7 @@ public class RelationshipRepositoryBehaviorTest {
 	@Test
 	public void checkNoLookupTriggersImplicitOwnerRepo() {
 		RegistryEntry entry = resourceRegistry.getEntry(RelationshipBehaviorTestResource.class);
-		Object relRepository = entry.getRelationshipRepositoryForType("lazy_tasks", null)
+		Object relRepository = entry.getRelationshipRepository("testNoLookup", null)
 				.getRelationshipRepository();
 		Assert.assertEquals(ImplicitOwnerBasedRelationshipRepository.class, relRepository.getClass());
 	}
@@ -47,14 +47,14 @@ public class RelationshipRepositoryBehaviorTest {
 	@Test(expected = RelationshipRepositoryNotFoundException.class)
 	public void checkAlwaysLookupTriggersNoImplicitRepo() {
 		RegistryEntry entry = resourceRegistry.getEntry(RelationshipBehaviorTestResource.class);
-		Object relRepository = entry.getRelationshipRepositoryForType("projects-polymorphic", null);
+		Object relRepository = entry.getRelationshipRepository("testAlwaysLookup", null);
 		Assert.assertNull(relRepository);
 	}
 
 	@Test
 	public void checkImplicitOwnerRepo() {
 		RegistryEntry entry = resourceRegistry.getEntry(RelationshipBehaviorTestResource.class);
-		Object relRepository = entry.getRelationshipRepositoryForType("projects", null)
+		Object relRepository = entry.getRelationshipRepository("testImplicityFromOwner", null)
 				.getRelationshipRepository();
 		Assert.assertEquals(ImplicitOwnerBasedRelationshipRepository.class, relRepository.getClass());
 	}
@@ -62,7 +62,7 @@ public class RelationshipRepositoryBehaviorTest {
 	@Test
 	public void checkImplicitGetOppositeModifyOwner() {
 		RegistryEntry entry = resourceRegistry.getEntry(RelationshipBehaviorTestResource.class);
-		Object relRepository = entry.getRelationshipRepositoryForType("tasks", null)
+		Object relRepository = entry.getRelationshipRepository("testImplicitGetOppositeModifyOwner", null)
 				.getRelationshipRepository();
 		Assert.assertEquals(RelationshipRepositoryBase.class, relRepository.getClass());
 	}

--- a/crnk-core/src/test/java/io/crnk/core/mock/models/User.java
+++ b/crnk-core/src/test/java/io/crnk/core/mock/models/User.java
@@ -21,7 +21,7 @@ public class User {
 
 	@JsonApiToMany(lazy = false)
 	@JsonApiIncludeByDefault
-	private List<Project> assignedTasks = Collections.emptyList();
+	private List<Task> assignedTasks = Collections.emptyList();
 
 	@JsonApiMetaInformation
 	private MetaInformation metaInformation;
@@ -69,11 +69,11 @@ public class User {
 		this.linksInformation = linksInformation;
 	}
 
-	public List<Project> getAssignedTasks() {
+	public List<Task> getAssignedTasks() {
 		return assignedTasks;
 	}
 
-	public void setAssignedTasks(List<Project> assignedTasks) {
+	public void setAssignedTasks(List<Task> assignedTasks) {
 		this.assignedTasks = assignedTasks;
 	}
 }

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/QuerySpecAdapterTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/QuerySpecAdapterTest.java
@@ -10,6 +10,7 @@ import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.mock.models.Task;
 import io.crnk.core.module.ModuleRegistry;
 import io.crnk.core.queryspec.internal.QuerySpecAdapter;
+import io.crnk.legacy.internal.DirectResponseResourceEntry;
 import io.crnk.legacy.queryParams.params.IncludedFieldsParams;
 import io.crnk.legacy.queryParams.params.IncludedRelationsParams;
 import io.crnk.legacy.queryParams.params.TypedParams;
@@ -24,9 +25,11 @@ public class QuerySpecAdapterTest {
 	public void test() {
 		ModuleRegistry moduleRegistry = new ModuleRegistry();
 		ResourceRegistry resourceRegistry = new ResourceRegistryImpl(new DefaultResourceRegistryPart(), moduleRegistry);
-		ResourceInformation resourceInformation = new ResourceInformation(moduleRegistry.getTypeParser(), Task.class, "tasks", null, null);
+		ResourceInformation resourceInformation =
+				new ResourceInformation(moduleRegistry.getTypeParser(), Task.class, "tasks", null, null);
 		resourceRegistry.addEntry(
-				new RegistryEntry(resourceInformation, new ResourceRepositoryInformationImpl("tasks", resourceInformation, RepositoryMethodAccess.ALL), null, null));
+				new RegistryEntry(new DirectResponseResourceEntry(null, new ResourceRepositoryInformationImpl("tasks",
+						resourceInformation, RepositoryMethodAccess.ALL))));
 
 		QuerySpec spec = new QuerySpec(Task.class);
 		spec.includeField(Arrays.asList("test"));

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/repository/QuerySpecRepositoryTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/repository/QuerySpecRepositoryTest.java
@@ -54,8 +54,8 @@ public class QuerySpecRepositoryTest extends AbstractQuerySpecTest {
 		scheduleAdapter = scheduleEntry.getResourceRepository(null);
 		projectAdapter = projectEntry.getResourceRepository(null);
 		taskAdapter = taskEntry.getResourceRepository(null);
-		projectRelAdapter = taskEntry.getRelationshipRepositoryForType("projects", null);
-		tasksRelAdapter = projectEntry.getRelationshipRepositoryForType("tasks", null);
+		projectRelAdapter = taskEntry.getRelationshipRepository("projects", null);
+		tasksRelAdapter = projectEntry.getRelationshipRepository("tasks", null);
 	}
 
 	@Test

--- a/crnk-core/src/test/java/io/crnk/core/repository/ReadOnlyRelationshipRepositoryBaseTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/repository/ReadOnlyRelationshipRepositoryBaseTest.java
@@ -1,0 +1,56 @@
+package io.crnk.core.repository;
+
+import org.junit.Test;
+
+public class ReadOnlyRelationshipRepositoryBaseTest {
+
+
+	private ReadOnlyRelationshipRepositoryBase repo = new ReadOnlyRelationshipRepositoryBase() {
+
+	};
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void getSourceResourceClass() {
+		repo.getSourceResourceClass();
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void getMatcher() {
+		repo.getMatcher();
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void getTargetResourceClass() {
+		repo.getTargetResourceClass();
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void findOneTarget() {
+		repo.findOneTarget(null, null, null);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void findManyTargets() {
+		repo.findManyTargets(null, null, null);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void setRelation() {
+		repo.setRelation(null, null, null);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void setRelations() {
+		repo.setRelations(null, null, null);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void addRelations() {
+		repo.setRelations(null, null, null);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void removeRelations() {
+		repo.removeRelations(null, null, null);
+	}
+}

--- a/crnk-core/src/test/java/io/crnk/core/repository/RelationshipMatcherTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/repository/RelationshipMatcherTest.java
@@ -1,0 +1,96 @@
+package io.crnk.core.repository;
+
+import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.information.resource.ResourceFieldType;
+import io.crnk.core.engine.information.resource.ResourceInformation;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class RelationshipMatcherTest {
+
+	private ResourceField field;
+
+	@Before
+	public void setup() {
+		ResourceInformation resource = Mockito.mock(ResourceInformation.class);
+		Mockito.when(resource.getResourceClass()).thenReturn((Class) String.class);
+		Mockito.when(resource.getResourceType()).thenReturn("resource");
+
+		field = Mockito.mock(ResourceField.class);
+		Mockito.when(field.getResourceFieldType()).thenReturn(ResourceFieldType.RELATIONSHIP);
+		Mockito.when(field.getUnderlyingName()).thenReturn("fieldName");
+		Mockito.when(field.getOppositeName()).thenReturn("oppositeFieldName");
+		Mockito.when(field.getOppositeResourceType()).thenReturn("oppositeResourceType");
+		Mockito.when(field.getElementType()).thenReturn((Class) Integer.class);
+		Mockito.when(field.getElementType()).thenReturn((Class) Integer.class);
+		Mockito.when(field.getParentResourceInformation()).thenReturn(resource);
+	}
+
+	@Test
+	public void checkEmpty() {
+		Assert.assertFalse(new RelationshipMatcher().matches(field));
+	}
+
+	@Test
+	public void checkMatchTargetResourceType() {
+		Assert.assertTrue(new RelationshipMatcher().rule().target(Integer.class).add().matches(field));
+	}
+
+	@Test
+	public void checkNotMatchTargetResourceType() {
+		Assert.assertFalse(new RelationshipMatcher().rule().target(Long.class).add().matches(field));
+	}
+
+	@Test
+	public void checkMatchTargetClass() {
+		Assert.assertTrue(new RelationshipMatcher().rule().target("oppositeResourceType").add().matches(field));
+	}
+
+	@Test
+	public void checkNotMatchTargetClass() {
+		Assert.assertFalse(new RelationshipMatcher().rule().target("notAMatch").add().matches(field));
+	}
+
+
+	@Test
+	public void checkMatchSourceResourceType() {
+		Assert.assertTrue(new RelationshipMatcher().rule().source(String.class).add().matches(field));
+	}
+
+	@Test
+	public void checkNotMatchSourceResourceType() {
+		Assert.assertFalse(new RelationshipMatcher().rule().source(Long.class).add().matches(field));
+	}
+
+	@Test
+	public void checkMatchSourceClass() {
+		Assert.assertTrue(new RelationshipMatcher().rule().source("resource").add().matches(field));
+	}
+
+	@Test
+	public void checkNotMatchSourceClass() {
+		Assert.assertFalse(new RelationshipMatcher().rule().source("notAMatch").add().matches(field));
+	}
+
+	@Test
+	public void checkMatchField() {
+		Assert.assertTrue(new RelationshipMatcher().rule().field("fieldName").add().matches(field));
+	}
+
+	@Test
+	public void checkNotMatchField() {
+		Assert.assertFalse(new RelationshipMatcher().rule().field("notAMatch").add().matches(field));
+	}
+
+	@Test
+	public void checkMatchOppositeField() {
+		Assert.assertTrue(new RelationshipMatcher().rule().oppositeField("oppositeFieldName").add().matches(field));
+	}
+
+	@Test
+	public void checkNotMatchOppositeField() {
+		Assert.assertFalse(new RelationshipMatcher().rule().oppositeField("notAMatch").add().matches(field));
+	}
+}

--- a/crnk-core/src/test/java/io/crnk/core/repository/RelationshipRepositoryV2Test.java
+++ b/crnk-core/src/test/java/io/crnk/core/repository/RelationshipRepositoryV2Test.java
@@ -1,0 +1,125 @@
+package io.crnk.core.repository;
+
+import io.crnk.core.mock.models.Project;
+import io.crnk.core.mock.models.Task;
+import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.resource.list.ResourceList;
+import java.io.Serializable;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RelationshipRepositoryV2Test {
+
+
+	private RelationshipRepositoryV2 untypedRepo = new UntypedRelationshipRepository() {
+
+		@Override
+		public Class getSourceResourceClass() {
+			return Task.class;
+		}
+
+		@Override
+		public Class getTargetResourceClass() {
+			return Project.class;
+		}
+
+		@Override
+		public void setRelation(Object source, Serializable targetId, String fieldName) {
+
+		}
+
+		@Override
+		public void setRelations(Object source, Iterable targetIds, String fieldName) {
+
+		}
+
+		@Override
+		public void addRelations(Object source, Iterable targetIds, String fieldName) {
+
+		}
+
+		@Override
+		public void removeRelations(Object source, Iterable targetIds, String fieldName) {
+
+		}
+
+		@Override
+		public Object findOneTarget(Serializable sourceId, String fieldName, QuerySpec querySpec) {
+			return null;
+		}
+
+		@Override
+		public ResourceList findManyTargets(Serializable sourceId, String fieldName, QuerySpec querySpec) {
+			return null;
+		}
+
+		@Override
+		public String getSourceResourceType() {
+			return "tasks";
+		}
+
+		@Override
+		public String getTargetResourceType() {
+			return "projects";
+		}
+	};
+
+	private RelationshipRepositoryV2 nullRepo = new RelationshipRepositoryV2() {
+
+		@Override
+		public Class getSourceResourceClass() {
+			return null;
+		}
+
+		@Override
+		public Class getTargetResourceClass() {
+			return null;
+		}
+
+		@Override
+		public void setRelation(Object source, Serializable targetId, String fieldName) {
+
+		}
+
+		@Override
+		public void setRelations(Object source, Iterable targetIds, String fieldName) {
+
+		}
+
+		@Override
+		public void addRelations(Object source, Iterable targetIds, String fieldName) {
+
+		}
+
+		@Override
+		public void removeRelations(Object source, Iterable targetIds, String fieldName) {
+
+		}
+
+		@Override
+		public Object findOneTarget(Serializable sourceId, String fieldName, QuerySpec querySpec) {
+			return null;
+		}
+
+		@Override
+		public ResourceList findManyTargets(Serializable sourceId, String fieldName, QuerySpec querySpec) {
+			return null;
+		}
+	};
+
+	@Test
+	public void getMatcherForUntyped() {
+		RelationshipMatcher matcher = untypedRepo.getMatcher();
+
+		Assert.assertEquals(1, matcher.rules.size());
+		RelationshipMatcherRule rule = matcher.rules.get(0);
+		Assert.assertEquals("tasks", rule.sourceResourceType);
+		Assert.assertEquals("projects", rule.targetResourceType);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void getMatcherThrowsExceptionWithoutTypes() {
+		nullRepo.getMatcher();
+	}
+
+}

--- a/crnk-core/src/test/java/io/crnk/core/resource/registry/RegistryEntryTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/resource/registry/RegistryEntryTest.java
@@ -1,36 +1,31 @@
 package io.crnk.core.resource.registry;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.crnk.core.engine.information.repository.RepositoryMethodAccess;
 import io.crnk.core.engine.information.repository.ResourceRepositoryInformation;
+import io.crnk.core.engine.information.resource.ResourceField;
 import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.information.repository.ResourceRepositoryInformationImpl;
-import io.crnk.core.engine.internal.repository.RelationshipRepositoryAdapter;
 import io.crnk.core.engine.parser.TypeParser;
 import io.crnk.core.engine.registry.RegistryEntry;
-import io.crnk.core.exception.RelationshipRepositoryNotFoundException;
+import io.crnk.core.engine.registry.ResourceEntry;
+import io.crnk.core.exception.ResourceFieldNotFoundException;
 import io.crnk.core.mock.models.Document;
 import io.crnk.core.mock.models.Memorandum;
 import io.crnk.core.mock.models.Task;
 import io.crnk.core.mock.models.Thing;
-import io.crnk.core.mock.repository.TaskRepository;
 import io.crnk.core.mock.repository.TaskToProjectRepository;
 import io.crnk.core.module.ModuleRegistry;
 import io.crnk.legacy.internal.DirectResponseRelationshipEntry;
+import io.crnk.legacy.internal.DirectResponseResourceEntry;
 import io.crnk.legacy.locator.SampleJsonServiceLocator;
-import io.crnk.legacy.registry.AnnotatedResourceEntry;
 import io.crnk.legacy.registry.RepositoryInstanceBuilder;
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.Mockito;
-
-import java.lang.reflect.Field;
-import java.util.Collections;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("unchecked")
 public class RegistryEntryTest {
@@ -39,48 +34,42 @@ public class RegistryEntryTest {
 	public ExpectedException expectedException = ExpectedException.none();
 
 	@Test
-	public void onValidRelationshipClassShouldReturnRelationshipRepository() throws Exception {
-		// GIVEN
-		ModuleRegistry moduleRegistry = new ModuleRegistry();
-		ResourceInformation resourceInformation = Mockito.mock(ResourceInformation.class);
-		RegistryEntry sut = new RegistryEntry(resourceInformation, new ResourceRepositoryInformationImpl(null, resourceInformation, null), new AnnotatedResourceEntry(new RepositoryInstanceBuilder(new SampleJsonServiceLocator(), TaskRepository.class)),
-				(List) Collections.singletonList(new DirectResponseRelationshipEntry(new RepositoryInstanceBuilder(new SampleJsonServiceLocator(), TaskToProjectRepository.class))));
-		sut.initialize(moduleRegistry);
-
-		// WHEN
-		RelationshipRepositoryAdapter<Task, ?, ?, ?> relationshipRepository = sut.getRelationshipRepositoryForType("projects", null);
-
-		// THEN
-		assertThat(relationshipRepository).isExactlyInstanceOf(RelationshipRepositoryAdapter.class);
-	}
-
-	@Test
 	public void onInvalidRelationshipClassShouldThrowException() throws Exception {
 		// GIVEN
 		ResourceRepositoryInformation repositoryInformation = newRepositoryInformation(Task.class, "tasks");
-		List relRepos = Collections.singletonList(new DirectResponseRelationshipEntry(new RepositoryInstanceBuilder(new SampleJsonServiceLocator(), TaskToProjectRepository.class)));
-		RegistryEntry sut = new RegistryEntry(repositoryInformation.getResourceInformation().get(), repositoryInformation, null, relRepos);
+		ResourceField relationshipField = repositoryInformation.getResourceInformation().get().findFieldByUnderlyingName
+				("tasks");
+		Map relRepos = new HashMap<>();
+		relRepos.put(relationshipField, new DirectResponseRelationshipEntry(
+				new RepositoryInstanceBuilder(new SampleJsonServiceLocator(), TaskToProjectRepository.class)));
+		RegistryEntry sut =
+				new RegistryEntry(new DirectResponseResourceEntry(null, repositoryInformation), relRepos);
 
 		// THEN
-		expectedException.expect(RelationshipRepositoryNotFoundException.class);
+		expectedException.expect(ResourceFieldNotFoundException.class);
 
 		// WHEN
-		sut.getRelationshipRepositoryForType("users", null);
+		sut.getRelationshipRepository("users", null);
+	}
+
+	private ResourceEntry newResourceEntry(Class repositoryClass, String path) {
+		return new DirectResponseResourceEntry(null, newRepositoryInformation(repositoryClass, path));
 	}
 
 	private <T> ResourceRepositoryInformation newRepositoryInformation(Class<T> repositoryClass, String path) {
 		ModuleRegistry moduleRegistry = new ModuleRegistry();
 		TypeParser typeParser = moduleRegistry.getTypeParser();
-		return new ResourceRepositoryInformationImpl( path, new ResourceInformation(typeParser, Task.class, path, null, null), RepositoryMethodAccess.ALL);
+		return new ResourceRepositoryInformationImpl(path, new ResourceInformation(typeParser, Task.class, path, null, null),
+				RepositoryMethodAccess.ALL);
 	}
 
 	@Test
 	public void onValidParentShouldReturnTrue() throws Exception {
 		// GIVEN
-		RegistryEntry thing = new RegistryEntry(newRepositoryInformation(Thing.class, "things"), null);
-		RegistryEntry document = new RegistryEntry(newRepositoryInformation(Document.class, "documents"), null);
+		RegistryEntry thing = new RegistryEntry(newResourceEntry(Thing.class, "things"));
+		RegistryEntry document = new RegistryEntry(newResourceEntry(Document.class, "documents"));
 		document.setParentRegistryEntry(thing);
-		RegistryEntry memorandum = new RegistryEntry(newRepositoryInformation(Memorandum.class, "memorandum"), null);
+		RegistryEntry memorandum = new RegistryEntry(newResourceEntry(Memorandum.class, "memorandum"));
 		memorandum.setParentRegistryEntry(document);
 
 		// WHEN
@@ -93,25 +82,13 @@ public class RegistryEntryTest {
 	@Test
 	public void onInvalidParentShouldReturnFalse() throws Exception {
 		// GIVEN
-		RegistryEntry document = new RegistryEntry(newRepositoryInformation(Document.class, "documents"), null);
-		RegistryEntry task = new RegistryEntry(newRepositoryInformation(Task.class, "tasks"), null);
+		RegistryEntry document = new RegistryEntry(newResourceEntry(Document.class, "documents"));
+		RegistryEntry task = new RegistryEntry(newResourceEntry(Task.class, "tasks"));
 
 		// WHEN
 		boolean result = document.isParent(task);
 
 		// THEN
 		assertThat(result).isFalse();
-	}
-
-	@Test
-	public void equalsContract() throws NoSuchFieldException {
-		ModuleRegistry moduleRegistry = new ModuleRegistry();
-		RegistryEntry blue = new RegistryEntry(newRepositoryInformation(String.class, "strings"), null);
-		RegistryEntry red = new RegistryEntry(newRepositoryInformation(Long.class, "longs"), null);
-		TypeParser typeParser = moduleRegistry.getTypeParser();
-		EqualsVerifier.forClass(RegistryEntry.class).withPrefabValues(RegistryEntry.class, blue, red)
-				.withPrefabValues(ResourceInformation.class, new ResourceInformation(typeParser, String.class, null, null, null), new ResourceInformation(typeParser, Long.class, null, null, null, null))
-				.withPrefabValues(Field.class, String.class.getDeclaredField("value"), String.class.getDeclaredField("hash")).withPrefabValues(ModuleRegistry.class, new ModuleRegistry(), new ModuleRegistry())
-				.suppress(Warning.NONFINAL_FIELDS).suppress(Warning.STRICT_INHERITANCE).verify();
 	}
 }

--- a/crnk-core/src/test/java/io/crnk/core/resource/registry/ResourceRegistryTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/resource/registry/ResourceRegistryTest.java
@@ -23,6 +23,7 @@ import io.crnk.core.mock.models.Task;
 import io.crnk.core.module.ModuleRegistry;
 import io.crnk.core.resource.annotations.JsonApiResource;
 
+import io.crnk.legacy.internal.DirectResponseResourceEntry;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -68,8 +69,8 @@ public class ResourceRegistryTest {
 	private <T> RegistryEntry newRegistryEntry(Class<T> repositoryClass, String path) {
 		ResourceInformation resourceInformation =
 				new ResourceInformation(moduleRegistry.getTypeParser(), Task.class, path, null, null);
-		return new RegistryEntry(resourceInformation, new ResourceRepositoryInformationImpl(path, resourceInformation, RepositoryMethodAccess.ALL), null,
-				null);
+		return new RegistryEntry(new DirectResponseResourceEntry(null,
+				new ResourceRepositoryInformationImpl(path, resourceInformation, RepositoryMethodAccess.ALL)));
 	}
 
 	@Test
@@ -104,11 +105,12 @@ public class ResourceRegistryTest {
 		ResourceField idField = new ResourceFieldImpl("id", "id", ResourceFieldType.ID, Long.class, Long.class, null);
 		ResourceField valueField = new ResourceFieldImpl("value", "value", ResourceFieldType.RELATIONSHIP, String.class,
 				String.class, "projects");
-		TypeParser typeParser = new TypeParser();
 		ResourceInformation resourceInformation =
-				new ResourceInformation(moduleRegistry.getTypeParser(), Task.class, "tasks", null, Arrays.asList(idField, valueField));
-		RegistryEntry registryEntry = new RegistryEntry(resourceInformation, new ResourceRepositoryInformationImpl("tasks", resourceInformation, RepositoryMethodAccess.ALL), null,
-				null);
+				new ResourceInformation(moduleRegistry.getTypeParser(), Task.class, "tasks", null,
+						Arrays.asList(idField, valueField));
+		RegistryEntry registryEntry = new RegistryEntry(new DirectResponseResourceEntry(null, new
+				ResourceRepositoryInformationImpl
+				("tasks", resourceInformation, RepositoryMethodAccess.ALL)));
 		resourceRegistry.addEntry(Task.class, registryEntry);
 
 		String resourceUrl = resourceRegistry.getResourceUrl(task);

--- a/crnk-documentation/src/docs/asciidoc/repositories.adoc
+++ b/crnk-documentation/src/docs/asciidoc/repositories.adoc
@@ -136,6 +136,13 @@ defined implementing `RelationshipRepositoryV2`. `RelationshipRepositoryV2` impl
 necessary to work with a relationship. It provides methods for both single-valued and multi-valued
 relationships:
 
+
+* `getMatcher()`
+  Provides a  `RelationshipMatcher` instance that specifies which relationships it is able provide.
+  It can match against source and target types and fields in any combination. Note that this
+  is a default method that access the legacy `getSourceResourceClass` and `getTargetResourceClass`
+  by default. Implementation of those methods can be omitted if a matcher is available.
+
 * `setRelation(T source, D_ID targetId, String fieldName)`
   Sets a resource defined by targetId to a field fieldName in an instance source. If no value is to be set, null value is passed.
 
@@ -178,7 +185,7 @@ implementation then looks as simple as:
 ----
 	public class ProjectToTaskRepository extends RelationshipRepositoryBase<Project, Long, Task, Long> {
 
-		public ScheduleToTaskRepository() {
+		public ProjectToTaskRepository() {
 			super(Project.class, Task.class);
 		}
 	}
@@ -198,6 +205,51 @@ For this to work, relations must be set up bidirectionally with the `opposite` a
 	    ...
 	}
 ----
+
+## RelationshipMatcher
+
+The ProjectToTaskRepository repository from the previous section establishes a relationship between
+project and task. But by implementing `RelationshipRepositoryV2.getMatcher()`, one can gain much
+more flexibility about which kind of relationships a repository is possible to serve.
+Rules can look like:
+
+[source]
+.RelationshipMatcherTest
+----
+new RelationshipMatcher().rule().source("projects").add().matches(field)
+new RelationshipMatcher().rule().target(Task.class).add().matches(field)
+new RelationshipMatcher().rule().target(Tasks.class).add().matches(field)
+new RelationshipMatcher().rule().field("tasks").add().matches(field)
+new RelationshipMatcher().rule().oppositeField("project").add().matches(field)
+[source]
+----
+
+One example might be a history relationship repository that introduces a history for every other resource.
+There would match against `target`. Such an example is available in
+https://github.com/crnk-project/crnk-example[crnk-example].
+
+
+## ResourceFieldContributor
+
+`ResourceFieldContributor` allows to dynamically introduce new fields to resources without actually
+touching them. This is useful, for example, if you have a JPA entity exposed with crnk-jpa and
+want to add further fields like that mentioned history relationship from the previous section.
+
+Any type of field can be added: meta, links, attribute and relationship fields. For relationship fields
+an application may make use of `RelationshipMatcher` to provide repository serving those fields.
+Notice the `accessor` property that is used to obtain the value of that field
+(make sure this method is efficient to execute). An example is given by the `HistoryRelationshipRepository` in https://github
+.com/crnk-project/crnk-example[crnk-example]:
+
+[source]
+.HistoryRelationshipRepository
+----
+include::../../../../crnk-examples/spring-boot-example/src/main/java/io/crnk/example/springboot/domain/repository/HistoryRelationshipRepository.java[tag=docs]
+----
+
+- `getRelationshipFields` introduces the field dynamically instead of statically.
+- `getMatcher` attaches the repository to the historized resources.
+- `findManyTarget` implements the lookup of history elements.
 
 
 ## BulkRelationshipRepositoryV2

--- a/crnk-documentation/src/docs/asciidoc/repositories.adoc
+++ b/crnk-documentation/src/docs/asciidoc/repositories.adoc
@@ -224,22 +224,23 @@ new RelationshipMatcher().rule().oppositeField("project").add().matches(field)
 [source]
 ----
 
-One example might be a history relationship repository that introduces a history for every other resource.
-There would match against `target`. Such an example is available in
-https://github.com/crnk-project/crnk-example[crnk-example].
+One can implement, for example, a history relationship repository that introduces a history relationship for every other resource.
+In this example, `RelationshipMatcher` would match against the history resource as target. Such an example is
+depicated in the next section.
 
 
 ## ResourceFieldContributor
 
-`ResourceFieldContributor` allows to dynamically introduce new fields to resources without actually
+The `ResourceFieldContributor` interface allows to dynamically introduce new fields to resources without actually
 touching them. This is useful, for example, if you have a JPA entity exposed with crnk-jpa and
-want to add further fields like that mentioned history relationship from the previous section.
+want to add further fields like that mentioned history relationship from the previous section. It can be implemented
+by a repository or obtained from the regular service discovery mechanism.
 
 Any type of field can be added: meta, links, attribute and relationship fields. For relationship fields
 an application may make use of `RelationshipMatcher` to provide repository serving those fields.
 Notice the `accessor` property that is used to obtain the value of that field
-(make sure this method is efficient to execute). An example is given by the `HistoryRelationshipRepository` in https://github
-.com/crnk-project/crnk-example[crnk-example]:
+(make sure this method is efficient to execute). An example is given by the `HistoryRelationshipRepository` in
+https://github.com/crnk-project/crnk-framework/tree/master/crnk-examples/spring-boot-example[crnk-examples/spring-boot-example]:
 
 [source]
 .HistoryRelationshipRepository

--- a/crnk-examples/spring-boot-example/build.gradle
+++ b/crnk-examples/spring-boot-example/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 	compile 'org.hibernate:hibernate-core:5.1.0.Final'
 	compile 'org.hibernate:hibernate-entitymanager:5.1.0.Final'
 	compile 'com.h2database:h2:1.4.195'
-	compile 'io.zipkin.brave:brave-instrumentation-okhttp3:4.9.1'
 	compile 'com.squareup.okhttp3:okhttp:3.4.1'
 	compile 'com.jayway.restassured:rest-assured:2.9.0'
 	compile 'com.jayway.restassured:json-schema-validator:2.9.0'

--- a/crnk-examples/spring-boot-example/src/main/java/io/crnk/example/springboot/domain/model/History.java
+++ b/crnk-examples/spring-boot-example/src/main/java/io/crnk/example/springboot/domain/model/History.java
@@ -1,0 +1,33 @@
+package io.crnk.example.springboot.domain.model;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.crnk.core.resource.annotations.JsonApiId;
+import io.crnk.core.resource.annotations.JsonApiResource;
+
+@JsonApiResource(type = "history")
+public class History {
+
+	@JsonApiId
+	private UUID id;
+
+	@JsonProperty
+	private String name;
+
+	public UUID getId() {
+		return id;
+	}
+
+	public void setId(UUID id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/crnk-examples/spring-boot-example/src/main/java/io/crnk/example/springboot/domain/repository/HistoryRelationshipRepository.java
+++ b/crnk-examples/spring-boot-example/src/main/java/io/crnk/example/springboot/domain/repository/HistoryRelationshipRepository.java
@@ -1,0 +1,75 @@
+package io.crnk.example.springboot.domain.repository;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import io.crnk.core.engine.information.InformationBuilder;
+import io.crnk.core.engine.information.contributor.ResourceFieldContributor;
+import io.crnk.core.engine.information.contributor.ResourceFieldContributorContext;
+import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.information.resource.ResourceFieldAccessor;
+import io.crnk.core.engine.information.resource.ResourceFieldType;
+import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.repository.ReadOnlyRelationshipRepositoryBase;
+import io.crnk.core.repository.RelationshipMatcher;
+import io.crnk.core.resource.annotations.LookupIncludeBehavior;
+import io.crnk.core.resource.list.DefaultResourceList;
+import io.crnk.core.resource.list.ResourceList;
+import io.crnk.example.springboot.domain.model.History;
+import org.springframework.stereotype.Component;
+
+/**
+ * Generic repository that introduces a history relationship for project and task resource without touching
+ * those resources.
+ */
+// tag::docs[]
+@Component
+public class HistoryRelationshipRepository extends ReadOnlyRelationshipRepositoryBase<Object, Serializable, History, UUID>
+		implements ResourceFieldContributor {
+
+	@Override
+	public List<ResourceField> getResourceFields(ResourceFieldContributorContext context) {
+		// this method could be omitted if the history field is added regularly to Project and Task resource. This would be
+		// simpler and recommended, but may not always be possible. Here we demonstrate doing it dynamically.
+		InformationBuilder.Field fieldBuilder = context.getInformationBuilder().createResourceField();
+		fieldBuilder.name("history");
+		fieldBuilder.type(History.class);
+		fieldBuilder.oppositeResourceType("history");
+		fieldBuilder.fieldType(ResourceFieldType.RELATIONSHIP);
+
+		// field values are "null" on resource and we make use of automated lookup to the relationship repository
+		// instead:
+		fieldBuilder.lookupIncludeBehavior(LookupIncludeBehavior.AUTOMATICALLY_ALWAYS);
+		fieldBuilder.accessor(new ResourceFieldAccessor() {
+			@Override
+			public Object getValue(Object resource) {
+				return null;
+			}
+
+			@Override
+			public void setValue(Object resource, Object fieldValue) {
+			}
+		});
+		return Arrays.asList(fieldBuilder.build());
+	}
+
+	@Override
+	public RelationshipMatcher getMatcher() {
+		return new RelationshipMatcher().rule().target(History.class).add();
+	}
+
+	@Override
+	public ResourceList<History> findManyTargets(Serializable sourceId, String fieldName, QuerySpec querySpec) {
+		DefaultResourceList list = new DefaultResourceList();
+		for (int i = 0; i < 10; i++) {
+			History history = new History();
+			history.setId(UUID.nameUUIDFromBytes(("historyElement" + i).getBytes()));
+			history.setName("historyElement" + i);
+			list.add(history);
+		}
+		return list;
+	}
+}
+// end::docs[]

--- a/crnk-examples/spring-boot-example/src/main/java/io/crnk/example/springboot/domain/repository/HistoryRelationshipRepository.java
+++ b/crnk-examples/spring-boot-example/src/main/java/io/crnk/example/springboot/domain/repository/HistoryRelationshipRepository.java
@@ -1,5 +1,6 @@
 package io.crnk.example.springboot.domain.repository;
 
+import com.google.common.reflect.TypeToken;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
@@ -35,7 +36,8 @@ public class HistoryRelationshipRepository extends ReadOnlyRelationshipRepositor
 		// simpler and recommended, but may not always be possible. Here we demonstrate doing it dynamically.
 		InformationBuilder.Field fieldBuilder = context.getInformationBuilder().createResourceField();
 		fieldBuilder.name("history");
-		fieldBuilder.type(History.class);
+		fieldBuilder.genericType(new TypeToken<List<History>>() {
+		}.getType());
 		fieldBuilder.oppositeResourceType("history");
 		fieldBuilder.fieldType(ResourceFieldType.RELATIONSHIP);
 

--- a/crnk-examples/spring-boot-example/src/main/java/io/crnk/example/springboot/domain/repository/HistoryResourceRepository.java
+++ b/crnk-examples/spring-boot-example/src/main/java/io/crnk/example/springboot/domain/repository/HistoryResourceRepository.java
@@ -1,0 +1,46 @@
+package io.crnk.example.springboot.domain.repository;
+
+import java.util.UUID;
+
+import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.repository.ResourceRepositoryBase;
+import io.crnk.core.resource.list.DefaultResourceList;
+import io.crnk.core.resource.list.ResourceList;
+import io.crnk.example.springboot.domain.model.History;
+import org.springframework.stereotype.Component;
+
+/**
+ * See HistoryRelationshipRepository for more information/actual use case
+ */
+@Component
+public class HistoryResourceRepository extends ResourceRepositoryBase<History, UUID> {
+
+	protected HistoryResourceRepository() {
+		super(History.class);
+	}
+
+	@Override
+	public History findOne(UUID id, QuerySpec querySpec) {
+		History history = new History();
+		history.setId(id);
+		history.setName("test");
+		return history;
+	}
+
+	@Override
+	public ResourceList<History> findAll(Iterable<UUID> ids, QuerySpec querySpec) {
+		DefaultResourceList list = new DefaultResourceList();
+		for (UUID id : ids) {
+			History history = new History();
+			history.setId(id);
+			history.setName("test");
+			list.add(history);
+		}
+		return list;
+	}
+
+	@Override
+	public ResourceList<History> findAll(QuerySpec querySpec) {
+		throw new UnsupportedOperationException("no implemented");
+	}
+}

--- a/crnk-home/src/test/java/io/crnk/home/HomeModuleTest.java
+++ b/crnk-home/src/test/java/io/crnk/home/HomeModuleTest.java
@@ -4,9 +4,8 @@ import io.crnk.core.boot.CrnkBoot;
 import io.crnk.core.engine.http.HttpRequestContextBase;
 import io.crnk.core.engine.internal.http.HttpRequestProcessorImpl;
 import io.crnk.core.engine.url.ConstantServiceUrlProvider;
-import io.crnk.core.module.discovery.ReflectionsServiceDiscovery;
-import io.crnk.legacy.locator.SampleJsonServiceLocator;
 import io.crnk.test.mock.ClassTestUtils;
+import io.crnk.test.mock.TestModule;
 import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Before;
@@ -24,9 +23,8 @@ public class HomeModuleTest {
 		this.module = Mockito.spy(HomeModule.create(HomeFormat.JSON_HOME));
 		boot = new CrnkBoot();
 		boot.addModule(module);
+		boot.addModule(new TestModule());
 		boot.setServiceUrlProvider(new ConstantServiceUrlProvider("http://localhost"));
-		boot.setServiceDiscovery(new ReflectionsServiceDiscovery("io.crnk.test.mock", new SampleJsonServiceLocator
-				()));
 		boot.boot();
 	}
 

--- a/crnk-home/src/test/java/io/crnk/home/HomeResourceFilteringTest.java
+++ b/crnk-home/src/test/java/io/crnk/home/HomeResourceFilteringTest.java
@@ -10,15 +10,13 @@ import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.http.HttpRequestProcessorImpl;
 import io.crnk.core.engine.url.ConstantServiceUrlProvider;
 import io.crnk.core.module.SimpleModule;
-import io.crnk.core.module.discovery.ReflectionsServiceDiscovery;
-import io.crnk.legacy.locator.SampleJsonServiceLocator;
+import io.crnk.test.mock.TestModule;
+import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-
-import java.io.IOException;
 
 public class HomeResourceFilteringTest {
 
@@ -37,9 +35,8 @@ public class HomeResourceFilteringTest {
 		this.module = Mockito.spy(HomeModule.create());
 		boot = new CrnkBoot();
 		boot.addModule(module);
+		boot.addModule(new TestModule());
 		boot.setServiceUrlProvider(new ConstantServiceUrlProvider("http://localhost"));
-		boot.setServiceDiscovery(new ReflectionsServiceDiscovery("io.crnk.test.mock", new SampleJsonServiceLocator
-				()));
 		boot.addModule(filterModule);
 		boot.boot();
 	}

--- a/crnk-home/src/test/java/io/crnk/home/JsonApiFormatTest.java
+++ b/crnk-home/src/test/java/io/crnk/home/JsonApiFormatTest.java
@@ -6,11 +6,10 @@ import io.crnk.core.engine.http.HttpHeaders;
 import io.crnk.core.engine.http.HttpRequestContextBase;
 import io.crnk.core.engine.internal.http.HttpRequestProcessorImpl;
 import io.crnk.core.engine.url.ConstantServiceUrlProvider;
-import io.crnk.core.module.discovery.ReflectionsServiceDiscovery;
-import io.crnk.legacy.locator.SampleJsonServiceLocator;
 import io.crnk.meta.MetaModule;
 import io.crnk.meta.MetaModuleConfig;
 import io.crnk.meta.provider.resource.ResourceMetaProvider;
+import io.crnk.test.mock.TestModule;
 import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,9 +33,8 @@ public class JsonApiFormatTest {
 		boot = new CrnkBoot();
 		boot.addModule(module);
 		boot.addModule(metaModule);
+		boot.addModule(new TestModule());
 		boot.setServiceUrlProvider(new ConstantServiceUrlProvider("http://localhost"));
-		boot.setServiceDiscovery(new ReflectionsServiceDiscovery("io.crnk.test.mock", new SampleJsonServiceLocator
-				()));
 		boot.boot();
 	}
 

--- a/crnk-home/src/test/java/io/crnk/home/JsonHomeFormatTest.java
+++ b/crnk-home/src/test/java/io/crnk/home/JsonHomeFormatTest.java
@@ -5,11 +5,10 @@ import io.crnk.core.boot.CrnkBoot;
 import io.crnk.core.engine.http.HttpRequestContextBase;
 import io.crnk.core.engine.internal.http.HttpRequestProcessorImpl;
 import io.crnk.core.engine.url.ConstantServiceUrlProvider;
-import io.crnk.core.module.discovery.ReflectionsServiceDiscovery;
-import io.crnk.legacy.locator.SampleJsonServiceLocator;
 import io.crnk.meta.MetaModule;
 import io.crnk.meta.MetaModuleConfig;
 import io.crnk.meta.provider.resource.ResourceMetaProvider;
+import io.crnk.test.mock.TestModule;
 import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,9 +32,8 @@ public class JsonHomeFormatTest {
 		boot = new CrnkBoot();
 		boot.addModule(module);
 		boot.addModule(metaModule);
+		boot.addModule(new TestModule());
 		boot.setServiceUrlProvider(new ConstantServiceUrlProvider("http://localhost"));
-		boot.setServiceDiscovery(new ReflectionsServiceDiscovery("io.crnk.test.mock", new SampleJsonServiceLocator
-				()));
 		boot.boot();
 	}
 

--- a/crnk-jpa/src/main/java/io/crnk/jpa/DefaultJpaRepositoryFactory.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/DefaultJpaRepositoryFactory.java
@@ -1,18 +1,20 @@
 package io.crnk.jpa;
 
+import io.crnk.core.engine.information.resource.ResourceField;
 import java.io.Serializable;
 
 public class DefaultJpaRepositoryFactory implements JpaRepositoryFactory {
 
 	@Override
 	public <T, I extends Serializable> JpaEntityRepository<T, I> createEntityRepository(JpaModule module,
-																						JpaRepositoryConfig<T> config) {
+			JpaRepositoryConfig<T> config) {
 		return new JpaEntityRepository<>(module, config);
 	}
 
 	@Override
-	public <T, I extends Serializable, D, J extends Serializable> JpaRelationshipRepository<T, I, D, J> createRelationshipRepository(
-			JpaModule module, Class<T> sourceResourceClass, JpaRepositoryConfig<D> config) {
-		return new JpaRelationshipRepository<>(module, sourceResourceClass, config);
+	public <T, I extends Serializable, D, J extends Serializable> JpaRelationshipRepository<T, I, D, J>
+	createRelationshipRepository(
+			JpaModule module, ResourceField field, JpaRepositoryConfig<D> config) {
+		return new JpaRelationshipRepository<>(module, field, config);
 	}
 }

--- a/crnk-jpa/src/main/java/io/crnk/jpa/JpaModule.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/JpaModule.java
@@ -1,5 +1,6 @@
 package io.crnk.jpa;
 
+import io.crnk.jpa.internal.JpaRepositoryBase;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.util.HashSet;
@@ -472,7 +473,7 @@ public class JpaModule implements InitializingModule {
 		if (attrConfig != null) {
 			JpaRepositoryFactory repositoryFactory = config.getRepositoryFactory();
 			RelationshipRepositoryV2<?, ?, ?, ?> relationshipRepository = filterRelationshipCreation(attrType,
-					repositoryFactory.createRelationshipRepository(this, resourceClass, attrConfig));
+					repositoryFactory.createRelationshipRepository(this, field, attrConfig));
 			context.addRepository(relationshipRepository);
 		}
 	}
@@ -491,7 +492,7 @@ public class JpaModule implements InitializingModule {
 
 			JpaRepositoryFactory repositoryFactory = config.getRepositoryFactory();
 			RelationshipRepositoryV2<?, ?, ?, ?> relationshipRepository = filterRelationshipCreation(targetResourceClass,
-					repositoryFactory.createRelationshipRepository(this, resourceClass, attrConfig));
+					repositoryFactory.createRelationshipRepository(this, field, attrConfig));
 			context.addRepository(relationshipRepository);
 		}
 	}
@@ -631,9 +632,11 @@ public class JpaModule implements InitializingModule {
 		@Override
 		public <T, I extends Serializable> ResourceRepositoryDecorator<T, I> decorateRepository(
 				ResourceRepositoryV2<T, I> repository) {
-			JpaRepositoryConfig<T> config = getRepositoryConfig(repository.getResourceClass());
-			if (config != null) {
-				return config.getRepositoryDecorator();
+			if (repository instanceof JpaRepositoryBase) {
+				JpaRepositoryConfig<T> config = getRepositoryConfig(repository.getResourceClass());
+				if (config != null) {
+					return config.getRepositoryDecorator();
+				}
 			}
 			return null;
 		}
@@ -642,9 +645,11 @@ public class JpaModule implements InitializingModule {
 		public <T, I extends Serializable, D, J extends Serializable> RelationshipRepositoryDecorator<T, I, D, J>
 		decorateRepository(
 				RelationshipRepositoryV2<T, I, D, J> repository) {
-			JpaRepositoryConfig<T> config = getRepositoryConfig(repository.getSourceResourceClass());
-			if (config != null) {
-				return config.getRepositoryDecorator(repository.getTargetResourceClass());
+			if (repository instanceof JpaRepositoryBase) {
+				JpaRepositoryConfig<T> config = getRepositoryConfig(repository.getSourceResourceClass());
+				if (config != null) {
+					return config.getRepositoryDecorator(repository.getTargetResourceClass());
+				}
 			}
 			return null;
 		}

--- a/crnk-jpa/src/main/java/io/crnk/jpa/JpaModule.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/JpaModule.java
@@ -1,5 +1,15 @@
 package io.crnk.jpa;
 
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
 import io.crnk.core.engine.dispatcher.Response;
 import io.crnk.core.engine.error.ExceptionMapper;
 import io.crnk.core.engine.filter.AbstractDocumentFilter;
@@ -23,7 +33,11 @@ import io.crnk.core.repository.decorate.RepositoryDecoratorFactory;
 import io.crnk.core.repository.decorate.ResourceRepositoryDecorator;
 import io.crnk.core.resource.meta.DefaultHasMoreResourcesMetaInformation;
 import io.crnk.core.resource.meta.DefaultPagedMetaInformation;
-import io.crnk.jpa.internal.*;
+import io.crnk.jpa.internal.JpaRequestContext;
+import io.crnk.jpa.internal.JpaResourceInformationProvider;
+import io.crnk.jpa.internal.OptimisticLockExceptionMapper;
+import io.crnk.jpa.internal.PersistenceExceptionMapper;
+import io.crnk.jpa.internal.PersistenceRollbackExceptionMapper;
 import io.crnk.jpa.internal.query.backend.querydsl.QuerydslQueryImpl;
 import io.crnk.jpa.meta.JpaMetaProvider;
 import io.crnk.jpa.meta.MetaEntity;
@@ -39,14 +53,6 @@ import io.crnk.meta.MetaModuleExtension;
 import io.crnk.meta.provider.MetaPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import java.io.Serializable;
-import java.lang.reflect.Constructor;
-import java.util.*;
-import java.util.concurrent.Callable;
 
 /**
  * Crnk module that adds support to expose JPA entities as repositories. It
@@ -475,17 +481,19 @@ public class JpaModule implements InitializingModule {
 		Class<?> attrImplClass = field.getElementType();
 		JpaRepositoryConfig<?> attrConfig = getRepositoryConfig(attrImplClass);
 
-		PreconditionUtil.verify(attrConfig != null && attrConfig.getMapper() != null,
-				"no mapped entity for %s reference from %s.%s registered", field.getOppositeResourceType(),
-				field.getParentResourceInformation().getResourceType(), field.getUnderlyingName());
+		if (attrConfig != null) {
+			PreconditionUtil.verify(attrConfig.getMapper() != null,
+					"no mapped entity %s referenced from %s.%s registered", attrImplClass.getName(),
+					field.getParentResourceInformation().getResourceType(), field.getUnderlyingName());
 
-		JpaRepositoryConfig<?> targetConfig = getRepositoryConfig(attrImplClass);
-		Class<?> targetResourceClass = targetConfig.getResourceClass();
+			JpaRepositoryConfig<?> targetConfig = getRepositoryConfig(attrImplClass);
+			Class<?> targetResourceClass = targetConfig.getResourceClass();
 
-		JpaRepositoryFactory repositoryFactory = config.getRepositoryFactory();
-		RelationshipRepositoryV2<?, ?, ?, ?> relationshipRepository = filterRelationshipCreation(targetResourceClass,
-				repositoryFactory.createRelationshipRepository(this, resourceClass, attrConfig));
-		context.addRepository(relationshipRepository);
+			JpaRepositoryFactory repositoryFactory = config.getRepositoryFactory();
+			RelationshipRepositoryV2<?, ?, ?, ?> relationshipRepository = filterRelationshipCreation(targetResourceClass,
+					repositoryFactory.createRelationshipRepository(this, resourceClass, attrConfig));
+			context.addRepository(relationshipRepository);
+		}
 	}
 
 

--- a/crnk-jpa/src/main/java/io/crnk/jpa/JpaRelationshipRepository.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/JpaRelationshipRepository.java
@@ -1,5 +1,7 @@
 package io.crnk.jpa;
 
+import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.repository.RelationshipMatcher;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,6 +36,8 @@ import io.crnk.meta.model.MetaType;
 public class JpaRelationshipRepository<S, I extends Serializable, T, J extends Serializable> extends JpaRepositoryBase<T>
 		implements RelationshipRepositoryV2<S, I, T, J>, BulkRelationshipRepositoryV2<S, I, T, J> {
 
+	private final ResourceField resourceField;
+
 	private Class<S> sourceResourceClass;
 
 	private Class<?> sourceEntityClass;
@@ -46,18 +50,24 @@ public class JpaRelationshipRepository<S, I extends Serializable, T, J extends S
 	 * JPA relationship directly exposed as repository
 	 *
 	 * @param module that manages this repository
-	 * @param sourceResourceClass from this relation
-	 * @param targetResourceClass from this relation
+	 * @param resourceField from this relation
+	 * @param repositoryConfig from this relation
 	 */
-	public JpaRelationshipRepository(JpaModule module, Class<S> sourceResourceClass, JpaRepositoryConfig<T>
-			targetResourceClass) {
-		super(module, targetResourceClass);
-		this.sourceResourceClass = sourceResourceClass;
+	public JpaRelationshipRepository(JpaModule module, ResourceField resourceField, JpaRepositoryConfig<T>
+			repositoryConfig) {
+		super(module, repositoryConfig);
+		this.sourceResourceClass = (Class<S>) resourceField.getParentResourceInformation().getResourceClass();
+		this.resourceField = resourceField;
 
 		JpaRepositoryConfig<S> sourceMapping = module.getRepositoryConfig(sourceResourceClass);
 		this.sourceEntityClass = sourceMapping.getEntityClass();
 		this.sourceMapper = sourceMapping.getMapper();
 		this.entityMeta = module.getJpaMetaProvider().getMeta(sourceEntityClass);
+	}
+
+	@Override
+	public RelationshipMatcher getMatcher() {
+		return new RelationshipMatcher().rule().field(resourceField).add();
 	}
 
 	@Override

--- a/crnk-jpa/src/main/java/io/crnk/jpa/JpaRepositoryFactory.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/JpaRepositoryFactory.java
@@ -1,5 +1,6 @@
 package io.crnk.jpa;
 
+import io.crnk.core.engine.information.resource.ResourceField;
 import java.io.Serializable;
 
 /**
@@ -30,11 +31,11 @@ public interface JpaRepositoryFactory {
 	 * @param <T>                 target document type
 	 * @param <J>                 target identifier type
 	 * @param module              managing the document
-	 * @param sourceResourceClass representing the source of the relation (entity or mapped dto)
+	 * @param resourceField       representing the source field of the relation (entity or mapped dto)
 	 * @param config              for this document
 	 * @return created document
 	 */
 	<S, I extends Serializable, T, J extends Serializable> JpaRelationshipRepository<S, I, T, J> createRelationshipRepository(
-			JpaModule module, Class<S> sourceResourceClass, JpaRepositoryConfig<T> config);
+			JpaModule module, ResourceField resourceField, JpaRepositoryConfig<T> config);
 
 }

--- a/crnk-jpa/src/test/java/io/crnk/jpa/AbstractJpaJerseyTest.java
+++ b/crnk-jpa/src/test/java/io/crnk/jpa/AbstractJpaJerseyTest.java
@@ -21,6 +21,7 @@ import io.crnk.meta.MetaModuleConfig;
 import io.crnk.meta.provider.resource.ResourceMetaProvider;
 import io.crnk.rs.CrnkFeature;
 import io.crnk.test.JerseyTestBase;
+import io.crnk.test.mock.TestModule;
 import okhttp3.OkHttpClient.Builder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.After;
@@ -116,7 +117,6 @@ public abstract class AbstractJpaJerseyTest extends JerseyTestBase {
 	private class TestApplication extends ResourceConfig {
 
 		public TestApplication() {
-			property(CrnkProperties.RESOURCE_SEARCH_PACKAGE, "io.crnk.test.mock");
 
 			Assert.assertNull(context);
 
@@ -130,10 +130,13 @@ public abstract class AbstractJpaJerseyTest extends JerseyTestBase {
 			if (useQuerySpec) {
 				feature = new CrnkFeature(new ObjectMapper(), new QueryParamsBuilder(new DefaultQueryParamsParser()),
 						new SampleJsonServiceLocator());
-			} else {
+			}
+			else {
 				feature = new CrnkFeature(new ObjectMapper(), new DefaultQuerySpecDeserializer(), new SampleJsonServiceLocator
 						());
 			}
+
+			feature.addModule(new TestModule());
 
 			JpaModule module = JpaModule.newServerModule(em, transactionRunner);
 			module.setQueryFactory(QuerydslQueryFactory.newInstance());

--- a/crnk-jpa/src/test/java/io/crnk/jpa/query/AbstractJpaTest.java
+++ b/crnk-jpa/src/test/java/io/crnk/jpa/query/AbstractJpaTest.java
@@ -8,6 +8,7 @@ import io.crnk.core.engine.registry.DefaultResourceRegistryPart;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.engine.url.ConstantServiceUrlProvider;
 import io.crnk.core.module.ModuleRegistry;
+import io.crnk.core.module.discovery.EmptyServiceDiscovery;
 import io.crnk.jpa.JpaModule;
 import io.crnk.jpa.meta.JpaMetaProvider;
 import io.crnk.jpa.model.*;
@@ -102,6 +103,7 @@ public abstract class AbstractJpaTest {
 		moduleRegistry.addModule(new JacksonModule(new ObjectMapper()));
 		moduleRegistry.addModule(new CoreModule());
 		moduleRegistry.addModule(module);
+		moduleRegistry.setServiceDiscovery(new EmptyServiceDiscovery());
 		moduleRegistry.init(new ObjectMapper());
 
 		queryFactory = createQueryFactory(em);

--- a/crnk-jpa/src/test/java/io/crnk/jpa/repository/JpaRelationshipRepositoryTestBase.java
+++ b/crnk-jpa/src/test/java/io/crnk/jpa/repository/JpaRelationshipRepositoryTestBase.java
@@ -1,5 +1,6 @@
 package io.crnk.jpa.repository;
 
+import io.crnk.core.engine.information.resource.ResourceField;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -32,9 +33,16 @@ public abstract class JpaRelationshipRepositoryTestBase extends AbstractJpaTest 
 	@Before
 	public void setup() {
 		super.setup();
-		repo = new JpaRelationshipRepository<TestEntity, Long, RelatedEntity, Long>(module, TestEntity.class,
+
+		ResourceField resourceField = this.resourceRegistry.getEntry(TestEntity.class).getResourceInformation()
+				.findFieldByUnderlyingName("oneRelatedValue");
+
+		ResourceField relatedField = this.resourceRegistry.getEntry(RelatedEntity.class).getResourceInformation()
+				.findFieldByUnderlyingName("testEntity");
+
+		repo = new JpaRelationshipRepository<TestEntity, Long, RelatedEntity, Long>(module, resourceField,
 				JpaRepositoryConfig.create(RelatedEntity.class));
-		relatedRepo = new JpaRelationshipRepository<RelatedEntity, Long, TestEntity, Long>(module, RelatedEntity.class,
+		relatedRepo = new JpaRelationshipRepository<RelatedEntity, Long, TestEntity, Long>(module, relatedField,
 				JpaRepositoryConfig.create(TestEntity.class));
 	}
 

--- a/crnk-meta/src/main/java/io/crnk/meta/model/MetaAttribute.java
+++ b/crnk-meta/src/main/java/io/crnk/meta/model/MetaAttribute.java
@@ -172,13 +172,13 @@ public class MetaAttribute extends MetaElement {
 		this.version = version;
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void addValue(Object dataObject, Object value) {
 		Collection col = (Collection) getValue(dataObject);
 		col.add(value);
 	}
 
-	@SuppressWarnings({"rawtypes"})
+	@SuppressWarnings({ "rawtypes" })
 	public void removeValue(Object dataObject, Object value) {
 		Collection col = (Collection) getValue(dataObject);
 		col.remove(value);

--- a/crnk-meta/src/test/java/io/crnk/meta/model/MetaKeyTest.java
+++ b/crnk-meta/src/test/java/io/crnk/meta/model/MetaKeyTest.java
@@ -39,6 +39,12 @@ public class MetaKeyTest extends AbstractMetaTest {
 	}
 
 
+	@Test
+	public void testToKeyStringWithNull() {
+		MetaKey key = new MetaKey();
+		Assert.assertNull(key.toKeyString(null));
+	}
+
 	public static class SomePrimaryKey {
 
 		private String attr1;

--- a/crnk-security/src/test/java/io/crnk/security/SecurityModuleTest.java
+++ b/crnk-security/src/test/java/io/crnk/security/SecurityModuleTest.java
@@ -9,6 +9,7 @@ import io.crnk.core.engine.security.SecurityProvider;
 import io.crnk.core.exception.ResourceNotFoundException;
 import io.crnk.core.module.ModuleRegistry;
 import io.crnk.core.module.SimpleModule;
+import io.crnk.core.module.discovery.EmptyServiceDiscovery;
 import io.crnk.security.SecurityConfig.Builder;
 import io.crnk.security.model.Project;
 import io.crnk.security.model.ProjectRepository;
@@ -56,6 +57,7 @@ public class SecurityModuleTest {
 		Assert.assertSame(config, securityModule.getConfig());
 
 		ModuleRegistry moduleRegistry = new ModuleRegistry();
+		moduleRegistry.setServiceDiscovery(new EmptyServiceDiscovery());
 		moduleRegistry.setResourceRegistry(new ResourceRegistryImpl(new DefaultResourceRegistryPart(), moduleRegistry));
 		moduleRegistry.addModule(securityModule);
 		moduleRegistry.addModule(appModule);

--- a/crnk-test/src/main/java/io/crnk/test/mock/repository/TaskToProjectRepository.java
+++ b/crnk-test/src/main/java/io/crnk/test/mock/repository/TaskToProjectRepository.java
@@ -19,6 +19,10 @@ public class TaskToProjectRepository implements RelationshipRepositoryV2<Task, L
 		THREAD_LOCAL_REPOSITORY.clear();
 	}
 
+	public TaskToProjectRepository(){
+
+	}
+
 	@Override
 	public void setRelation(Task source, Long targetId, String fieldName) {
 		removeRelations(fieldName);


### PR DESCRIPTION
- RelationshipRepositoryV2.getMatcher as default method introduced
- refactoring of CrnkBoot to properly make use of InformationBuilder
- updated documentation
