### PR TITLE
Angular binding improvements #252

### DIFF
--- a/crnk-client-angular-ngrx/binding/crnk.binding.table.js
+++ b/crnk-client-angular-ngrx/binding/crnk.binding.table.js
@@ -43,12 +43,12 @@ var DataTableBinding = (function () {
 			for (var _i = 0, _a = event.multiSortMeta; _i < _a.length; _i++) {
 				var sortMeta = _a[_i];
 				var direction = sortMeta.order == -1 ? jsonapi_1.Direction.DESC : jsonapi_1.Direction.ASC;
-				sorting.push({direction: direction, api: this.utils.toSearchPath(sortMeta.field)});
+				sorting.push({direction: direction, api: this.utils.toQueryPath(sortMeta.field)});
 			}
 		}
 		else if (event.sortField) {
 			var direction = event.sortOrder == -1 ? jsonapi_1.Direction.DESC : jsonapi_1.Direction.ASC;
-			sorting.push({direction: direction, api: this.utils.toSearchPath(event.sortField)});
+			sorting.push({direction: direction, api: this.utils.toQueryPath(event.sortField)});
 		}
 		if (event.filters) {
 			for (var filterKey in event.filters) {
@@ -61,12 +61,12 @@ var DataTableBinding = (function () {
 				if (matchMode == 'like') {
 					value = '%' + value + '%';
 				}
-				var attributePath = this.utils.toSearchPath(filterKey);
+				var attributePath = this.utils.toQueryPath(filterKey);
 				filters.push({value: value, path: attributePath, operator: matchMode});
 			}
 		}
 		var query = _.cloneDeep(this.config.query);
-		this.utils.applyQueryParams(query, {
+		this.utils.updateQueryParams(query, {
 			limit: limit,
 			offset: offset,
 			include: includes,

--- a/crnk-client-angular-ngrx/binding/crnk.binding.table.ts
+++ b/crnk-client-angular-ngrx/binding/crnk.binding.table.ts
@@ -1,5 +1,5 @@
-import {Subject} from 'rxjs/Subject';
-import {Observable} from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import { Observable } from 'rxjs/Observable';
 import * as _ from 'lodash';
 import 'rxjs/add/operator/zip';
 import 'rxjs/add/operator/do';
@@ -14,12 +14,39 @@ import {
 	Query,
 	Resource,
 	SortingParam,
-	NgrxJsonApiZoneService, NGRX_JSON_API_DEFAULT_ZONE, getNgrxJsonApiZone, selectNgrxJsonApiZone
+	NgrxJsonApiZoneService, NGRX_JSON_API_DEFAULT_ZONE, getNgrxJsonApiZone, selectNgrxJsonApiZone, QueryParams
 } from 'ngrx-json-api';
-import {CrnkBindingUtils} from './crnk.binding.utils';
+import { CrnkBindingUtils, toQueryPath } from './crnk.binding.utils';
 // TODO get rid of this? or support multiple ones, only dependency to primeng here...
-import {LazyLoadEvent} from 'primeng/primeng';
-import {Store} from '@ngrx/store';
+import { LazyLoadEvent } from 'primeng/primeng';
+import { Store } from '@ngrx/store';
+import { Subscription } from 'rxjs/Subscription';
+
+export interface DataTableImplementationContext {
+
+	/**
+	 * applies the given query parameters
+	 *
+	 * @param {QueryParams} param
+	 */
+	applyQueryParams(param: QueryParams);
+
+}
+
+export interface DataTableImplementationAdapter {
+
+	/**
+	 * Called on startup and provides access to interface with binding implementation.
+	 *
+	 * @param {DataTableImplementationContext} context
+	 */
+	init(context: DataTableImplementationContext);
+
+	/**
+	 * @param event called by table implementation to update the query
+	 */
+	onLazyLoad(event);
+}
 
 export interface DataTableBindingConfig {
 
@@ -36,31 +63,53 @@ export interface DataTableBindingConfig {
 	 * Zone to use within ngrx-json-api.
 	 */
 	zoneId?: string;
+
+	/**
+	 * Table implementation to use, currently the PrimeNG DataTable is supported out-of-the-box.
+	 */
+	implementationAdapter?: DataTableImplementationAdapter;
+
+	/**
+	 * Additional query parameters (sorting, filtering, etc.) that will be applied to the query.
+	 * As long as the observable emits no value, it is ignored. No waiting takes place.
+	 */
+	customQueryParams?: Observable<QueryParams>;
 }
 
 export class DataTableBinding {
 
 	public result$: Observable<ManyQueryResult>;
 
-	public resultSubject$: Subject<ManyQueryResult> = new Subject();
-
-	public selectedResource: Resource;
-
 	private baseQuery: Query = null;
 
 	private latestQuery: Query = null;
 
-	private num = 0;
+	private latestImplementationQueryParams: QueryParams = null;
+
+	private latestExternalQueryParams: QueryParams = null;
+
+	public implementationAdapter: DataTableImplementationAdapter;
+
+	private customQueryParamsSubscription: Subscription;
+
+	private zoneId: string;
 
 	public readonly zone: NgrxJsonApiZoneService;
 
 	constructor(ngrxJsonApiService: NgrxJsonApiService, private config: DataTableBindingConfig,
-		private utils: CrnkBindingUtils, store: Store<any>
+		private utils: CrnkBindingUtils, private store: Store<any>
 	) {
 
-		const zoneId = config.zoneId || NGRX_JSON_API_DEFAULT_ZONE;
-		this.zone = ngrxJsonApiService.getZone(zoneId);
-		this.result$ = this.resultSubject$.asObservable();
+		this.zoneId = config.zoneId || NGRX_JSON_API_DEFAULT_ZONE;
+		this.zone = ngrxJsonApiService.getZone(this.zoneId);
+
+		this.implementationAdapter = this.config.implementationAdapter;
+		if (!this.implementationAdapter) {
+			this.implementationAdapter = new DataTablePrimengAdapter();
+		}
+		this.implementationAdapter.init({
+			applyQueryParams: implementationParams => this.setImplementationQueryParams(implementationParams)
+		});
 
 		if (!this.config.queryId) {
 			throw new Error('no queryId specified in config');
@@ -68,52 +117,149 @@ export class DataTableBinding {
 		if (_.isUndefined(this.config.fromServer)) {
 			this.config.fromServer = true;
 		}
-		this.baseQuery = this.config.baseQuery;
 
-		store.let(selectNgrxJsonApiZone(zoneId)).take(1)
-			.map(it => it.queries[this.config.queryId])
-			.subscribe(storeQuery => {
-				if (storeQuery != null) {
-					this.latestQuery = storeQuery.query;
-					this.baseQuery = storeQuery.query;
-				}
-			});
-
-		if (!this.baseQuery) {
-			throw new Error('baseQuery not available');
-		}
+		this.initBaseQuery();
 
 		this.result$ = this.zone
 			.selectManyResults(this.config.queryId, true)
-			.do(it => {
-				if (this.baseQuery === null) {
-					this.baseQuery = it.query;
-					this.latestQuery = it.query;
-				}
-			})
-			.map(result => {
-				// query not available until load event trigger by PrimeNG
-				// return empty object in that case
-				if (result) {
-					return result;
-				}
-				else {
-					const emptyResult: ManyQueryResult = {
-						query: null,
-						loading: false,
-						resultIds: [],
-						meta: {},
-						links: {},
-						data: [],
-						errors: []
-					};
-					return emptyResult;
-				}
+			.do(this.setBaseQueryIfNecessary)
+			.map(this.guardAgainstEmptyQuery)
+			.finally(() => this.cancelSubscriptions)
+			.share();
+	}
+
+
+	private checkSubscriptions() {
+		if (!this.customQueryParamsSubscription && this.config.customQueryParams) {
+			this.customQueryParamsSubscription = this.config.customQueryParams.subscribe(customQueryParams => {
+				this.latestExternalQueryParams = customQueryParams;
+				this.updateQueryParams();
 			});
+		}
+	}
+
+	private cancelSubscriptions() {
+		if (this.customQueryParamsSubscription !== null) {
+			this.customQueryParamsSubscription.unsubscribe();
+			this.customQueryParamsSubscription = null;
+		}
+	}
+
+	private initBaseQuery() {
+		this.baseQuery = this.config.baseQuery;
+		if (!this.baseQuery) {
+			this.store.let(selectNgrxJsonApiZone(this.zoneId)).take(1)
+				.map(it => it.queries[this.config.queryId])
+				.subscribe(storeQuery => {
+					if (storeQuery != null) {
+						this.latestQuery = storeQuery.query;
+						this.baseQuery = storeQuery.query;
+					}
+				});
+		}
+		if (!this.baseQuery) {
+			throw new Error('baseQuery not available');
+		}
+	}
+
+	private setBaseQueryIfNecessary(result: ManyQueryResult) {
+		if (this.baseQuery === null) {
+			this.baseQuery = result.query;
+			this.latestQuery = result.query;
+		}
+	}
+
+	private guardAgainstEmptyQuery(result: ManyQueryResult): ManyQueryResult {
+		// query not available until load event trigger by PrimeNG
+		// return empty object in that case
+		if (result) {
+			return result;
+		}
+		else {
+			const emptyResult: ManyQueryResult = {
+				query: null,
+				loading: false,
+				resultIds: [],
+				meta: {},
+				links: {},
+				data: [],
+				errors: []
+			};
+			return emptyResult;
+		}
 	}
 
 	public refresh() {
 		this.zone.refreshQuery(this.config.queryId);
+	}
+
+	private setImplementationQueryParams(implementationParams: QueryParams) {
+		this.checkSubscriptions();
+		this.latestImplementationQueryParams = implementationParams;
+		this.updateQueryParams();
+	}
+
+	private updateQueryParams() {
+		if (!this.latestImplementationQueryParams) {
+			// implementation not ready yet, wait
+			// note that custom parameters are optional and no waiting takes palce
+			return;
+		}
+		if (!this.baseQuery) {
+			throw new Error('illegal state, base query not available');
+		}
+
+		const query = _.cloneDeep(this.baseQuery);
+
+		if (this.latestExternalQueryParams) {
+			this.utils.applyQueryParams(query, this.latestExternalQueryParams);
+		}
+		this.utils.applyQueryParams(query, this.latestImplementationQueryParams);
+
+		if (!_.isEqual(query, this.latestQuery)) {
+			this.zone.putQuery({
+					query: query,
+					fromServer: this.config.fromServer
+				}
+			);
+			this.latestQuery = query;
+		}
+
+	}
+
+	public onLazyLoad(event) {
+		this.implementationAdapter.onLazyLoad(event);
+	}
+}
+
+/**
+ * Maps an filter input value to a JSON API filter value.
+ */
+export interface DataFilterValueMapper {
+
+	mapFilterValue(attributePath: string, operator: string, value);
+}
+
+export class DefaultDataFilterValueMapper implements DataFilterValueMapper {
+
+	mapFilterValue(attributePath: string, operator: string, value) {
+		if (operator === 'like') {
+			return '%' + value + '%';
+		}
+		return value;
+	}
+}
+
+export class DataTablePrimengAdapter implements DataTableImplementationAdapter {
+
+	private context: DataTableImplementationContext;
+
+	public defaultMatchMode = 'like';
+
+	public filterValueMapper: DataFilterValueMapper = new DefaultDataFilterValueMapper();
+
+	public init(context: DataTableImplementationContext) {
+		this.context = context;
 	}
 
 	public onLazyLoad(event: LazyLoadEvent) {
@@ -126,51 +272,33 @@ export class DataTableBinding {
 		if (event.multiSortMeta) {
 			for (const sortMeta of event.multiSortMeta) {
 				const direction = sortMeta.order === -1 ? Direction.DESC : Direction.ASC;
-				sorting.push({direction: direction, api: this.utils.toSearchPath(sortMeta.field)});
+				sorting.push({ direction: direction, api: toQueryPath(sortMeta.field) });
 			}
 		}
 		else if (event.sortField) {
 			const direction = event.sortOrder === -1 ? Direction.DESC : Direction.ASC;
-			sorting.push({direction: direction, api: this.utils.toSearchPath(event.sortField)});
+			sorting.push({ direction: direction, api: toQueryPath(event.sortField) });
 		}
 		if (event.filters) {
 			for (const filterKey of Object.keys(event.filters)) {
+				const attributePath = toQueryPath(filterKey);
 				const filterMeta = event.filters[filterKey];
 				let matchMode = filterMeta.matchMode;
-				let value = filterMeta.value;
+				const value = filterMeta.value;
 				if (!matchMode) {
-					matchMode = 'like';
+					matchMode = this.defaultMatchMode;
 				}
-				if (matchMode === 'like') {
-					value = '%' + value + '%';
-				}
-				const attributePath = this.utils.toSearchPath(filterKey);
-				filters.push({value: value, path: attributePath, operator: matchMode});
+				const mappedValue = this.filterValueMapper.mapFilterValue(attributePath, matchMode, value);
+				filters.push({ value: mappedValue, path: attributePath, operator: matchMode });
 			}
 		}
 
-		if (!this.baseQuery) {
-			throw new Error('illegal state, base query not available');
-		}
-
-		const query = _.cloneDeep(this.baseQuery);
-		this.utils.applyQueryParams(query, {
+		this.context.applyQueryParams({
 			limit: limit,
 			offset: offset,
 			include: includes,
 			sorting: sorting,
 			filtering: filters
 		});
-
-		this.num++;
-
-		if (!_.isEqual(query, this.latestQuery)) {
-			this.zone.putQuery({
-					query: query,
-					fromServer: this.config.fromServer
-				}
-			);
-			this.latestQuery = query;
-		}
 	}
 }

--- a/crnk-client-angular-ngrx/binding/crnk.binding.utils.ts
+++ b/crnk-client-angular-ngrx/binding/crnk.binding.utils.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import { Injectable } from '@angular/core';
 import 'rxjs/add/operator/zip';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/debounceTime';
@@ -17,8 +17,9 @@ import {
 } from 'ngrx-json-api';
 
 import * as _ from 'lodash';
-import {Observable} from 'rxjs/Observable';
-import {Store} from '@ngrx/store';
+import { Observable } from 'rxjs/Observable';
+import { Store } from '@ngrx/store';
+import { Expression } from '../expression';
 
 
 export const getNgrxJsonApiStore$ = function (state$: Store<any>): Observable<NgrxJsonApiStore> {
@@ -45,6 +46,69 @@ export const assumeNoError = function () {
 	};
 };
 
+export const applyQueryParams = function (query: Query, params: QueryParams) {
+	if (!query.params) {
+		query.params = {};
+	}
+
+	query.params.limit = params.limit;
+	query.params.offset = params.offset;
+	if (!_.isEmpty(params.include)) {
+		if (!query.params.include) {
+			query.params.include = [];
+		}
+		query.params.include.push(...params.include);
+	}
+	if (!_.isEmpty(params.fields)) {
+		if (!query.params.fields) {
+			query.params.fields = [];
+		}
+		query.params.fields.push(...params.fields);
+	}
+	if (!_.isEmpty(params.sorting)) {
+		if (!query.params.sorting) {
+			query.params.sorting = [];
+		}
+		query.params.sorting.push(...params.sorting);
+	}
+	if (!_.isEmpty(params.filtering)) {
+		if (!query.params.filtering) {
+			query.params.filtering = [];
+		}
+		query.params.filtering.push(...params.filtering);
+	}
+};
+
+export const toQueryPath = function (attributePath: string | Expression<any>): string {
+	const strAttributePath = attributePath.toString();
+
+	const pathElements = strAttributePath.split('.');
+
+	const searchPath = [];
+
+	for (let i = 0; i < pathElements.length; i++) {
+		if (pathElements[i] === 'attributes') {
+			// nothing to do
+		}
+		else if (pathElements[i] === 'relationships' && i < pathElements.length - 2) {
+			const relationshipName = pathElements[i + 1];
+			const dataType = pathElements[i + 2];
+			if (dataType === 'data' || dataType === 'reference') {
+				searchPath.push(relationshipName);
+				i += 2;
+			}
+			else {
+				throw new Error('cannot map relationship path in ' + attributePath + ', got ' + dataType +
+					' but expected data or reference');
+			}
+		}
+		else {
+			searchPath.push(pathElements[i]);
+		}
+	}
+	return _.join(searchPath, '.');
+};
+
 export class QueryError extends Error {
 
 	constructor(public errors: Array<ResourceError>) {
@@ -57,7 +121,7 @@ export class CrnkBindingUtils {
 
 
 	public toResourceIdentifier(resource: StoreResource): ResourceIdentifier {
-		return {type: resource.type, id: resource.id};
+		return { type: resource.type, id: resource.id };
 	};
 
 	public toResourceIdentifiers(resources: Array<StoreResource>): Array<ResourceIdentifier> {
@@ -69,59 +133,12 @@ export class CrnkBindingUtils {
 	}
 
 	public applyQueryParams(query: Query, params: QueryParams) {
-		if (!query.params) {
-			query.params = {};
-		}
-
-		query.params.limit = params.limit;
-		query.params.offset = params.offset;
-		if (!_.isEmpty(params.include)) {
-			if (!query.params.include) {
-				query.params.include = [];
-			}
-			query.params.include.push(...params.include);
-		}
-		if (!_.isEmpty(params.sorting)) {
-			if (!query.params.sorting) {
-				query.params.sorting = [];
-			}
-			query.params.sorting.push(...params.sorting);
-		}
-		if (!_.isEmpty(params.filtering)) {
-			if (!query.params.filtering) {
-				query.params.filtering = [];
-			}
-			query.params.filtering.push(...params.filtering);
-		}
+		return applyQueryParams(query, params);
 	}
 
 
-	public toSearchPath(attributePath: string) {
-		const pathElements = attributePath.split('.');
-
-		const searchPath = [];
-
-		for (let i = 0; i < pathElements.length; i++) {
-			if (pathElements[i] === 'attributes') {
-				// nothing to do
-			}
-			else if (pathElements[i] === 'relationships' && i < pathElements.length - 2) {
-				const relationshipName = pathElements[i + 1];
-				const dataType = pathElements[i + 2];
-				if (dataType === 'data' || dataType === 'reference') {
-					searchPath.push(relationshipName);
-					i += 2;
-				}
-				else {
-					throw new Error('cannot map relationship path in ' + attributePath + ', got ' + dataType +
-						' but expected data or reference');
-				}
-			}
-			else {
-				searchPath.push(pathElements[i]);
-			}
-		}
-		return _.join(searchPath, '.');
+	public toSearchPath(attributePath: string | Expression<any>) {
+		return toQueryPath(attributePath);
 	}
 
 }

--- a/crnk-client-angular-ngrx/expression/crnk.expression.ts
+++ b/crnk-client-angular-ngrx/expression/crnk.expression.ts
@@ -8,6 +8,8 @@
  *     <li>{@link Path}: property member access</li>
  * </ul>
  */
+import { toQueryPath } from '../binding';
+
 export interface Expression<T> {
 
 	/**
@@ -69,6 +71,10 @@ export interface Path<T> extends Expression<T> {
 	 */
 	getSourcePointer(): String;
 
+	/**
+	 * @returns {string} path used for sorting and filtering (excludes any 'relationships' and 'attributes' in the path)
+	 */
+	toQueryPath(): string;
 }
 
 export const OPERATION_EQ = 'EQ';
@@ -225,9 +231,6 @@ export class BooleanConstant extends BooleanExpression implements Constant<boole
 }
 
 
-
-
-
 function toSourcePointerInternal(path: string, resource: any) {
 	if (resource !== null) {
 		return '/data/' + path.replace(new RegExp('\\.', 'g'), '/');
@@ -339,6 +342,10 @@ export class BeanPath<T> extends SimpleExpression<T> implements Path<T> {
 	getSourcePointer(): string {
 		return toSourcePointerInternal(this.toString(), this.parentPath.getResource());
 	}
+
+	toQueryPath(): string {
+		return toQueryPath(this.toString());
+	}
 }
 
 
@@ -382,6 +389,10 @@ export class StringPath extends StringExpression implements Path<string> {
 
 	getSourcePointer(): string {
 		return toSourcePointerInternal(this.toString(), this.parent.getResource());
+	}
+
+	toQueryPath(): string {
+		return toQueryPath(this.toString());
 	}
 }
 
@@ -453,6 +464,10 @@ export class NumberPath extends NumberExpression implements Path<number> {
 	getSourcePointer(): string {
 		return toSourcePointerInternal(this.toString(), this.parent.getResource());
 	}
+
+	toQueryPath(): string {
+		return toQueryPath(this.toString());
+	}
 }
 
 
@@ -496,6 +511,10 @@ export class BooleanPath extends BooleanExpression implements Path<boolean> {
 
 	getSourcePointer(): string {
 		return toSourcePointerInternal(this.toString(), this.parent.getResource());
+	}
+
+	toQueryPath(): string {
+		return toQueryPath(this.toString());
 	}
 }
 

--- a/crnk-client-angular-ngrx/meta/meta.element.ts
+++ b/crnk-client-angular-ngrx/meta/meta.element.ts
@@ -43,9 +43,6 @@ export class QMetaElement extends BeanPath<MetaElement> {
 	attributes: QMetaElement.QAttributes = new QMetaElement.QAttributes(this, 'attributes');
 }
 export module QMetaElement {
-	export class QAttributes extends BeanPath<MetaElement.Attributes> {
-		name: StringPath = this.createString('name');
-	}
 	export class QRelationships extends BeanPath<MetaElement.Relationships> {
 		private _parent: QTypedOneResourceRelationship<QMetaElement, MetaElement>;
 		get parent(): QTypedOneResourceRelationship<QMetaElement, MetaElement> {
@@ -63,6 +60,9 @@ export module QMetaElement {
 			}
 			return this._children;
 		};
+	}
+	export class QAttributes extends BeanPath<MetaElement.Attributes> {
+		name: StringPath = this.createString('name');
 	}
 }
 export let createEmptyMetaElement = function(id: string): MetaElement {

--- a/crnk-client-angular-ngrx/test/crnk.binding.form.spec.ts
+++ b/crnk-client-angular-ngrx/test/crnk.binding.form.spec.ts
@@ -21,7 +21,6 @@ describe('FormBinding', () => {
 			imports: [TestingModule],
 			declarations: [TestEditorComponent]
 		}).compileComponents();
-
 	}));
 
 

--- a/crnk-client-angular-ngrx/test/crnk.binding.table.spec.ts
+++ b/crnk-client-angular-ngrx/test/crnk.binding.table.spec.ts
@@ -1,12 +1,13 @@
-import {async, ComponentFixture, fakeAsync, getTestBed, TestBed, tick} from '@angular/core/testing';
+import { async, ComponentFixture, fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
 
-import "rxjs/add/operator/merge";
-import {Store} from '@ngrx/store';
-import {LocalQueryInitAction, NewStoreResourceAction, NgrxJsonApiService, NgrxJsonApiStore} from "ngrx-json-api";
-import {By} from "@angular/platform-browser";
-import {TestingModule} from "./crnk.test.module";
-import {TestTableComponent} from "./crnk.test.table.component";
-import {DataTableModule} from "primeng/primeng";
+import 'rxjs/add/operator/merge';
+import { Store } from '@ngrx/store';
+import { LocalQueryInitAction, NewStoreResourceAction, NgrxJsonApiService, NgrxJsonApiStore, QueryParams } from 'ngrx-json-api';
+import { By } from '@angular/platform-browser';
+import { TestingModule } from './crnk.test.module';
+import { TestTableComponent } from './crnk.test.table.component';
+import { DataTableModule } from 'primeng/primeng';
+import { Observable } from 'rxjs/Observable';
 
 
 describe('TableBinding', () => {
@@ -55,15 +56,13 @@ describe('TableBinding', () => {
 		fixture.detectChanges();
 		tick();
 
-
-
-		let cellElements = fixture.debugElement.queryAll(By.css(".ui-cell-data"));
+		let cellElements = fixture.debugElement.queryAll(By.css('.ui-cell-data'));
 		expect(cellElements.length).toEqual(2);
-		expect(cellElements[0].nativeElement.textContent).toEqual("SomeAttribute1");
-		expect(cellElements[1].nativeElement.textContent).toEqual("SomeAttribute2");
+		expect(cellElements[0].nativeElement.textContent).toEqual('SomeAttribute1');
+		expect(cellElements[1].nativeElement.textContent).toEqual('SomeAttribute2');
 
-		let filterElement = fixture.debugElement.query(By.css(".ui-column-filter"));
-		filterElement.nativeElement.value = "SomeAttribute1";
+		let filterElement = fixture.debugElement.query(By.css('.ui-column-filter'));
+		filterElement.nativeElement.value = 'SomeAttribute1';
 		filterElement.nativeElement.dispatchEvent(new Event('input'));
 		fixture.detectChanges();
 		tick(500);
@@ -82,5 +81,45 @@ describe('TableBinding', () => {
 		// expect(cellElements.length).toEqual(1);
 		// expect(cellElements[0].nativeElement.textContent).toEqual("SomeAttribute1");
 
+	}));
+
+	it('should apply custom query params', fakeAsync(() => {
+		const config = fixture.componentInstance.config;
+		const customQueryParams: QueryParams = {
+			fields: ['testField']
+		}
+		config.customQueryParams = Observable.of(customQueryParams)
+
+		fixture.detectChanges();
+		tick();
+
+		// check custom params applied from start
+		let snapshot = jsonapi['storeSnapshot'] as NgrxJsonApiStore;
+		let querySnapshot = snapshot.queries['tableQuery'];
+		let appliedParams = querySnapshot.query.params;
+		expect(appliedParams.offset).toEqual(0);
+		expect(appliedParams.limit).toEqual(10);
+		expect(appliedParams.fields.length).toEqual(1);
+		expect(appliedParams.fields[0]).toEqual('testField');
+		expect(appliedParams.filtering).toBeUndefined();
+
+		let filterElement = fixture.debugElement.query(By.css('.ui-column-filter'));
+		filterElement.nativeElement.value = 'SomeAttribute1';
+		filterElement.nativeElement.dispatchEvent(new Event('input'));
+		fixture.detectChanges();
+		tick(500);
+
+		// check custom params with table params
+		snapshot = jsonapi['storeSnapshot'] as NgrxJsonApiStore;
+		querySnapshot = snapshot.queries['tableQuery'];
+		appliedParams = querySnapshot.query.params;
+		expect(appliedParams.offset).toEqual(0);
+		expect(appliedParams.limit).toEqual(10);
+		expect(appliedParams.fields.length).toEqual(1);
+		expect(appliedParams.fields[0]).toEqual('testField');
+		expect(appliedParams.filtering.length).toEqual(1);
+		expect(appliedParams.filtering[0].path).toEqual('name');
+		expect(appliedParams.filtering[0].operator).toEqual('exact');
+		expect(appliedParams.filtering[0].value).toEqual('SomeAttribute1');
 	}));
 });

--- a/crnk-client-angular-ngrx/test/crnk.expression.spec.ts
+++ b/crnk-client-angular-ngrx/test/crnk.expression.spec.ts
@@ -37,6 +37,7 @@ describe('Expression', () => {
 		expect(qbean.relationships.type.data.id.getValue()).toBe('testId');
 		expect(qbean.relationships.type.data.type.getValue()).toBe('testType');
 		expect(qbean.relationships.type.reference.attributes.name.getValue()).toBe('testName');
+		expect(qbean.relationships.type.reference.attributes.name.toQueryPath()).toBe('type.name');
 	});
 
 	it('should update bean', () => {

--- a/crnk-client-angular-ngrx/test/crnk.test.editor.component.html
+++ b/crnk-client-angular-ngrx/test/crnk.test.editor.component.html
@@ -1,7 +1,11 @@
 <form #formRef="ngForm">
 	<div *ngIf="resource != null">
 
-		<input id="nameInput" required [crnkFormExpression]="resource.attributes.name"/>
+		<div>
+			{{binding.unmappedErrors | json}}
+		</div>
+
+		<input id="nameInput" required [crnkFormExpression]="resource.attributes.name" />
 
 		<div id="valid">{{binding.valid | async}}</div>
 		<div id="dirty">{{binding.dirty | async}}</div>

--- a/crnk-client-angular-ngrx/test/crnk.test.table.component.html
+++ b/crnk-client-angular-ngrx/test/crnk.test.table.component.html
@@ -1,7 +1,6 @@
-<div *ngIf="result != null">
+<div *ngIf="result | async as result">
 	<p-dataTable [value]="result.data"
 			     selectionMode="single"
-				 [(selection)]="binding.selectedResource"
 				 [lazy]="true" [rows]="10" [paginator]="true"
 				 (onLazyLoad)="binding.onLazyLoad($event)"
 				 (onRowDblclick)="open($event.data)"

--- a/crnk-client-angular-ngrx/test/crnk.test.table.component.ts
+++ b/crnk-client-angular-ngrx/test/crnk.test.table.component.ts
@@ -1,35 +1,32 @@
-import {Component, OnDestroy, OnInit} from '@angular/core';
-import {MetaAttributeListResult} from '../meta/meta.attribute';
-import {Subscription} from 'rxjs/Subscription';
-import {CrnkBindingService} from '../binding/crnk.binding.service';
-import {DataTableBinding} from '../binding/crnk.binding.table';
+import { Component, OnInit } from '@angular/core';
+import { MetaAttributeListResult } from '../meta/meta.attribute';
+import { CrnkBindingService } from '../binding/crnk.binding.service';
+import { DataTableBinding } from '../binding/crnk.binding.table';
+import { DataTableBindingConfig } from '../binding';
+import { Observable } from 'rxjs/Observable';
 
 @Component({
 	selector: 'test-table',
 	templateUrl: 'crnk.test.table.component.html'
 })
-export class TestTableComponent implements OnInit, OnDestroy {
+export class TestTableComponent implements OnInit {
 
-	binding: DataTableBinding;
+	public binding: DataTableBinding;
 
-	private subscription: Subscription;
+	public result: Observable<MetaAttributeListResult>;
 
-	public result: MetaAttributeListResult;
+	public config: DataTableBindingConfig = {
+		queryId: 'tableQuery',
+		fromServer: false
+	}
 
 	constructor(private bindingService: CrnkBindingService) {
 	}
 
 	ngOnInit() {
-		this.binding = this.bindingService.bindDataTable({
-			queryId: 'tableQuery',
-			fromServer: false
-		});
-		this.subscription = this.binding.result$.subscribe(
-			it => this.result = it as MetaAttributeListResult
+		this.binding = this.bindingService.bindDataTable(this.config);
+		this.result = this.binding.result$.map(
+			it => it as MetaAttributeListResult
 		);
-	}
-
-	ngOnDestroy() {
-		this.subscription.unsubscribe();
 	}
 }

--- a/crnk-documentation/src/docs/asciidoc/angular.adoc
+++ b/crnk-documentation/src/docs/asciidoc/angular.adoc
@@ -121,6 +121,8 @@ Note that:
 - `getResource` returns the object resp. resource backing the path.
 - `toFormName` computes a default (unique) form name for that path. The name is composed of the
   resource type, resource id and path to allow editing of multiple resources on the same screen.
+- `toQueryPath` constructs a path used for sorting and filtering. Such a path does not include any
+  `attributes`, `relationships` or `data` elements necessary to navigate through JSON API structures.
 - QMetaAttribute can also be constructed without a bean binding. In this case it can still
   be used to construct type-safe paths and call `toString`. This can be used, for example, to specify
   a field for a table column where only later multiple records will then be loaded and shown.
@@ -156,12 +158,17 @@ Working with forms and JSON API is the same for many use cases:
 - components have to update store values by dispatching appropriate actions
 - components may perform basic local validation. For example with the Angular `required` directive.
 - components may get server-side validation errors using the JSON API error format.
-- components may perform client-side validation within the store with effects. The JSON API
-  error mechanism can reused for this purpose. The `ModifyStoreResourceErrorsAction`
-  action  of `ngrx-json-api` can be triggered by a (validation) effect listing to value changes and makes arbitrarily
-  complex, client-side validation logic possible.
+- components may perform complex client-side validation using `@ngrx/effects`. JSON API is
+  well suited for this purpose. For example,  a (validation) effect can listen to value changes
+  in the store and trigger `ModifyStoreResourceErrorsAction` of `ngrx-json-api` when necessary.
+  That validation effect is free to perform any kind of validation logic cleanly decoupled
+  from the presentation component.
 
-There is a `FormBinding` class provided by `CrnkExpressionFormModule` that takes care of exactly this:
+The `FormBinding` class provided by `CrnkExpressionFormModule` can take care of exactly this.
+
+### Setup
+
+An example setup looks like:
 
 [source]
 .crnk.test.editor.component.ts
@@ -177,36 +184,84 @@ A template then looks like:
 include::../../../../crnk-client-angular-ngrx/test/crnk.test.editor.component.html[]
 ----
 
-Note that:
+The `FormBinding` takes a `FormBindingConfig` as parameter. The most important parameters
+are `queryId` and `form`. `queryId` specifies the `ngrx-json-api` query the form is bound to, typically
+a query retrieving a single resource. `form` is the `NgForm` instance to interface with the
+Angular form mechanisms. Additionally, `zoneId`  can specify in which `ngrx-json-api` zone the
+query is located.
 
-- It is fully type-safe.
-- It is compact.
-- There are two flavors to display errors. Only one is needed for a real application.
-  Usually `crnk-control-errors` is used and allows to display any `FormControl` validation issue,
-  either from a local validator or from the JSON API resource.
-  `crnk-resource-errors` is a standalone flavor that is not bound to any `FormControl` and displays
-  JSON API errors only. In both case a template must be specified how the error is rendered.
-  In case of multiple errors, the template is rendered multiple times. `errorCode` and `errorData`
-  are available as variable. `errorData` contains the full JSON API error object in case of
-  a JSON API error.
-- `FormBinding` does not push changes to the store as long as local validation (`required`, `min-length`, etc.)
-  do not pass.
-- `FormBinding` makes use of the form name to update the store. Therefore, the use of the expression model
-  is optional and applications can also continue making use of `ngModel` and `formControlName` where
-  appropriate. The name of form controls can follow to patterns: `//<type>//<id>//path` or just
-  `path``. The form allows to modify multiple resources, while the later assumes the primary
-  resource loaded by the query is being modified.
+
+### Updating Data
+
+`FormBinding` listens to value changes of the bound form and updates accordingly updates the store through `ngrx-json-api`
+actions. To have a mapping between JSON API resource fields and form controls, the later must follow a naming pattern.
+There are two possibilities for form control names:
+
+- `//<type>//<id>//path` to reference a field by the resource type, resource id and path within the resource, e.g.
+  `//person//13//attributes.name`.
+- just `path` to reference a field of the resource returned by the `ngrx-json-api` query, e.g. 'attributes.name.
+  The query must return a unique result for this to work.
+
+The `crnkFormExpression` directive from the previous section already supports the naming schema natively. Meaning that any
+component making use of it, does not have to specify a name, but it will be computed based on the passed expression.
+This allows for type-safe development and reduces some of the typical boiler-plate.
+
+Note that `FormBinding` does not push changes to the store as long as local validation (`required`, `min-length`, etc.)
+do not pass. Two fields give access to that status information:
+
 - `FormBinding.dirty` notifies whether bound resource(s) were modified.
 - `FormBinding.valid` notifies whether bound resource(s) are invalid.
+
+
+
+### Validation and Error handling
+
+`FormBinding` takes care of error handling. It maps back any JSON API errors back to the form controls of the
+configured form. Internally it matches the source pointers of JSON API errors against the form names (see previous section)
+to match errors with form control. The `FormBinding` has an `unmappedErrors` property that lists any JSON API error that could not be assigned to a specific form
+control instance, either because the matching instance does not exists or the JSON API error is not specific to given attribute
+but concerns the entire resource (like a conflict).
+
+There are two possibilities how to display errors:
+
+- Make use of the default Angular API and display the errors of the `FormControl` instances.
+- Access the JSON API errors from the store directly.
+
+There are two components for this purpose that work together with the expression model from the previous section. Both
+components take an expression as parameter:
+
+- `crnk-control-errors` retrieves the errors from the `FormControl` having been bound to the same expression. As a consequence,
+  it displays both local and JSON API errors.
+- `crnk-resource-errors` retrieves the JSON API error directory from the store. As such, it works independently of the forms
+  but can display JSON API errors only.
+
+In both case a template must be specified how the error is rendered. In case of multiple errors, the template is rendered
+multiple times. `errorCode` and `errorData`  are available as variable. `errorData` contains the full JSON API error
+in case of a JSON API error.
+
+
+
+
+### Roadmap and Open Issues
 
 The Angular `FormModule` gives a number of restrictions. In the future we expect to also support the use
 `FormBinding` without a `NgForm` instance (for some performance and simplicity benefits). Please
 provide feedback in this area of what is most helpful.
 
 
+WARNING: Intellij IDEA seems to have some issues when it comes to using the async pipe and code completion. For this
+ reason the current example makes use of a subscription and avoid the async pipe.
+
+
 ## Table Binding
 
-Similar to `FormBinding` there is a `TableBinding` class that looks like:
+Similar to `FormBinding` there is a `DataTableBinding` class. It can help
+taking care of interfacing a table component with JSON API.
+
+
+### Setup
+
+An example looks like:
 
 [source]
 .crnk.test.table.component.ts
@@ -222,11 +277,27 @@ and
 include::../../../../crnk-client-angular-ngrx/test/crnk.test.table.component.html[]
 ----
 
+`DataTableBinding` takes a `DataTableBindingConfig` as parameters to configure the binding.
+Most important is the `queryId` that allows to specify which `ngrx-json-api` query should be
+bound to the table. `zoneId` additionally can specify in which `ngrx-json-api` zone the query is located.
+
+### Usage
+
+`DataTableBinding`  makes use of a `DataTableImplementationAdapter` and offers a
+`onLazyLoad(...)` method to translate native event of the table implementation
+to JSON API query parameters and then updates the query in the store accordingly. The update of the store in turns
+triggers a refresh from the server and lets the table component get the new data through the `result$` variable
+of type `Observable<ManyQueryResult>`. `ManyQueryResult` holds, next to the resources, information about
+linking, meta data, loading state and errors.
+
 Note that:
 
-- Also type-safe with the generated `MetaAttributeListResult`.
-- It currently is limited to the PrimeNG `DataTable`, but PRs for other implementations are welcomed.
-- `TableBinding.onLazyLoad` translates PrimeNG query, sort and page parameters to JSON API parameters.
+- `DataTableBinding` supports the PrimeNG DataTable out-of-the-box with `DataTablePrimengAdapter`.
+  Other tables can be supported by implementing `DataTableImplementationAdapter` and passing it as
+  `DataTableBindingConfig.implementationAdapter`.
+- `DataTableBindingConfig.customQueryParams` allows to pass custom query parameters next to the one provided by the
+  table and initial query.
+- The example is fully type-safe with the generated `MetaAttributeListResult`.
 
 ## Meta Model
 


### PR DESCRIPTION
- update documentation
- allow to support tables other than primeng
- allow to add custom QueryParameters to the table binding (next to the one provided by the table)
- allow quick access to sort/filter parameter naming from expressions