### PR TITLE
Issue 256

### DIFF
--- a/crnk-client/src/main/java/io/crnk/client/CrnkClient.java
+++ b/crnk-client/src/main/java/io/crnk/client/CrnkClient.java
@@ -2,7 +2,6 @@ package io.crnk.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-
 import io.crnk.client.action.ActionStubFactory;
 import io.crnk.client.action.ActionStubFactoryContext;
 import io.crnk.client.http.HttpAdapter;
@@ -43,37 +42,31 @@ import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.engine.internal.utils.UrlUtils;
 import io.crnk.core.engine.properties.NullPropertiesProvider;
 import io.crnk.core.engine.properties.PropertiesProvider;
-import io.crnk.core.engine.registry.DefaultResourceRegistryPart;
-import io.crnk.core.engine.registry.RegistryEntry;
-import io.crnk.core.engine.registry.ResourceEntry;
-import io.crnk.core.engine.registry.ResourceRegistry;
-import io.crnk.core.engine.registry.ResponseRelationshipEntry;
+import io.crnk.core.engine.properties.SystemPropertiesProvider;
+import io.crnk.core.engine.registry.*;
 import io.crnk.core.engine.url.ConstantServiceUrlProvider;
 import io.crnk.core.engine.url.ServiceUrlProvider;
 import io.crnk.core.exception.InvalidResourceException;
 import io.crnk.core.module.Module;
 import io.crnk.core.module.ModuleRegistry;
-import io.crnk.core.module.discovery.ResourceLookup;
+import io.crnk.core.module.discovery.*;
 import io.crnk.core.module.internal.DefaultRepositoryInformationProviderContext;
 import io.crnk.core.queryspec.pagingspec.OffsetLimitPagingBehavior;
+import io.crnk.core.queryspec.pagingspec.PagingBehavior;
 import io.crnk.core.repository.RelationshipRepositoryV2;
 import io.crnk.core.repository.ResourceRepositoryV2;
 import io.crnk.core.resource.list.DefaultResourceList;
 import io.crnk.legacy.internal.DirectResponseRelationshipEntry;
 import io.crnk.legacy.internal.DirectResponseResourceEntry;
+import io.crnk.legacy.locator.JsonServiceLocator;
+import io.crnk.legacy.locator.SampleJsonServiceLocator;
 import io.crnk.legacy.registry.RepositoryInstanceBuilder;
 import io.crnk.legacy.repository.RelationshipRepository;
 
 import java.io.Serializable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
+import java.util.*;
 
 /**
  * Client implementation giving access to JSON API repositories using stubs.
@@ -101,6 +94,15 @@ public class CrnkClient {
 	private ActionStubFactory actionStubFactory;
 
 	private ClientDocumentMapper documentMapper;
+
+	private ServiceDiscovery serviceDiscovery;
+	private ServiceDiscoveryFactory serviceDiscoveryFactory = new DefaultServiceDiscoveryFactory();
+	private JsonServiceLocator serviceLocator = new SampleJsonServiceLocator();
+	private PropertiesProvider propertiesProvider = new SystemPropertiesProvider();
+	private Long defaultPageLimit = null;
+
+	private Long maxPageLimit = null;
+
 
 	private List<HttpAdapterProvider> httpAdapterProviders = new ArrayList<>();
 
@@ -131,6 +133,8 @@ public class CrnkClient {
 		moduleRegistry.getHttpRequestContextProvider().setServiceUrlProvider(serviceUrlProvider);
 		moduleRegistry.addModule(new ClientModule());
 
+		setupPagingBehavior();
+
 		resourceRegistry = new ClientResourceRegistry(moduleRegistry);
 		urlBuilder = new JsonApiUrlBuilder(resourceRegistry);
 
@@ -158,9 +162,47 @@ public class CrnkClient {
 		setProxyFactory(new BasicProxyFactory());
 	}
 
+	private void setupServiceDiscovery() {
+		if (serviceDiscovery == null) {
+			// revert to reflection-based approach if no ServiceDiscovery is
+			// found
+			FallbackServiceDiscoveryFactory fallback =
+					new FallbackServiceDiscoveryFactory(serviceDiscoveryFactory, serviceLocator, propertiesProvider);
+			setServiceDiscovery(fallback.getInstance());
+		}
+	}
+
+	public void setServiceDiscovery(ServiceDiscovery serviceDiscovery) {
+		PreconditionUtil.assertNull("already set", this.serviceDiscovery);
+		this.serviceDiscovery = serviceDiscovery;
+		moduleRegistry.setServiceDiscovery(serviceDiscovery);
+	}
+
+	private void setupPagingBehavior() {
+		if (moduleRegistry.getPagingBehaviors().isEmpty()) {
+			if (this.serviceDiscovery == null) setupServiceDiscovery();
+
+ 			moduleRegistry.addAllPagingBehaviors(serviceDiscovery.getInstancesByType(PagingBehavior.class));
+
+			if (moduleRegistry.getPagingBehaviors().isEmpty()) {
+				moduleRegistry.addPagingBehavior(new OffsetLimitPagingBehavior());
+			}
+		}
+
+		for (PagingBehavior pagingBehavior: moduleRegistry.getPagingBehaviors()) {
+			if (pagingBehavior instanceof OffsetLimitPagingBehavior) {
+				if (defaultPageLimit != null) {
+					((OffsetLimitPagingBehavior) pagingBehavior).setDefaultLimit(defaultPageLimit);
+				}
+				if (maxPageLimit != null) {
+					((OffsetLimitPagingBehavior) pagingBehavior).setMaxPageLimit(maxPageLimit);
+				}
+			}
+		}
+	}
+
 	private void initJacksonModule(final boolean serializeLinksAsObjects) {
-		moduleRegistry.addModule(new JacksonModule(objectMapper, serializeLinksAsObjects,
-				Collections.singletonList(new OffsetLimitPagingBehavior())));
+		moduleRegistry.addModule(new JacksonModule(objectMapper, serializeLinksAsObjects, moduleRegistry.getPagingBehaviors()));
 	}
 
 	/**

--- a/crnk-client/src/test/java/io/crnk/client/module/ClientModuleFactoryTest.java
+++ b/crnk-client/src/test/java/io/crnk/client/module/ClientModuleFactoryTest.java
@@ -1,12 +1,12 @@
 package io.crnk.client.module;
 
-import java.util.List;
-
 import io.crnk.client.CrnkClient;
 import io.crnk.core.engine.internal.jackson.JacksonModule;
 import io.crnk.core.module.Module;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.List;
 
 public class ClientModuleFactoryTest {
 

--- a/crnk-core/src/main/java/io/crnk/core/boot/CrnkBoot.java
+++ b/crnk-core/src/main/java/io/crnk/core/boot/CrnkBoot.java
@@ -298,9 +298,6 @@ public class CrnkBoot {
 					ClassUtils.getAnnotation(repository.getClass(), JsonApiRelationshipRepository.class).get();
 			module.addRepository(annotation.source(), annotation.target(), repository);
 		}
-		for (PagingBehavior pagingBehavior: moduleRegistry.getPagingBehaviors()){
-			module.addPagingBehavior(pagingBehavior);
-		}
 		moduleRegistry.addModule(module);
 		moduleRegistry.addModule(new CoreModule());
 	}

--- a/crnk-core/src/main/java/io/crnk/core/engine/information/resource/ResourceInformation.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/information/resource/ResourceInformation.java
@@ -7,25 +7,17 @@ import io.crnk.core.engine.document.Resource;
 import io.crnk.core.engine.document.ResourceIdentifier;
 import io.crnk.core.engine.internal.information.resource.DefaultResourceInstanceBuilder;
 import io.crnk.core.engine.internal.utils.ClassUtils;
+import io.crnk.core.engine.internal.utils.StringUtils;
 import io.crnk.core.engine.parser.StringMapper;
 import io.crnk.core.engine.parser.TypeParser;
-import io.crnk.core.exception.InvalidResourceException;
-import io.crnk.core.exception.MultipleJsonApiLinksInformationException;
-import io.crnk.core.exception.MultipleJsonApiMetaInformationException;
-import io.crnk.core.exception.ResourceDuplicateIdException;
-import io.crnk.core.exception.ResourceException;
+import io.crnk.core.exception.*;
 import io.crnk.core.queryspec.pagingspec.PagingBehavior;
 import io.crnk.core.resource.annotations.JsonApiResource;
+
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * Holds information about the type of the resource.
@@ -282,6 +274,18 @@ public class ResourceInformation {
 
 	public String getSuperResourceType() {
 		return superResourceType;
+	}
+
+	public String getResourcePath() {
+		JsonApiResource jsonApiResourceClass = getResourceClass().getAnnotation(JsonApiResource.class);
+		String resourcePath;
+		if (jsonApiResourceClass != null) {
+			resourcePath = StringUtils.isBlank(jsonApiResourceClass.resourcePath()) ? getResourceType() : jsonApiResourceClass.resourcePath();
+		}
+		else {
+			resourcePath = getResourceType();
+		}
+		return resourcePath;
 	}
 
 	public <T> ResourceInstanceBuilder<T> getInstanceBuilder() {

--- a/crnk-core/src/main/java/io/crnk/core/engine/information/resource/ResourceInformation.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/information/resource/ResourceInformation.java
@@ -7,17 +7,26 @@ import io.crnk.core.engine.document.Resource;
 import io.crnk.core.engine.document.ResourceIdentifier;
 import io.crnk.core.engine.internal.information.resource.DefaultResourceInstanceBuilder;
 import io.crnk.core.engine.internal.utils.ClassUtils;
-import io.crnk.core.engine.internal.utils.StringUtils;
 import io.crnk.core.engine.parser.StringMapper;
 import io.crnk.core.engine.parser.TypeParser;
-import io.crnk.core.exception.*;
+import io.crnk.core.exception.InvalidResourceException;
+import io.crnk.core.exception.MultipleJsonApiLinksInformationException;
+import io.crnk.core.exception.MultipleJsonApiMetaInformationException;
+import io.crnk.core.exception.ResourceDuplicateIdException;
+import io.crnk.core.exception.ResourceException;
 import io.crnk.core.queryspec.pagingspec.PagingBehavior;
 import io.crnk.core.resource.annotations.JsonApiResource;
 
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Holds information about the type of the resource.
@@ -274,18 +283,6 @@ public class ResourceInformation {
 
 	public String getSuperResourceType() {
 		return superResourceType;
-	}
-
-	public String getResourcePath() {
-		JsonApiResource jsonApiResourceClass = getResourceClass().getAnnotation(JsonApiResource.class);
-		String resourcePath;
-		if (jsonApiResourceClass != null) {
-			resourcePath = StringUtils.isBlank(jsonApiResourceClass.resourcePath()) ? getResourceType() : jsonApiResourceClass.resourcePath();
-		}
-		else {
-			resourcePath = getResourceType();
-		}
-		return resourcePath;
 	}
 
 	public <T> ResourceInstanceBuilder<T> getInstanceBuilder() {

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/DefaultResourceInformationProvider.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/DefaultResourceInformationProvider.java
@@ -58,7 +58,8 @@ public class DefaultResourceInformationProvider extends ResourceInformationProvi
 
 	@Override
 	public boolean accept(Class<?> resourceClass) {
-		return resourceClass.getAnnotation(JsonApiResource.class) != null;
+		JsonApiResource annotation = resourceClass.getAnnotation(JsonApiResource.class);
+		return annotation == null ? false : pagingBehaviors.values().stream().filter(pagingBehavior -> pagingBehavior.getClass().getName() == annotation.pagingBehavior().getName()).findFirst().isPresent();
 	}
 
 	@SuppressWarnings({"unchecked", "rawtypes"})

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/registry/ResourceRegistryImpl.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/registry/ResourceRegistryImpl.java
@@ -1,22 +1,17 @@
 package io.crnk.core.engine.internal.registry;
 
-import java.util.Collection;
-import java.util.concurrent.ConcurrentHashMap;
-
 import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.engine.internal.utils.UrlUtils;
-import io.crnk.core.engine.registry.RegistryEntry;
-import io.crnk.core.engine.registry.ResourceRegistry;
-import io.crnk.core.engine.registry.ResourceRegistryPart;
-import io.crnk.core.engine.registry.ResourceRegistryPartBase;
-import io.crnk.core.engine.registry.ResourceRegistryPartEvent;
-import io.crnk.core.engine.registry.ResourceRegistryPartListener;
+import io.crnk.core.engine.registry.*;
 import io.crnk.core.engine.url.ServiceUrlProvider;
 import io.crnk.core.exception.InvalidResourceException;
 import io.crnk.core.exception.RepositoryNotFoundException;
 import io.crnk.core.module.ModuleRegistry;
 import io.crnk.core.utils.Optional;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ResourceRegistryImpl extends ResourceRegistryPartBase implements ResourceRegistry {
 
@@ -105,7 +100,7 @@ public class ResourceRegistryImpl extends ResourceRegistryPartBase implements Re
 	@Override
 	public String getResourceUrl(ResourceInformation resourceInformation) {
 		String url = UrlUtils.removeTrailingSlash(getServiceUrlProvider().getUrl());
-		return url != null ? String.format("%s/%s", url, resourceInformation.getResourceType()) : null;
+		return url != null ? String.format("%s/%s", url, resourceInformation.getResourcePath()) : null;
 	}
 
 	@Override

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/registry/ResourceRegistryImpl.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/registry/ResourceRegistryImpl.java
@@ -3,7 +3,12 @@ package io.crnk.core.engine.internal.registry;
 import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.engine.internal.utils.UrlUtils;
-import io.crnk.core.engine.registry.*;
+import io.crnk.core.engine.registry.RegistryEntry;
+import io.crnk.core.engine.registry.ResourceRegistry;
+import io.crnk.core.engine.registry.ResourceRegistryPart;
+import io.crnk.core.engine.registry.ResourceRegistryPartBase;
+import io.crnk.core.engine.registry.ResourceRegistryPartEvent;
+import io.crnk.core.engine.registry.ResourceRegistryPartListener;
 import io.crnk.core.engine.url.ServiceUrlProvider;
 import io.crnk.core.exception.InvalidResourceException;
 import io.crnk.core.exception.RepositoryNotFoundException;
@@ -100,7 +105,7 @@ public class ResourceRegistryImpl extends ResourceRegistryPartBase implements Re
 	@Override
 	public String getResourceUrl(ResourceInformation resourceInformation) {
 		String url = UrlUtils.removeTrailingSlash(getServiceUrlProvider().getUrl());
-		return url != null ? String.format("%s/%s", url, resourceInformation.getResourcePath()) : null;
+		return url != null ? String.format("%s/%s", url, resourceInformation.getResourceType()) : null;
 	}
 
 	@Override

--- a/crnk-core/src/main/java/io/crnk/core/engine/properties/SystemPropertiesProvider.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/properties/SystemPropertiesProvider.java
@@ -1,0 +1,9 @@
+package io.crnk.core.engine.properties;
+
+public class SystemPropertiesProvider implements PropertiesProvider {
+
+	@Override
+	public String getProperty(String key) {
+		return System.getProperty(key);
+	}
+}

--- a/crnk-core/src/main/java/io/crnk/core/module/Module.java
+++ b/crnk-core/src/main/java/io/crnk/core/module/Module.java
@@ -18,6 +18,7 @@ import io.crnk.core.engine.registry.ResourceRegistryPart;
 import io.crnk.core.engine.security.SecurityProvider;
 import io.crnk.core.module.discovery.ResourceLookup;
 import io.crnk.core.module.discovery.ServiceDiscovery;
+import io.crnk.core.queryspec.pagingspec.PagingBehavior;
 import io.crnk.core.repository.decorate.RepositoryDecoratorFactory;
 
 /**
@@ -89,6 +90,12 @@ public interface Module {
 		 * @param RepositoryInformationBuilder resource information builder
 		 */
 		void addRepositoryInformationBuilder(RepositoryInformationProvider repositoryInformationProvider);
+
+		/**
+		 * Add the given {@link PagingBehavior} to the module
+		 * @param pagingBehavior the paging behavior
+		 */
+		void addPagingBehavior(PagingBehavior pagingBehavior);
 
 		/**
 		 * Register the given {@link ResourceLookup} in Crnk.

--- a/crnk-core/src/main/java/io/crnk/core/module/ModuleRegistry.java
+++ b/crnk-core/src/main/java/io/crnk/core/module/ModuleRegistry.java
@@ -39,6 +39,7 @@ import io.crnk.core.module.discovery.MultiResourceLookup;
 import io.crnk.core.module.discovery.ResourceLookup;
 import io.crnk.core.module.discovery.ServiceDiscovery;
 import io.crnk.core.module.internal.ResourceFilterDirectoryImpl;
+import io.crnk.core.queryspec.pagingspec.PagingBehavior;
 import io.crnk.core.repository.ResourceRepositoryV2;
 import io.crnk.core.repository.decorate.RelationshipRepositoryDecorator;
 import io.crnk.core.repository.decorate.RepositoryDecoratorFactory;
@@ -559,6 +560,12 @@ public class ModuleRegistry {
 
 		public ModuleContextImpl(Module module) {
 			this.module = module;
+		}
+
+		@Override
+		public void addPagingBehavior(PagingBehavior pagingBehavior) {
+			checkState(InitializedState.NOT_INITIALIZED, InitializedState.NOT_INITIALIZED);
+			aggregatedModule.addPagingBehavior(pagingBehavior);
 		}
 
 		@Override

--- a/crnk-core/src/main/java/io/crnk/core/module/ModuleRegistry.java
+++ b/crnk-core/src/main/java/io/crnk/core/module/ModuleRegistry.java
@@ -1,15 +1,10 @@
 package io.crnk.core.module;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.crnk.core.engine.dispatcher.RequestDispatcher;
 import io.crnk.core.engine.error.ExceptionMapper;
 import io.crnk.core.engine.error.JsonApiExceptionMapper;
-import io.crnk.core.engine.filter.DocumentFilter;
-import io.crnk.core.engine.filter.RepositoryFilter;
-import io.crnk.core.engine.filter.ResourceFilter;
-import io.crnk.core.engine.filter.ResourceFilterDirectory;
-import io.crnk.core.engine.filter.ResourceModificationFilter;
+import io.crnk.core.engine.filter.*;
 import io.crnk.core.engine.http.HttpRequestContextProvider;
 import io.crnk.core.engine.http.HttpRequestProcessor;
 import io.crnk.core.engine.information.InformationBuilder;
@@ -49,14 +44,8 @@ import io.crnk.core.utils.Prioritizable;
 import io.crnk.legacy.registry.DefaultResourceInformationProviderContext;
 import io.crnk.legacy.repository.ResourceRepository;
 import io.crnk.legacy.repository.annotations.JsonApiResourceRepository;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -98,6 +87,8 @@ public class ModuleRegistry {
 
 	private ResourceFilterDirectory filterBehaviorProvider;
 
+	private List<PagingBehavior> pagingBehaviors = new ArrayList<>();
+
 	public ModuleRegistry() {
 		this(true);
 	}
@@ -126,6 +117,24 @@ public class ModuleRegistry {
 	public void addModule(Module module) {
 		module.setupModule(new ModuleContextImpl(module));
 		modules.add(module);
+	}
+	/**
+	 * Add the given {@link PagingBehavior} to the module
+	 * @param pagingBehavior the paging behavior
+	 */
+	public void addPagingBehavior(PagingBehavior pagingBehavior){
+		pagingBehaviors.add(pagingBehavior);
+	}
+
+	public void addAllPagingBehaviors(List<PagingBehavior> pagingBehaviors){
+		this.pagingBehaviors.addAll(pagingBehaviors);
+		for (PagingBehavior pagingBehavior: pagingBehaviors){
+			this.aggregatedModule.addPagingBehavior(pagingBehavior);
+		}
+	}
+
+	public List<PagingBehavior> getPagingBehaviors() {
+		return pagingBehaviors;
 	}
 
 	public ResourceRegistry getResourceRegistry() {
@@ -565,6 +574,7 @@ public class ModuleRegistry {
 		@Override
 		public void addPagingBehavior(PagingBehavior pagingBehavior) {
 			checkState(InitializedState.NOT_INITIALIZED, InitializedState.NOT_INITIALIZED);
+			pagingBehaviors.add(pagingBehavior);
 			aggregatedModule.addPagingBehavior(pagingBehavior);
 		}
 

--- a/crnk-core/src/main/java/io/crnk/core/module/ModuleRegistry.java
+++ b/crnk-core/src/main/java/io/crnk/core/module/ModuleRegistry.java
@@ -87,8 +87,6 @@ public class ModuleRegistry {
 
 	private ResourceFilterDirectory filterBehaviorProvider;
 
-	private List<PagingBehavior> pagingBehaviors = new ArrayList<>();
-
 	public ModuleRegistry() {
 		this(true);
 	}
@@ -123,18 +121,17 @@ public class ModuleRegistry {
 	 * @param pagingBehavior the paging behavior
 	 */
 	public void addPagingBehavior(PagingBehavior pagingBehavior){
-		pagingBehaviors.add(pagingBehavior);
+		this.aggregatedModule.addPagingBehavior(pagingBehavior);
 	}
 
 	public void addAllPagingBehaviors(List<PagingBehavior> pagingBehaviors){
-		this.pagingBehaviors.addAll(pagingBehaviors);
 		for (PagingBehavior pagingBehavior: pagingBehaviors){
 			this.aggregatedModule.addPagingBehavior(pagingBehavior);
 		}
 	}
 
 	public List<PagingBehavior> getPagingBehaviors() {
-		return pagingBehaviors;
+		return this.aggregatedModule.getPagingBehaviors();
 	}
 
 	public ResourceRegistry getResourceRegistry() {
@@ -574,7 +571,6 @@ public class ModuleRegistry {
 		@Override
 		public void addPagingBehavior(PagingBehavior pagingBehavior) {
 			checkState(InitializedState.NOT_INITIALIZED, InitializedState.NOT_INITIALIZED);
-			pagingBehaviors.add(pagingBehavior);
 			aggregatedModule.addPagingBehavior(pagingBehavior);
 		}
 

--- a/crnk-core/src/main/java/io/crnk/core/module/SimpleModule.java
+++ b/crnk-core/src/main/java/io/crnk/core/module/SimpleModule.java
@@ -1,6 +1,5 @@
 package io.crnk.core.module;
 
-import com.google.common.collect.ImmutableList;
 import io.crnk.core.engine.error.JsonApiExceptionMapper;
 import io.crnk.core.engine.filter.DocumentFilter;
 import io.crnk.core.engine.filter.RepositoryFilter;
@@ -10,10 +9,6 @@ import io.crnk.core.engine.http.HttpRequestProcessor;
 import io.crnk.core.engine.information.repository.RepositoryInformationProvider;
 import io.crnk.core.engine.information.resource.ResourceInformationProvider;
 import io.crnk.core.engine.internal.exception.ExceptionMapperLookup;
-import io.crnk.core.engine.internal.information.resource.DefaultResourceFieldInformationProvider;
-import io.crnk.core.engine.internal.information.resource.DefaultResourceInformationProvider;
-import io.crnk.core.engine.internal.jackson.JacksonResourceFieldInformationProvider;
-import io.crnk.core.engine.properties.NullPropertiesProvider;
 import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.registry.ResourceRegistryPart;
 import io.crnk.core.engine.security.SecurityProvider;
@@ -47,6 +42,8 @@ public class SimpleModule implements Module {
 	private List<SecurityProvider> securityProviders = new ArrayList<>();
 
 	private List<ResourceLookup> resourceLookups = new ArrayList<>();
+
+	private List<PagingBehavior> pagingBehaviors = new ArrayList<>();
 
 	private List<com.fasterxml.jackson.databind.Module> jacksonModules = new ArrayList<>();
 
@@ -114,6 +111,9 @@ public class SimpleModule implements Module {
 		}
 		for (ModuleExtension extension : extensions) {
 			context.addExtension(extension);
+		}
+		for (PagingBehavior pagingBehavior : pagingBehaviors) {
+			context.addPagingBehavior(pagingBehavior);
 		}
 	}
 
@@ -250,12 +250,7 @@ public class SimpleModule implements Module {
 	 */
 	public void addPagingBehavior(PagingBehavior pagingBehavior){
 		checkInitialized();
-		addResourceInformationProvider(new DefaultResourceInformationProvider(
-				new NullPropertiesProvider()
-				, ImmutableList.of(pagingBehavior)
-				, new DefaultResourceFieldInformationProvider()
-				, new JacksonResourceFieldInformationProvider()
-		));
+		pagingBehaviors.add(pagingBehavior);
 	}
 
 	/**

--- a/crnk-core/src/main/java/io/crnk/core/module/SimpleModule.java
+++ b/crnk-core/src/main/java/io/crnk/core/module/SimpleModule.java
@@ -253,6 +253,11 @@ public class SimpleModule implements Module {
 		pagingBehaviors.add(pagingBehavior);
 	}
 
+	public List<PagingBehavior> getPagingBehaviors() {
+		checkInitialized();
+		return Collections.unmodifiableList(pagingBehaviors);
+	}
+
 	/**
 	 * Registers a new {@link ResourceLookup} with this module.
 	 *

--- a/crnk-core/src/main/java/io/crnk/core/module/SimpleModule.java
+++ b/crnk-core/src/main/java/io/crnk/core/module/SimpleModule.java
@@ -1,14 +1,6 @@
 package io.crnk.core.module;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableList;
 import io.crnk.core.engine.error.JsonApiExceptionMapper;
 import io.crnk.core.engine.filter.DocumentFilter;
 import io.crnk.core.engine.filter.RepositoryFilter;
@@ -18,11 +10,18 @@ import io.crnk.core.engine.http.HttpRequestProcessor;
 import io.crnk.core.engine.information.repository.RepositoryInformationProvider;
 import io.crnk.core.engine.information.resource.ResourceInformationProvider;
 import io.crnk.core.engine.internal.exception.ExceptionMapperLookup;
+import io.crnk.core.engine.internal.information.resource.DefaultResourceFieldInformationProvider;
+import io.crnk.core.engine.internal.information.resource.DefaultResourceInformationProvider;
+import io.crnk.core.engine.internal.jackson.JacksonResourceFieldInformationProvider;
+import io.crnk.core.engine.properties.NullPropertiesProvider;
 import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.registry.ResourceRegistryPart;
 import io.crnk.core.engine.security.SecurityProvider;
 import io.crnk.core.module.discovery.ResourceLookup;
+import io.crnk.core.queryspec.pagingspec.PagingBehavior;
 import io.crnk.core.repository.decorate.RepositoryDecoratorFactory;
+
+import java.util.*;
 
 /**
  * Vanilla {@link Module} implementation that allows registration of extensions.
@@ -243,6 +242,20 @@ public class SimpleModule implements Module {
 	protected List<com.fasterxml.jackson.databind.Module> getJacksonModules() {
 		checkInitialized();
 		return Collections.unmodifiableList(jacksonModules);
+	}
+
+	/**
+	 * Add the given {@link PagingBehavior} to the module
+	 * @param pagingBehavior the paging behavior
+	 */
+	public void addPagingBehavior(PagingBehavior pagingBehavior){
+		checkInitialized();
+		addResourceInformationProvider(new DefaultResourceInformationProvider(
+				new NullPropertiesProvider()
+				, ImmutableList.of(pagingBehavior)
+				, new DefaultResourceFieldInformationProvider()
+				, new JacksonResourceFieldInformationProvider()
+		));
 	}
 
 	/**

--- a/crnk-core/src/main/java/io/crnk/core/resource/annotations/JsonApiResource.java
+++ b/crnk-core/src/main/java/io/crnk/core/resource/annotations/JsonApiResource.java
@@ -3,7 +3,12 @@ package io.crnk.core.resource.annotations;
 import io.crnk.core.queryspec.pagingspec.OffsetLimitPagingBehavior;
 import io.crnk.core.queryspec.pagingspec.PagingBehavior;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 
 /**
  * Defines a resource. Each class annotated with {@link JsonApiResource} must have defined {@link JsonApiResource#type()}.
@@ -21,15 +26,6 @@ public @interface JsonApiResource {
 	 * @see <a href="http://jsonapi.org/format/#document-structure-resource-types">JSON API - Resource Types</a>
 	 */
 	String type();
-
-	/**
-	 * Defines path of the resource specified by <i>type</i>. According to JSON API, the <i>type</i> can be either singular or
-	 * plural.
-	 *
-	 * @return path of the <i>type</i> of the resource, default the type attribute value
-	 * @see <a href="http://jsonapi.org/format/#document-structure-resource-types">JSON API - Resource Types</a>
-	 */
-	String resourcePath() default "";
 
 	/**
 	 * Defines paging behavior of the resource

--- a/crnk-core/src/main/java/io/crnk/core/resource/annotations/JsonApiResource.java
+++ b/crnk-core/src/main/java/io/crnk/core/resource/annotations/JsonApiResource.java
@@ -3,11 +3,7 @@ package io.crnk.core.resource.annotations;
 import io.crnk.core.queryspec.pagingspec.OffsetLimitPagingBehavior;
 import io.crnk.core.queryspec.pagingspec.PagingBehavior;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Defines a resource. Each class annotated with {@link JsonApiResource} must have defined {@link JsonApiResource#type()}.
@@ -25,6 +21,15 @@ public @interface JsonApiResource {
 	 * @see <a href="http://jsonapi.org/format/#document-structure-resource-types">JSON API - Resource Types</a>
 	 */
 	String type();
+
+	/**
+	 * Defines path of the resource specified by <i>type</i>. According to JSON API, the <i>type</i> can be either singular or
+	 * plural.
+	 *
+	 * @return path of the <i>type</i> of the resource, default the type attribute value
+	 * @see <a href="http://jsonapi.org/format/#document-structure-resource-types">JSON API - Resource Types</a>
+	 */
+	String resourcePath() default "";
 
 	/**
 	 * Defines paging behavior of the resource

--- a/crnk-core/src/test/java/io/crnk/core/module/ModuleRegistryTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/module/ModuleRegistryTest.java
@@ -2,7 +2,6 @@ package io.crnk.core.module;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
-
 import io.crnk.core.engine.error.JsonApiExceptionMapper;
 import io.crnk.core.engine.filter.DocumentFilter;
 import io.crnk.core.engine.filter.RepositoryFilter;
@@ -29,26 +28,8 @@ import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.engine.security.SecurityProvider;
 import io.crnk.core.engine.url.ConstantServiceUrlProvider;
-import io.crnk.core.mock.models.ComplexPojo;
-import io.crnk.core.mock.models.Document;
-import io.crnk.core.mock.models.FancyProject;
-import io.crnk.core.mock.models.Project;
-import io.crnk.core.mock.models.Schedule;
-import io.crnk.core.mock.models.Task;
-import io.crnk.core.mock.models.Thing;
-import io.crnk.core.mock.models.User;
-import io.crnk.core.mock.repository.DocumentRepository;
-import io.crnk.core.mock.repository.PojoRepository;
-import io.crnk.core.mock.repository.ProjectRepository;
-import io.crnk.core.mock.repository.RelationIdTestRepository;
-import io.crnk.core.mock.repository.ResourceWithoutRepositoryToProjectRepository;
-import io.crnk.core.mock.repository.ScheduleRepository;
-import io.crnk.core.mock.repository.ScheduleRepositoryImpl;
-import io.crnk.core.mock.repository.TaskRepository;
-import io.crnk.core.mock.repository.TaskToProjectRepository;
-import io.crnk.core.mock.repository.TaskWithLookupRepository;
-import io.crnk.core.mock.repository.UserRepository;
-import io.crnk.core.mock.repository.UserToProjectRepository;
+import io.crnk.core.mock.models.*;
+import io.crnk.core.mock.repository.*;
 import io.crnk.core.module.discovery.ResourceLookup;
 import io.crnk.core.module.discovery.ServiceDiscovery;
 import io.crnk.core.queryspec.QuerySpec;
@@ -63,7 +44,6 @@ import io.crnk.core.resource.annotations.JsonApiResource;
 import io.crnk.core.resource.list.ResourceList;
 import io.crnk.core.utils.Prioritizable;
 import io.crnk.legacy.internal.DirectResponseRelationshipEntry;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -102,6 +82,12 @@ public class ModuleRegistryTest {
 
 	interface PrioDocumentFilter extends DocumentFilter, Prioritizable {
 
+	}
+
+	@Test
+	public void checkAddingPagingBehavior(){
+		moduleRegistry.addPagingBehavior(Mockito.mock(OffsetLimitPagingBehavior.class));
+		Assert.assertEquals(1, moduleRegistry.getPagingBehaviors().size());
 	}
 
 	@Test

--- a/crnk-core/src/test/java/io/crnk/core/module/SimpleModuleTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/module/SimpleModuleTest.java
@@ -24,6 +24,7 @@ import io.crnk.core.engine.security.SecurityProvider;
 import io.crnk.core.module.Module.ModuleContext;
 import io.crnk.core.module.discovery.ResourceLookup;
 import io.crnk.core.module.discovery.ServiceDiscovery;
+import io.crnk.core.queryspec.pagingspec.PagingBehavior;
 import io.crnk.core.repository.decorate.RepositoryDecoratorFactory;
 import org.junit.Assert;
 import org.junit.Before;
@@ -196,6 +197,8 @@ public class SimpleModuleTest {
 
 		private int numResourceInformationBuilds = 0;
 
+		private int numPagingBehaviors = 0;
+
 		private int numRepositoryInformationBuilds = 0;
 
 		private int numResourceLookups = 0;
@@ -305,6 +308,11 @@ public class SimpleModuleTest {
 		@Override
 		public void addRepositoryInformationBuilder(RepositoryInformationProvider repositoryInformationProvider) {
 			numRepositoryInformationBuilds++;
+		}
+
+		@Override
+		public void addPagingBehavior(PagingBehavior pagingBehavior) {
+			numPagingBehaviors++;
 		}
 
 		@Override

--- a/crnk-core/src/test/java/io/crnk/core/module/SimpleModuleTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/module/SimpleModuleTest.java
@@ -24,6 +24,7 @@ import io.crnk.core.engine.security.SecurityProvider;
 import io.crnk.core.module.Module.ModuleContext;
 import io.crnk.core.module.discovery.ResourceLookup;
 import io.crnk.core.module.discovery.ServiceDiscovery;
+import io.crnk.core.queryspec.pagingspec.OffsetLimitPagingBehavior;
 import io.crnk.core.queryspec.pagingspec.PagingBehavior;
 import io.crnk.core.repository.decorate.RepositoryDecoratorFactory;
 import org.junit.Assert;
@@ -87,6 +88,19 @@ public class SimpleModuleTest {
 
 		Assert.assertEquals(0, context.numResourceInformationBuilds);
 		Assert.assertEquals(1, context.numResourceLookups);
+		Assert.assertEquals(0, context.numFilters);
+		Assert.assertEquals(0, context.numJacksonModules);
+		Assert.assertEquals(0, context.numRepositories);
+	}
+
+	@Test
+	public void testPagingBehaviorsBuilder() {
+		module.addPagingBehavior(Mockito.mock(OffsetLimitPagingBehavior.class));
+		Assert.assertEquals(1, module.getPagingBehaviors().size());
+		module.setupModule(context);
+		Assert.assertEquals(1, context.numPagingBehaviors);
+		Assert.assertEquals(0, context.numResourceInformationBuilds);
+		Assert.assertEquals(0, context.numResourceLookups);
 		Assert.assertEquals(0, context.numFilters);
 		Assert.assertEquals(0, context.numJacksonModules);
 		Assert.assertEquals(0, context.numRepositories);


### PR DESCRIPTION
The fix allow to accept the resource class only if the resource annotations contains JsonApiResource (like before) AND if the JsonApiResource.pagingBehavior value is part of the class pagingBehaviors.
If the test on pagingBehavior is not there, the OffsetLimitPagingBehavior will always be used no matter the pagingBehavior class set in the Resource's annotation