### PR TITLE
Return Bad Request exception when relationship resource type doesn't exist

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/ResourceUpsert.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/ResourceUpsert.java
@@ -44,6 +44,7 @@ import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.engine.result.Result;
 import io.crnk.core.engine.result.ResultFactory;
+import io.crnk.core.exception.BadRequestException;
 import io.crnk.core.exception.ForbiddenException;
 import io.crnk.core.exception.RepositoryNotFoundException;
 import io.crnk.core.exception.RequestBodyException;
@@ -340,6 +341,11 @@ public abstract class ResourceUpsert extends ResourceIncludeField {
 			} else {
 				ResourceRegistry resourceRegistry = context.getResourceRegistry();
 				RegistryEntry entry = resourceRegistry.getEntry(relationshipId.getType());
+				if (entry == null) {
+					throw new BadRequestException(
+							String.format("Invalid resource type: %s for relationship: %s", relationshipId.getType(), relationshipName)
+					);
+				}
 				Class idFieldType = entry.getResourceInformation()
 						.getIdField()
 						.getType();


### PR DESCRIPTION
If you try and POST a resource with a relationship attached and the type doesn't exist, then you get a NPE.

I've changed the Invalid Relationship exception to a BadRequestException too because it's a user error