### PR TITLE
Allow setting resource path for JPA entity through @JpaResource 

### DIFF
--- a/crnk-jpa/src/main/java/io/crnk/jpa/annotations/JpaResource.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/annotations/JpaResource.java
@@ -26,4 +26,9 @@ public @interface JpaResource {
 	 * Defines the type of the resource.
 	 */
 	String type();
+
+	/**
+	 * Defines resource path for JPA entity.
+	 */
+	String resourcePath() default "";
 }

--- a/crnk-jpa/src/main/java/io/crnk/jpa/internal/JpaResourceInformationProvider.java
+++ b/crnk-jpa/src/main/java/io/crnk/jpa/internal/JpaResourceInformationProvider.java
@@ -1,13 +1,5 @@
 package io.crnk.jpa.internal;
 
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import javax.persistence.MappedSuperclass;
-import javax.persistence.OptimisticLockException;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import io.crnk.core.engine.document.Document;
 import io.crnk.core.engine.document.Resource;
@@ -24,9 +16,7 @@ import io.crnk.core.engine.parser.StringMapper;
 import io.crnk.core.engine.parser.TypeParser;
 import io.crnk.core.engine.properties.PropertiesProvider;
 import io.crnk.core.queryspec.pagingspec.OffsetLimitPagingSpec;
-import io.crnk.core.queryspec.pagingspec.PagingBehavior;
 import io.crnk.core.resource.annotations.LookupIncludeBehavior;
-import io.crnk.core.utils.Supplier;
 import io.crnk.jpa.annotations.JpaResource;
 import io.crnk.jpa.meta.JpaMetaProvider;
 import io.crnk.jpa.meta.MetaEntity;
@@ -38,6 +28,14 @@ import io.crnk.meta.model.MetaDataObject;
 import io.crnk.meta.model.MetaElement;
 import io.crnk.meta.model.MetaKey;
 import io.crnk.meta.model.MetaType;
+
+import javax.persistence.MappedSuperclass;
+import javax.persistence.OptimisticLockException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Extracts resource information from JPA and Crnk annotations. Crnk
@@ -76,8 +74,7 @@ public class JpaResourceInformationProvider extends ResourceInformationProviderB
 				MetaEntity metaEntity = (MetaEntity) meta;
 				MetaKey primaryKey = metaEntity.getPrimaryKey();
 				return primaryKey != null && primaryKey.getElements().size() == 1;
-			}
-			else {
+			} else {
 				// note that DTOs cannot be handled here
 				return meta instanceof MetaJpaDataObject;
 			}
@@ -86,7 +83,7 @@ public class JpaResourceInformationProvider extends ResourceInformationProviderB
 	}
 
 	@Override
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public ResourceInformation build(final Class<?> resourceClass) {
 		String resourceType = getResourceType(resourceClass);
 		String resourcePath = getResourcePath(resourceClass);
@@ -130,6 +127,12 @@ public class JpaResourceInformationProvider extends ResourceInformationProviderB
 
 	@Override
 	public String getResourcePath(Class<?> entityClass) {
+		JpaResource annotation = entityClass.getAnnotation(JpaResource.class);
+		if (annotation != null) {
+			String path = annotation.resourcePath();
+			return "".equals(path) ? null : path;
+		}
+
 		return null;
 	}
 
@@ -204,8 +207,7 @@ public class JpaResourceInformationProvider extends ResourceInformationProviderB
 			// => support compound keys with unique ids
 			if (type instanceof MetaDataObject) {
 				return parseEmbeddableString((MetaDataObject) type, idString);
-			}
-			else {
+			} else {
 				return context.getTypeParser().parse(idString, (Class) type.getImplementationClass());
 			}
 		}

--- a/crnk-jpa/src/test/java/io/crnk/jpa/information/JpaResourceInformationProviderTest.java
+++ b/crnk-jpa/src/test/java/io/crnk/jpa/information/JpaResourceInformationProviderTest.java
@@ -1,12 +1,5 @@
 package io.crnk.jpa.information;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.crnk.core.engine.information.resource.ResourceField;
 import io.crnk.core.engine.information.resource.ResourceFieldType;
@@ -14,12 +7,12 @@ import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.information.DefaultInformationBuilder;
 import io.crnk.core.engine.parser.TypeParser;
 import io.crnk.core.engine.properties.NullPropertiesProvider;
-import io.crnk.core.queryspec.pagingspec.OffsetLimitPagingBehavior;
 import io.crnk.core.resource.annotations.SerializeType;
 import io.crnk.jpa.internal.JpaResourceInformationProvider;
 import io.crnk.jpa.meta.JpaMetaProvider;
 import io.crnk.jpa.model.AnnotationMappedSuperclassEntity;
 import io.crnk.jpa.model.AnnotationTestEntity;
+import io.crnk.jpa.model.JpaResourcePathTestEntity;
 import io.crnk.jpa.model.JpaTransientTestEntity;
 import io.crnk.jpa.model.ManyToManyOppositeEntity;
 import io.crnk.jpa.model.ManyToManyTestEntity;
@@ -38,18 +31,23 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 public class JpaResourceInformationProviderTest {
 
 	private JpaResourceInformationProvider builder;
-
-	private MetaLookup lookup;
 
 	private JpaMetaProvider jpaMetaProvider;
 
 	@Before
 	public void setup() {
-		jpaMetaProvider = new JpaMetaProvider(Collections.<Class>emptySet());
-		lookup = new MetaLookup();
+		jpaMetaProvider = new JpaMetaProvider(Collections.emptySet());
+		MetaLookup lookup = new MetaLookup();
 		lookup.addProvider(jpaMetaProvider);
 		builder = new JpaResourceInformationProvider(new NullPropertiesProvider());
 		builder.init(new DefaultResourceInformationProviderContext(builder, new DefaultInformationBuilder(new TypeParser()),
@@ -57,7 +55,7 @@ public class JpaResourceInformationProviderTest {
 	}
 
 	@Test
-	public void test() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+	public void test() throws SecurityException, IllegalArgumentException {
 
 		ResourceInformation info = builder.build(TestEntity.class);
 		ResourceField idField = info.getIdField();
@@ -68,7 +66,7 @@ public class JpaResourceInformationProviderTest {
 		assertEquals(Long.class, idField.getGenericType());
 
 		List<ResourceField> attrFields = new ArrayList<>(info.getAttributeFields());
-		Collections.sort(attrFields, ResourceFieldComparator.INSTANCE);
+		attrFields.sort(ResourceFieldComparator.INSTANCE);
 		assertEquals(5, attrFields.size());
 		ResourceField embField = attrFields.get(1);
 		assertEquals(TestEntity.ATTR_embValue, embField.getJsonName());
@@ -80,8 +78,8 @@ public class JpaResourceInformationProviderTest {
 		Assert.assertTrue(embField.getAccess().isSortable());
 		Assert.assertTrue(embField.getAccess().isFilterable());
 
-		ArrayList<ResourceField> relFields = new ArrayList<ResourceField>(info.getRelationshipFields());
-		Collections.sort(relFields, ResourceFieldComparator.INSTANCE);
+		ArrayList<ResourceField> relFields = new ArrayList<>(info.getRelationshipFields());
+		relFields.sort(ResourceFieldComparator.INSTANCE);
 		assertEquals(4, relFields.size());
 		boolean found = false;
 		for (ResourceField relField : relFields) {
@@ -163,7 +161,6 @@ public class JpaResourceInformationProviderTest {
 		Assert.assertEquals(SerializeType.LAZY, field.getSerializeType());
 	}
 
-
 	@Test
 	public void testManyToManyRelation() {
 		ResourceInformation info = builder.build(ManyToManyTestEntity.class);
@@ -194,7 +191,6 @@ public class JpaResourceInformationProviderTest {
 		Assert.assertNull(field.getOppositeName());
 	}
 
-
 	@Test
 	public void testOneToManyRelation() {
 		ResourceInformation info = builder.build(TestEntity.class);
@@ -206,8 +202,7 @@ public class JpaResourceInformationProviderTest {
 	}
 
 	@Test
-	public void testAttributeAnnotations()
-			throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+	public void testAttributeAnnotations() throws SecurityException, IllegalArgumentException {
 		ResourceInformation info = builder.build(AnnotationTestEntity.class);
 
 		ResourceField lobField = info.findAttributeFieldByName("lobValue");
@@ -241,8 +236,14 @@ public class JpaResourceInformationProviderTest {
 	}
 
 	@Test
-	public void testReadOnlyField()
-			throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+	public void testJpaResourceAnnotationPath() {
+		ResourceInformation info = builder.build(JpaResourcePathTestEntity.class);
+		Assert.assertEquals("jpaResourceTestEntity", info.getResourceType());
+		Assert.assertEquals("jpa-resource-test-entity", info.getResourcePath());
+	}
+
+	@Test
+	public void testReadOnlyField() throws SecurityException, IllegalArgumentException {
 		ResourceInformation info = builder.build(AnnotationTestEntity.class);
 
 		ResourceField field = info.findAttributeFieldByName("readOnlyValue");
@@ -258,8 +259,7 @@ public class JpaResourceInformationProviderTest {
 	}
 
 	@Test
-	public void testMappedSuperclass()
-			throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+	public void testMappedSuperclass() throws SecurityException, IllegalArgumentException {
 		ResourceInformation info = builder.build(AnnotationMappedSuperclassEntity.class);
 
 		Assert.assertNull(info.getResourceType());
@@ -287,5 +287,4 @@ public class JpaResourceInformationProviderTest {
 		Assert.assertTrue(meta.getAttribute("lobValue").isLob());
 		Assert.assertFalse(meta.getAttribute("fieldAnnotatedValue").isLob());
 	}
-
 }

--- a/crnk-jpa/src/test/java/io/crnk/jpa/model/JpaResourcePathTestEntity.java
+++ b/crnk-jpa/src/test/java/io/crnk/jpa/model/JpaResourcePathTestEntity.java
@@ -1,0 +1,22 @@
+package io.crnk.jpa.model;
+
+import io.crnk.jpa.annotations.JpaResource;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+@JpaResource(type = "jpaResourceTestEntity", resourcePath = "jpa-resource-test-entity")
+public class JpaResourcePathTestEntity {
+
+	@Id
+	private Long id;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+}


### PR DESCRIPTION
Allow setting resource path for JPA entity through @JpaResource annotation on JPA entity.
Old behavior of JPA module not changed.