### PR TITLE
Attribute treated as a JsonApiRelationId even though not annotated

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/ResourceInformationProviderBase.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/ResourceInformationProviderBase.java
@@ -22,7 +22,6 @@ import io.crnk.core.engine.information.resource.ResourceInformationProvider;
 import io.crnk.core.engine.information.resource.ResourceInformationProviderContext;
 import io.crnk.core.engine.internal.document.mapper.IncludeLookupUtil;
 import io.crnk.core.engine.internal.utils.ClassUtils;
-import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.engine.properties.PropertiesProvider;
 import io.crnk.core.exception.InvalidResourceException;
 import io.crnk.core.resource.annotations.JsonApiRelation;
@@ -139,7 +138,7 @@ public abstract class ResourceInformationProviderBase implements ResourceInforma
 						idAttribute = idAttributeTemp;
 					}
 				}
-				if (idAttribute != null) {
+				if (idAttribute != null && idAttribute.getAnnotation(JsonApiRelationId.class).isPresent()) {
 					fieldBuilder.idName(idFieldName);
 					fieldBuilder.idType(idAttribute.getImplementationClass());
 				}


### PR DESCRIPTION
Fixed an issue by checking that a field has the JsonApiRelationId annotation before setting it as an id to a relationship field.

Refer to https://github.com/crnk-project/crnk-framework/issues/378 for more details.