### PR TITLE
support for deeply nested inheritance without dedicated repository #323

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/registry/RegistryEntryImpl.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/registry/RegistryEntryImpl.java
@@ -60,7 +60,7 @@ public class RegistryEntryImpl implements RegistryEntry {
 
 	@Override
 	public String toString() {
-		return getClass().getSimpleName() + "[type=" + resourceInformation.getResourceType() + "]";
+		return getClass().getSimpleName() + "[type=" + resourceInformation.getResourceType() + ", path=" + resourceInformation.getResourcePath() + "]";
 	}
 
 	@Override

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/resource/InheritanceWithoutSubtypeRepositoryTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/resource/InheritanceWithoutSubtypeRepositoryTest.java
@@ -88,6 +88,32 @@ public class InheritanceWithoutSubtypeRepositoryTest extends BaseControllerTest 
 
 
 	@Test
+	public void checkNestedSubTypeRegistered() {
+		RegistryEntry entryA = resourceRegistry.getEntry(TestResourceA.class);
+		RegistryEntry entryB = resourceRegistry.getEntry(TestResourceB.class);
+		RegistryEntry entryC1 = resourceRegistry.getEntry(NestedTestResourceC1.class);
+		RegistryEntry entryC2 = resourceRegistry.getEntry(NestedTestResourceC2.class);
+
+		Assert.assertNotNull(entryC1);
+		Assert.assertNotNull(entryC2);
+		Assert.assertNotEquals(entryA, entryC1);
+		Assert.assertNotEquals(entryB, entryC1);
+		Assert.assertNotEquals(entryA, entryC2);
+		Assert.assertNotEquals(entryB, entryC2);
+		Assert.assertNotEquals(entryC2, entryC1);
+
+		Assert.assertNull(entryC1.getRepositoryInformation());
+		Assert.assertNull(entryC2.getRepositoryInformation());
+		Assert.assertFalse(entryC1.hasResourceRepository());
+		Assert.assertFalse(entryC2.hasResourceRepository());
+
+		ResourceInformation resourceInformationC1 = entryC1.getResourceInformation();
+		Assert.assertEquals("testC1", resourceInformationC1.getResourceType());
+		Assert.assertEquals("testA", resourceInformationC1.getResourcePath());
+	}
+
+
+	@Test
 	public void checkCrudWithController() {
 		// CREATE resource
 		Relationship relationship = new Relationship();
@@ -180,7 +206,7 @@ public class InheritanceWithoutSubtypeRepositoryTest extends BaseControllerTest 
 		}
 	}
 
-	@JsonApiResource(type = "testB", resourcePath = "testA")
+	@JsonApiResource(type = "testB", resourcePath = "testA", subTypes = {NestedTestResourceC1.class, NestedTestResourceC2.class})
 	public static class TestResourceB extends TestResourceA {
 
 		private String value;
@@ -224,6 +250,35 @@ public class InheritanceWithoutSubtypeRepositoryTest extends BaseControllerTest 
 
 		public void setRelatedWithRepository(RelatedResource relatedWithRepository) {
 			this.relatedWithRepository = relatedWithRepository;
+		}
+	}
+
+	@JsonApiResource(type = "testC1", resourcePath = "testA")
+	public static class NestedTestResourceC1 extends TestResourceB {
+
+		private String valueC1;
+
+
+		public String getValueC1() {
+			return valueC1;
+		}
+
+		public void setValueC1(String valueC1) {
+			this.valueC1 = valueC1;
+		}
+	}
+
+	@JsonApiResource(type = "testC2", resourcePath = "testA")
+	public static class NestedTestResourceC2 extends TestResourceB {
+
+		private String valueC2;
+
+		public String getValueC2() {
+			return valueC2;
+		}
+
+		public void setValueC2(String valueC2) {
+			this.valueC2 = valueC2;
 		}
 	}
 

--- a/crnk-gen-typescript/src/main/java/io/crnk/gen/runtime/reflections/ReflectionsMetaResolver.java
+++ b/crnk-gen-typescript/src/main/java/io/crnk/gen/runtime/reflections/ReflectionsMetaResolver.java
@@ -73,6 +73,14 @@ public class ReflectionsMetaResolver implements RuntimeMetaResolver {
 
 			SimpleModule reflectionsModule = new SimpleModule("reflections");
 			for (Class resourceClass : resourceClasses) {
+				JsonApiResource resourceAnnotation = (JsonApiResource) resourceClass.getAnnotation(JsonApiResource.class);
+				JsonApiResource superAnnotation = (JsonApiResource) resourceClass.getSuperclass().getAnnotation(JsonApiResource.class);
+				String superPath = superAnnotation != null ? superAnnotation.resourcePath().isEmpty() ? superAnnotation.type() : superAnnotation.resourcePath() : null;
+				if (superPath != null && resourceAnnotation.resourcePath().equals(superPath)) {
+					// repository shared path with super type, meaning that it does not have a repository on its own
+					continue;
+				}
+
 				Class repositoryInterface = resourceRepositoryMap.get(resourceClass);
 				if (repositoryInterface != null) {
 					// repository class provides further ResourceList meta data

--- a/crnk-meta/src/main/java/io/crnk/meta/internal/resource/ResourceMetaParitition.java
+++ b/crnk-meta/src/main/java/io/crnk/meta/internal/resource/ResourceMetaParitition.java
@@ -141,7 +141,7 @@ public class ResourceMetaParitition extends TypedMetaPartitionBase {
 
 			ResourceRepositoryInformation repositoryInformation = entry.getRepositoryInformation();
 			ResourceRepositoryAdapter resourceRepository = entry.getResourceRepository();
-			if (resourceRepository != null) {
+			if (repositoryInformation != null) {
 				MetaResourceRepository repository = discoverRepository(repositoryInformation, metaResource,
 						resourceRepository);
 				context.addElement(repository);


### PR DESCRIPTION
nested subtypes can now share a @JsonApiResource.resourcePath with the root resource and do not have to implement a repository of their own.