### PR TITLE
Early verification of security constraints for bulk operations

### DIFF
--- a/crnk-client/src/main/java/io/crnk/client/internal/ClientStubBase.java
+++ b/crnk-client/src/main/java/io/crnk/client/internal/ClientStubBase.java
@@ -1,5 +1,8 @@
 package io.crnk.client.internal;
 
+import java.io.IOException;
+import java.util.List;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.crnk.client.ClientException;
 import io.crnk.client.CrnkClient;
@@ -23,9 +26,6 @@ import io.crnk.core.resource.list.DefaultResourceList;
 import io.crnk.core.utils.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.List;
 
 public class ClientStubBase {
 
@@ -85,7 +85,8 @@ public class ClientStubBase {
 				if (Resource.class.equals(resourceClass)) {
 					Document document = objectMapper.readValue(body, Document.class);
 					return toResourceResponse(document, objectMapper);
-				} else {
+				}
+				else {
 					Document document = objectMapper.readValue(body, Document.class);
 
 					ClientDocumentMapper documentMapper = client.getDocumentMapper();
@@ -93,7 +94,8 @@ public class ClientStubBase {
 				}
 			}
 			return null;
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 			throw new TransportException(e);
 		}
 	}
@@ -110,12 +112,17 @@ public class ClientStubBase {
 				list.setLinks(new JsonLinksInformation(document.getMeta(), objectMapper));
 			}
 			return list;
-		} else {
+		}
+		else {
 			return data;
 		}
 	}
 
 	protected RuntimeException handleError(HttpAdapterResponse response) throws IOException {
+		return handleError(client, response);
+	}
+
+	public static RuntimeException handleError(CrnkClient client, HttpAdapterResponse response) throws IOException {
 		ErrorResponse errorResponse = null;
 		String body = response.body();
 		String contentType = response.getResponseHeader(HttpHeaders.HTTP_CONTENT_TYPE);
@@ -137,10 +144,12 @@ public class ClientStubBase {
 			Throwable throwable = mapper.get().fromErrorResponse(errorResponse);
 			if (throwable instanceof RuntimeException) {
 				return (RuntimeException) throwable;
-			} else {
+			}
+			else {
 				return new ClientException(response.code(), response.message(), throwable);
 			}
-		} else {
+		}
+		else {
 			return new ClientException(response.code(), response.message());
 		}
 	}

--- a/crnk-core/src/main/java/io/crnk/core/engine/dispatcher/Response.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/dispatcher/Response.java
@@ -1,8 +1,13 @@
 package io.crnk.core.engine.dispatcher;
 
-import io.crnk.core.engine.document.Document;
-
 import java.util.Objects;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.crnk.core.engine.document.Document;
+import io.crnk.core.engine.http.HttpHeaders;
+import io.crnk.core.engine.http.HttpResponse;
+import io.crnk.core.engine.http.HttpStatus;
 
 public class Response {
 
@@ -39,9 +44,28 @@ public class Response {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (!(obj instanceof Response))
+		if (!(obj instanceof Response)) {
 			return false;
+		}
 		Response other = (Response) obj;
 		return Objects.equals(document, other.document) && Objects.equals(httpStatus, other.httpStatus);
+	}
+
+	public HttpResponse toHttpResponse(ObjectMapper objectMapper) {
+		HttpResponse httpResponse = new HttpResponse();
+		httpResponse.setStatusCode(getHttpStatus());
+
+		if (getHttpStatus() != HttpStatus.NO_CONTENT_204) {
+			String responseBody;
+			try {
+				responseBody = objectMapper.writeValueAsString(getDocument());
+			}
+			catch (JsonProcessingException e) {
+				throw new IllegalStateException(e);
+			}
+			httpResponse.setBody(responseBody);
+			httpResponse.setContentType(HttpHeaders.JSONAPI_CONTENT_TYPE_AND_CHARSET);
+		}
+		return httpResponse;
 	}
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/repository/ResponseRepositoryAdapter.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/repository/ResponseRepositoryAdapter.java
@@ -245,8 +245,7 @@ public abstract class ResponseRepositoryAdapter {
 			QueryContext queryContext = queryAdapter.getQueryContext();
 			FilterBehavior filterBehavior = resourceFilterDirectory.get(resourceInformation, request.getMethod(), queryContext);
 			if (filterBehavior != FilterBehavior.NONE) {
-				String msg = "not allowed to access " + request.getMethod() + " " + resourceInformation.getResourceType();
-				throw new ForbiddenException(msg);
+				throw new ForbiddenException(resourceInformation, request.getMethod());
 			}
 		}
 

--- a/crnk-core/src/main/java/io/crnk/core/exception/ForbiddenException.java
+++ b/crnk-core/src/main/java/io/crnk/core/exception/ForbiddenException.java
@@ -1,7 +1,9 @@
 package io.crnk.core.exception;
 
 import io.crnk.core.engine.document.ErrorData;
+import io.crnk.core.engine.http.HttpMethod;
 import io.crnk.core.engine.http.HttpStatus;
+import io.crnk.core.engine.information.resource.ResourceInformation;
 
 public class ForbiddenException extends CrnkMappableException {  // NOSONAR exception hierarchy deep but ok
 
@@ -10,5 +12,9 @@ public class ForbiddenException extends CrnkMappableException {  // NOSONAR exce
 	public ForbiddenException(String message) {
 		super(HttpStatus.FORBIDDEN_403, ErrorData.builder().setTitle(TITLE).setDetail(message)
 				.setStatus(String.valueOf(HttpStatus.FORBIDDEN_403)).build());
+	}
+
+	public ForbiddenException(ResourceInformation resourceInformation, HttpMethod method) {
+		this("not allowed to access " + method + " " + resourceInformation.getResourceType());
 	}
 }

--- a/crnk-operations/src/main/java/io/crnk/operations/client/OperationsCall.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/client/OperationsCall.java
@@ -1,11 +1,17 @@
 package io.crnk.operations.client;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.crnk.client.CrnkClient;
 import io.crnk.client.http.HttpAdapter;
 import io.crnk.client.http.HttpAdapterRequest;
 import io.crnk.client.http.HttpAdapterResponse;
 import io.crnk.client.internal.ClientDocumentMapper;
+import io.crnk.client.internal.ClientStubBase;
 import io.crnk.core.engine.document.Document;
 import io.crnk.core.engine.document.Resource;
 import io.crnk.core.engine.http.HttpHeaders;
@@ -15,18 +21,12 @@ import io.crnk.core.engine.internal.document.mapper.DocumentMappingConfig;
 import io.crnk.core.engine.query.QueryAdapter;
 import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.ResourceRegistry;
-import io.crnk.core.exception.InternalServerErrorException;
 import io.crnk.core.queryspec.QuerySpec;
 import io.crnk.core.queryspec.internal.QuerySpecAdapter;
 import io.crnk.core.repository.response.JsonApiResponse;
 import io.crnk.operations.Operation;
 import io.crnk.operations.OperationResponse;
 import io.crnk.operations.server.OperationsRequestProcessor;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class OperationsCall {
 
@@ -103,17 +103,17 @@ public class OperationsCall {
 			request.header(HttpHeaders.HTTP_HEADER_ACCEPT, OperationsRequestProcessor.JSONPATCH_CONTENT_TYPE);
 			HttpAdapterResponse response = request.execute();
 
-			int status = response.code();
-			if (status != 200) {
-				// general issue, status of individual operations is important.
-				throw new InternalServerErrorException("patch execution failed with status " + status);
+			if (!response.isSuccessful()) {
+				throw ClientStubBase.handleError(client.getCrnk(), response);
 			}
 			String json = response.body();
 			responses = Arrays.asList(mapper.readValue(json, OperationResponse[].class));
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 			throw new IllegalStateException(e);
 		}
 	}
+
 
 	public OperationResponse getResponse(int index) {
 		checkResponsesAvailable();

--- a/crnk-operations/src/test/java/io/crnk/operations/AbstractOperationsTest.java
+++ b/crnk-operations/src/test/java/io/crnk/operations/AbstractOperationsTest.java
@@ -1,5 +1,16 @@
 package io.crnk.operations;
 
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.metamodel.ManagedType;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
 import io.crnk.client.CrnkClient;
 import io.crnk.client.action.JerseyActionStubFactory;
 import io.crnk.client.http.okhttp.OkHttpAdapter;
@@ -29,17 +40,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.metamodel.ManagedType;
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 public abstract class AbstractOperationsTest extends JerseyTestBase {
 
@@ -193,8 +193,13 @@ public abstract class AbstractOperationsTest extends JerseyTestBase {
 			feature.addModule(jpaModule);
 			feature.addModule(operationsModule);
 			feature.addModule(ValidationModule.create());
+			setupServer(feature);
 			register(feature);
 		}
+	}
+
+	protected void setupServer(CrnkFeature feature) {
+		// noting to do, override if necessary
 	}
 
 }

--- a/crnk-operations/src/test/java/io/crnk/operations/OperationsSecurityTest.java
+++ b/crnk-operations/src/test/java/io/crnk/operations/OperationsSecurityTest.java
@@ -1,0 +1,79 @@
+package io.crnk.operations;
+
+import io.crnk.core.engine.filter.FilterBehavior;
+import io.crnk.core.engine.filter.ResourceFilter;
+import io.crnk.core.engine.http.HttpMethod;
+import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.exception.ForbiddenException;
+import io.crnk.core.module.SimpleModule;
+import io.crnk.operations.client.OperationsCall;
+import io.crnk.operations.client.OperationsClient;
+import io.crnk.operations.model.PersonEntity;
+import io.crnk.rs.CrnkFeature;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OperationsSecurityTest extends AbstractOperationsTest {
+
+
+	private OperationsClient operationsClient;
+
+	private boolean active = false;
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		operationsClient = new OperationsClient(client);
+	}
+
+	@Override
+	protected void setupServer(CrnkFeature feature) {
+		SimpleModule module = new SimpleModule("security");
+		module.addResourceFilter(new ResourceFilter() {
+			@Override
+			public FilterBehavior filterResource(ResourceInformation resourceInformation, HttpMethod method) {
+				return active ? FilterBehavior.FORBIDDEN : FilterBehavior.NONE;
+			}
+
+			@Override
+			public FilterBehavior filterField(ResourceField field, HttpMethod method) {
+				return FilterBehavior.NONE;
+			}
+		});
+		feature.addModule(module);
+	}
+
+	@Test
+	public void checkForbidden() {
+		active = true;
+		PersonEntity person1 = newPerson("1");
+		PersonEntity person2 = newPerson("2");
+
+		OperationsCall insertCall = operationsClient.createCall();
+		insertCall.add(HttpMethod.POST, person1);
+		insertCall.add(HttpMethod.POST, person2);
+		try {
+			insertCall.execute();
+			Assert.fail();
+		}
+		catch (ForbiddenException e) {
+			// ok
+		}
+	}
+
+
+	@Test
+	public void checkAllowed() {
+		active = false;
+		PersonEntity person1 = newPerson("1");
+		PersonEntity person2 = newPerson("2");
+
+		OperationsCall insertCall = operationsClient.createCall();
+		insertCall.add(HttpMethod.POST, person1);
+		insertCall.add(HttpMethod.POST, person2);
+		insertCall.execute();
+	}
+}


### PR DESCRIPTION
The OperationsModule now performs all security checks before executing any operations/accessing any repositories. Useful if updates are non-atomar and one of the non-first operations fails.