### PR TITLE
support for renamed attributes in error-response

### DIFF
--- a/crnk-meta/src/main/java/io/crnk/meta/internal/resource/ResourceMetaParitition.java
+++ b/crnk-meta/src/main/java/io/crnk/meta/internal/resource/ResourceMetaParitition.java
@@ -287,7 +287,7 @@ public class ResourceMetaParitition extends TypedMetaPartitionBase {
 	private void addAttribute(MetaResourceBase resource, ResourceField field) {
 		MetaResourceField attr = new MetaResourceField();
 
-		attr.setFieldName(field.getUnderlyingName());
+		attr.setUnderlyingName(field.getUnderlyingName());
 
 		attr.setParent(resource, true);
 		attr.setName(field.getJsonName());

--- a/crnk-meta/src/main/java/io/crnk/meta/internal/resource/ResourceMetaParitition.java
+++ b/crnk-meta/src/main/java/io/crnk/meta/internal/resource/ResourceMetaParitition.java
@@ -287,6 +287,8 @@ public class ResourceMetaParitition extends TypedMetaPartitionBase {
 	private void addAttribute(MetaResourceBase resource, ResourceField field) {
 		MetaResourceField attr = new MetaResourceField();
 
+		attr.setFieldName(field.getUnderlyingName());
+
 		attr.setParent(resource, true);
 		attr.setName(field.getJsonName());
 		attr.setAssociation(field.getResourceFieldType() == ResourceFieldType.RELATIONSHIP);

--- a/crnk-meta/src/main/java/io/crnk/meta/model/MetaAttribute.java
+++ b/crnk-meta/src/main/java/io/crnk/meta/model/MetaAttribute.java
@@ -33,6 +33,10 @@ public class MetaAttribute extends MetaElement {
 	@JsonIgnore
 	private Field field;
 
+	// if set, then the java field name is different than the json attribute name
+	@JsonIgnore
+	private String fieldName;
+
 	private boolean derived;
 
 	private boolean lazy;
@@ -64,7 +68,7 @@ public class MetaAttribute extends MetaElement {
 		if (field == null || readMethod == null) {
 			MetaDataObject parent = getParent();
 			Class<?> beanClass = parent.getImplementationClass();
-			String name = getName();
+			String name = getFieldName() == null ? getName() : getFieldName();
 
 			this.field = ClassUtils.findClassField(beanClass, name);
 			this.readMethod = ClassUtils.findGetter(beanClass, name);
@@ -275,5 +279,13 @@ public class MetaAttribute extends MetaElement {
 
 	public void setLob(boolean blob) {
 		this.lob = blob;
+	}
+
+	public String getFieldName() {
+		return fieldName;
+	}
+
+	public void setFieldName(String fieldName) {
+		this.fieldName = fieldName;
 	}
 }

--- a/crnk-meta/src/main/java/io/crnk/meta/model/MetaAttribute.java
+++ b/crnk-meta/src/main/java/io/crnk/meta/model/MetaAttribute.java
@@ -35,7 +35,7 @@ public class MetaAttribute extends MetaElement {
 
 	// if set, then the java field name is different than the json attribute name
 	@JsonIgnore
-	private String fieldName;
+	private String underlyingName;
 
 	private boolean derived;
 
@@ -68,7 +68,7 @@ public class MetaAttribute extends MetaElement {
 		if (field == null || readMethod == null) {
 			MetaDataObject parent = getParent();
 			Class<?> beanClass = parent.getImplementationClass();
-			String name = getFieldName() == null ? getName() : getFieldName();
+			String name = getUnderlyingName() == null ? getName() : getUnderlyingName();
 
 			this.field = ClassUtils.findClassField(beanClass, name);
 			this.readMethod = ClassUtils.findGetter(beanClass, name);
@@ -281,11 +281,11 @@ public class MetaAttribute extends MetaElement {
 		this.lob = blob;
 	}
 
-	public String getFieldName() {
-		return fieldName;
+	public String getUnderlyingName() {
+		return underlyingName;
 	}
 
-	public void setFieldName(String fieldName) {
-		this.fieldName = fieldName;
+	public void setUnderlyingName(String underlyingName) {
+		this.underlyingName = underlyingName;
 	}
 }

--- a/crnk-validation/src/main/java/io/crnk/validation/internal/ConstraintViolationExceptionMapper.java
+++ b/crnk-validation/src/main/java/io/crnk/validation/internal/ConstraintViolationExceptionMapper.java
@@ -334,7 +334,8 @@ public class ConstraintViolationExceptionMapper implements ExceptionMapper<Const
 				String mappedName = name;
 				if (resourceField != null) {
 					// in case of @JsonApiRelationId it will be mapped to original name
-					mappedName = resourceField.getUnderlyingName();
+					resourceField = resourceInformation.findFieldByUnderlyingName(resourceField.getUnderlyingName());
+					mappedName = resourceField.getJsonName();
 				}
 
 				appendSeparator();

--- a/crnk-validation/src/main/java/io/crnk/validation/internal/ConstraintViolationImpl.java
+++ b/crnk-validation/src/main/java/io/crnk/validation/internal/ConstraintViolationImpl.java
@@ -126,11 +126,8 @@ public class ConstraintViolationImpl implements ConstraintViolation<Object> {
 	}
 
 	private String findPropertyNameByJsonName(String jsonName) {
-		return resourceInformation.getAttributeFields().stream()
-				.filter(field -> jsonName.equals(field.getJsonName()))
-				.map(ResourceField::getUnderlyingName)
-				.findFirst()
-				.orElse(jsonName);
+		ResourceField field = resourceInformation.findAttributeFieldByName(jsonName);
+		return field != null ? field.getUnderlyingName() : jsonName;
 	}
 
 	private boolean isJsonApiStructure(String[] elements, int i) {

--- a/crnk-validation/src/main/java/io/crnk/validation/internal/ConstraintViolationImpl.java
+++ b/crnk-validation/src/main/java/io/crnk/validation/internal/ConstraintViolationImpl.java
@@ -1,6 +1,9 @@
 package io.crnk.validation.internal;
 
 import io.crnk.core.engine.document.ErrorData;
+import io.crnk.core.engine.filter.ResourceFilter;
+import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.engine.internal.utils.PropertyUtils;
@@ -20,11 +23,14 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 // TODO remo: take care of UnsupportedOperationExceptions to adhere to spec
 public class ConstraintViolationImpl implements ConstraintViolation<Object> {
 
 	private ErrorData errorData;
+
+	private ResourceInformation resourceInformation;
 
 	private Class<?> resourceClass;
 
@@ -42,9 +48,10 @@ public class ConstraintViolationImpl implements ConstraintViolation<Object> {
 
 			if (resourceType != null) {
 				RegistryEntry entry = resourceRegistry.getEntry(resourceType);
-				resourceClass = entry.getResourceInformation().getResourceClass();
+				resourceInformation = entry.getResourceInformation();
+				resourceClass = resourceInformation.getResourceClass();
 				if (strResourceId != null) {
-					resourceId = entry.getResourceInformation().parseIdString(strResourceId);
+					resourceId = resourceInformation.parseIdString(strResourceId);
 				}
 			}
 		}
@@ -105,14 +112,25 @@ public class ConstraintViolationImpl implements ConstraintViolation<Object> {
 			} else if (isJsonApiStructure(elements, i)) {
 				i++; // skip next as well
 			} else {
-				nodes.add(new NodeImpl(element));
+				// we don't have any meta-information about nested objects (https://github.com/crnk-project/crnk-framework/issues/399) yet,
+				// therefore we're not attempting to find the property name, as soon as we're in a nested object.
+				String propertyName = type == resourceClass ? findPropertyNameByJsonName(element) : element;
+				nodes.add(new NodeImpl(propertyName));
 
 				// follow attribute
-				type = PropertyUtils.getPropertyType(rawType, element);
+				type = PropertyUtils.getPropertyType(rawType, propertyName);
 			}
 			i++;
 		}
 		return new PathImpl(nodes);
+	}
+
+	private String findPropertyNameByJsonName(String jsonName) {
+		return resourceInformation.getAttributeFields().stream()
+				.filter(field -> jsonName.equals(field.getJsonName()))
+				.map(ResourceField::getUnderlyingName)
+				.findFirst()
+				.orElse(jsonName);
 	}
 
 	private boolean isJsonApiStructure(String[] elements, int i) {

--- a/crnk-validation/src/test/java/io/crnk/validation/ValidationEndToEndTest.java
+++ b/crnk-validation/src/test/java/io/crnk/validation/ValidationEndToEndTest.java
@@ -38,7 +38,7 @@ public class ValidationEndToEndTest extends AbstractValidationTest {
 			Assert.assertEquals("name", violation.getPropertyPath().toString());
 			Assert.assertNotNull(violation.getMessage());
 			Assert.assertTrue(violation.getMessage().contains("null"));
-			Assert.assertEquals("/data/attributes/name", violation.getErrorData().getSourcePointer());
+			Assert.assertEquals("/data/attributes/renamed-name", violation.getErrorData().getSourcePointer());
 		}
 	}
 
@@ -86,7 +86,7 @@ public class ValidationEndToEndTest extends AbstractValidationTest {
 			ConstraintViolationImpl violation = (ConstraintViolationImpl) violations.iterator().next();
 			Assert.assertEquals("{javax.validation.constraints.NotNull.message}", violation.getMessageTemplate());
 			Assert.assertEquals("data.value", violation.getPropertyPath().toString());
-			Assert.assertEquals("/data/attributes/data/value", violation.getErrorData().getSourcePointer());
+			Assert.assertEquals("/data/attributes/renamed-data/value", violation.getErrorData().getSourcePointer());
 		}
 	}
 
@@ -109,7 +109,7 @@ public class ValidationEndToEndTest extends AbstractValidationTest {
 			Assert.assertEquals("{javax.validation.constraints.NotNull.message}", violation.getMessageTemplate());
 			Assert.assertEquals("dataList[0].value", violation.getPropertyPath().toString());
 			Assert.assertNotNull(violation.getMessage());
-			Assert.assertEquals("/data/attributes/dataList/0/value", violation.getErrorData().getSourcePointer());
+			Assert.assertEquals("/data/attributes/data-list/0/value", violation.getErrorData().getSourcePointer());
 		}
 	}
 
@@ -136,7 +136,7 @@ public class ValidationEndToEndTest extends AbstractValidationTest {
 			Assert.assertEquals("{javax.validation.constraints.NotNull.message}", violation.getMessageTemplate());
 			Assert.assertEquals("dataMap[someKey].value", violation.getPropertyPath().toString());
 			Assert.assertNotNull(violation.getMessage());
-			Assert.assertEquals("/data/attributes/dataMap/someKey/value", violation.getErrorData().getSourcePointer());
+			Assert.assertEquals("/data/attributes/data-map/someKey/value", violation.getErrorData().getSourcePointer());
 		}
 	}
 

--- a/crnk-validation/src/test/java/io/crnk/validation/mock/models/Project.java
+++ b/crnk-validation/src/test/java/io/crnk/validation/mock/models/Project.java
@@ -1,5 +1,7 @@
 package io.crnk.validation.mock.models;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.crnk.core.resource.annotations.JsonApiId;
 import io.crnk.core.resource.annotations.JsonApiResource;
 import io.crnk.core.resource.annotations.JsonApiToMany;
@@ -23,20 +25,24 @@ public class Project {
 	private Long id;
 
 	@NotNull
+	@JsonProperty("renamed-name")
 	private String name;
 
 	private String description;
 
 	@Valid
+	@JsonProperty("renamed-data")
 	private ProjectData data;
 
 	@Valid
+	@JsonProperty("data-list")
 	private List<ProjectData> dataList = new ArrayList<>();
 
 	@Valid
 	private Set<ProjectData> dataSet = new HashSet<>();
 
 	@Valid
+	@JsonProperty("data-map")
 	private Map<String, ProjectData> dataMap = new HashMap<>();
 
 	@Size(min = 0, max = 3)


### PR DESCRIPTION
Resolves #406 

In order to fix `ValidationMetaProviderTest` I had to modify `ResourceMetaPartition` and `MetaAttribute`. Not sure if that's the right approach, though.