### PR TITLE
Enable enforceDotSeparator by default #405

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapper.java
+++ b/crnk-core/src/main/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapper.java
@@ -46,7 +46,7 @@ public class DefaultQuerySpecUrlMapper
 
 	private Set<FilterOperator> supportedOperators = new HashSet<>();
 
-	private boolean enforceDotPathSeparator = false;
+	private boolean enforceDotPathSeparator = true;
 
 	private boolean ignoreParseExceptions;
 

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapperSerializerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapperSerializerTest.java
@@ -46,6 +46,11 @@ public class DefaultQuerySpecUrlMapperSerializerTest {
 	}
 
 	@Test
+	public void dotSeparatorEnabledByDefault(){
+		Assert.assertTrue(urlMapper.getEnforceDotPathSeparator());
+	}
+
+	@Test
 	public void testHttpsSchema() {
 		CoreTestContainer container = new CoreTestContainer();
 		container.getBoot().setServiceUrlProvider(new ConstantServiceUrlProvider("https://127.0.0.1"));


### PR DESCRIPTION
Disables by default support for

```
filter[person][address][city]=Zurich
filter[address][city]=Zurich
```

in favor of

```
filter[person][address.city]=Zurich
filter[address.city]=Zurich
```

to avoid by default ambiguity if relationships and resources are named equally.