### PR TITLE
Supporting loading relationships according to spec #281

### DIFF
--- a/crnk-client/src/main/java/io/crnk/client/internal/RelationshipRepositoryStubImpl.java
+++ b/crnk-client/src/main/java/io/crnk/client/internal/RelationshipRepositoryStubImpl.java
@@ -75,13 +75,13 @@ public class RelationshipRepositoryStubImpl<T, I extends Serializable, D, J exte
 	@SuppressWarnings("unchecked")
 	@Override
 	public D findOneTarget(I sourceId, String fieldName, QuerySpec querySpec) {
-		String url = urlBuilder.buildUrl(sourceResourceInformation, sourceId, querySpec, fieldName);
+		String url = urlBuilder.buildUrl(sourceResourceInformation, sourceId, querySpec, fieldName, false);
 		return (D) executeGet(url, ResponseType.RESOURCE);
 	}
 
 	@Override
 	public DefaultResourceList<D> findManyTargets(I sourceId, String fieldName, QuerySpec querySpec) {
-		String url = urlBuilder.buildUrl(sourceResourceInformation, sourceId, querySpec, fieldName);
+		String url = urlBuilder.buildUrl(sourceResourceInformation, sourceId, querySpec, fieldName, false);
 		return (DefaultResourceList<D>) executeGet(url, ResponseType.RESOURCES);
 	}
 
@@ -104,12 +104,7 @@ public class RelationshipRepositoryStubImpl<T, I extends Serializable, D, J exte
 
 	private void doExecute(String requestUrl, HttpMethod method, final Document document) {
 		final ObjectMapper objectMapper = client.getObjectMapper();
-		String requestBodyValue = ExceptionUtil.wrapCatchedExceptions(new Callable<String>() {
-			@Override
-			public String call() throws Exception {
-				return objectMapper.writeValueAsString(document);
-			}
-		});
+		String requestBodyValue = ExceptionUtil.wrapCatchedExceptions(() -> objectMapper.writeValueAsString(document));
 		execute(requestUrl, ResponseType.NONE, method, requestBodyValue);
 	}
 

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/RelationshipsResourceGetController.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/RelationshipsResourceGetController.java
@@ -2,8 +2,11 @@ package io.crnk.core.engine.internal.dispatcher.controller;
 
 import io.crnk.core.engine.dispatcher.Response;
 import io.crnk.core.engine.document.Document;
+import io.crnk.core.engine.document.Resource;
+import io.crnk.core.engine.document.ResourceIdentifier;
 import io.crnk.core.engine.http.HttpMethod;
 import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.dispatcher.path.JsonPath;
 import io.crnk.core.engine.internal.dispatcher.path.RelationshipsPath;
 import io.crnk.core.engine.internal.document.mapper.DocumentMapper;
@@ -12,10 +15,18 @@ import io.crnk.core.engine.internal.repository.RelationshipRepositoryAdapter;
 import io.crnk.core.engine.query.QueryAdapter;
 import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.result.Result;
+import io.crnk.core.exception.RepositoryNotFoundException;
+import io.crnk.core.queryspec.IncludeFieldSpec;
+import io.crnk.core.queryspec.PathSpec;
+import io.crnk.core.queryspec.QuerySpec;
 import io.crnk.core.repository.response.JsonApiResponse;
 import io.crnk.core.utils.Nullable;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class RelationshipsResourceGetController extends ResourceIncludeField {
 
@@ -27,7 +38,7 @@ public class RelationshipsResourceGetController extends ResourceIncludeField {
 	@Override
 	public Result<Response> handleAsync(JsonPath jsonPath, QueryAdapter queryAdapter, Document requestBody) {
 		RelationshipsPath relationshipsPath = (RelationshipsPath) jsonPath;
-		RegistryEntry registryEntry = relationshipsPath.getRootEntry();
+		RegistryEntry rootEntry = relationshipsPath.getRootEntry();
 
 		Serializable id = jsonPath.getId();
 		ResourceField relationshipField = relationshipsPath.getRelationship();
@@ -35,24 +46,64 @@ public class RelationshipsResourceGetController extends ResourceIncludeField {
 		DocumentMappingConfig documentMapperConfig = DocumentMappingConfig.create();
 		DocumentMapper documentMapper = context.getDocumentMapper();
 
+		// only the IDs necssary, update QuerySpec accordingly
+		RegistryEntry relatedEntry = context.getResourceRegistry().getEntry(relationshipField.getOppositeResourceType());
+		ResourceInformation relatedResourceInformation;
+		if (relatedEntry != null) {
+			relatedResourceInformation = relatedEntry.getResourceInformation();
+			ResourceField idField = relatedResourceInformation.getIdField();
+			QuerySpec querySpec = queryAdapter.toQuerySpec();
+			querySpec.setIncludedFields(Arrays.asList(new IncludeFieldSpec(PathSpec.of(idField.getUnderlyingName()))));
+		} else {
+			relatedResourceInformation = null;
+		}
+
 		boolean isCollection = Iterable.class.isAssignableFrom(relationshipField.getType());
-		RelationshipRepositoryAdapter relationshipRepositoryForClass = registryEntry.getRelationshipRepository(relationshipField);
+		RelationshipRepositoryAdapter relationshipRepositoryForClass = rootEntry.getRelationshipRepository(relationshipField);
 		Result<JsonApiResponse> response;
 		if (isCollection) {
 			response = relationshipRepositoryForClass.findManyTargets(id, relationshipField, queryAdapter);
 		} else {
 			response = relationshipRepositoryForClass.findOneTarget(id, relationshipField, queryAdapter);
 		}
-		return response.merge(it -> documentMapper.toDocument(it, queryAdapter, documentMapperConfig)).map(this::toResponse);
+		return response.merge(it -> documentMapper.toDocument(it, queryAdapter, documentMapperConfig)).map(it -> toResponse(it, relatedResourceInformation));
 	}
 
 
-	public Response toResponse(Document document) {
+	public Response toResponse(Document document, ResourceInformation resourceInformation) {
 		// return explicit { data : null } if values found
-		if (!document.getData().isPresent()) {
+		Nullable<Object> data = document.getData();
+		if (data.isPresent()) {
+			if (data.get() != null) {
+				if (data.get() instanceof Collection) {
+					Collection<Object> resources = (Collection) data.get();
+					List<ResourceIdentifier> resourceIds = resources.stream()
+							.map(it -> toResourceIdentifier(it, resourceInformation))
+							.collect(Collectors.toList());
+					document.setData(Nullable.of(resourceIds));
+				} else {
+					Object resource = data.get();
+					document.setData(Nullable.of(toResourceIdentifier(resource, resourceInformation)));
+				}
+			}
+		} else {
 			document.setData(Nullable.nullValue());
 		}
 		return new Response(document, 200);
+	}
+
+	private ResourceIdentifier toResourceIdentifier(Object it, ResourceInformation resourceInformation) {
+		if (it instanceof Resource) {
+			return ((Resource) it).toIdentifier();
+		}
+		if (resourceInformation == null) {
+			RegistryEntry entry = context.getResourceRegistry().findEntry(it.getClass());
+			if (entry == null) {
+				throw new RepositoryNotFoundException("no repository found for " + it);
+			}
+			resourceInformation = entry.getResourceInformation();
+		}
+		return resourceInformation.toResourceIdentifier(it);
 	}
 
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/utils/JsonApiUrlBuilder.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/utils/JsonApiUrlBuilder.java
@@ -45,15 +45,18 @@ public class JsonApiUrlBuilder {
 	}
 
 	public String buildUrl(ResourceInformation resourceInformation, Object id, QuerySpec querySpec, String relationshipName) {
-		return buildUrlInternal(resourceInformation, id, querySpec, relationshipName);
+		return buildUrlInternal(resourceInformation, id, querySpec, relationshipName, true);
 	}
 
-	public String buildUrl(ResourceInformation resourceInformation, Object id, QueryParams queryParams, String
-			relationshipName) {
-		return buildUrlInternal(resourceInformation, id, queryParams, relationshipName);
+	public String buildUrl(ResourceInformation resourceInformation, Object id, QuerySpec querySpec, String relationshipName, boolean selfLink) {
+		return buildUrlInternal(resourceInformation, id, querySpec, relationshipName, selfLink);
 	}
 
-	private String buildUrlInternal(ResourceInformation resourceInformation, Object id, Object query, String relationshipName) {
+	public String buildUrl(ResourceInformation resourceInformation, Object id, QueryParams queryParams, String relationshipName) {
+		return buildUrlInternal(resourceInformation, id, queryParams, relationshipName, true);
+	}
+
+	private String buildUrlInternal(ResourceInformation resourceInformation, Object id, Object query, String relationshipName, boolean selfLink) {
 		String url;
 		ResourceRegistry resourceRegistry = moduleRegistry.getResourceRegistry();
 		if (id instanceof Collection) {
@@ -74,8 +77,10 @@ public class JsonApiUrlBuilder {
 		} else {
 			url = resourceRegistry.getResourceUrl(queryContext, resourceInformation);
 		}
-		if (relationshipName != null) {
+		if (relationshipName != null && selfLink) {
 			url += "/relationships/" + relationshipName;
+		}else if(relationshipName != null){
+			url += "/" + relationshipName;
 		}
 
 		UrlParameterBuilder urlBuilder = new UrlParameterBuilder(url);

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/resource/RelationshipsResourceGetControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/resource/RelationshipsResourceGetControllerTest.java
@@ -111,6 +111,7 @@ public class RelationshipsResourceGetControllerTest extends BaseControllerTest {
 		String resultJson = objectMapper.writeValueAsString(response.getDocument());
 		assertThatJson(resultJson).node("data.id").isStringEqualTo("42");
 		assertThatJson(resultJson).node("data.type").isEqualTo("projects");
+		assertThatJson(resultJson).node("data.attributes").isAbsent();
 	}
 
 	@Test

--- a/crnk-documentation/src/docs/asciidoc/repositories.adoc
+++ b/crnk-documentation/src/docs/asciidoc/repositories.adoc
@@ -551,11 +551,40 @@ new RelationshipMatcher().rule().target(Task.class).add().matches(field)
 new RelationshipMatcher().rule().target(Tasks.class).add().matches(field)
 new RelationshipMatcher().rule().field("tasks").add().matches(field)
 new RelationshipMatcher().rule().oppositeField("project").add().matches(field)
-[source]
 ----
 
 One can implement, for example, a history relationship repository that introduces a history relationship for every other resource
 as done in the example from the previous section.
+
+
+### Self and Related Links
+
+The JSON API specification from http://jsonapi.org/format/#fetching-relationships
+mandates two relationship links:
+
+- `"self": "http://example.com/articles/1/relationships/author"`
+- `"related": "http://example.com/articles/1/author"`
+
+While the `related` link returns full resources, the `self` link only returns the `type` and `id`:
+
+[source]
+----
+HTTP/1.1 200 OK
+Content-Type: application/vnd.api+json
+
+{
+  "links": {
+    "self": "/articles/1/relationships/author",
+    "related": "/articles/1/author"
+  },
+  "data": {
+    "type": "people",
+    "id": "12"
+  }
+----
+
+Behind the scenes, Crnk invokes the same relationship repository implementation , but the QuerySpec will specify whether only the identifier is required through
+the `includedFields` property.
 
 
 ### ForwardingRelationshipRepository

--- a/crnk-documentation/src/docs/releases/latest/info.html
+++ b/crnk-documentation/src/docs/releases/latest/info.html
@@ -1,4 +1,3 @@
-
 This release brings many incremental improvements and some long overdue architecture cleanups.
 Make sure to familiarize yourself with the updated UrlMapper behavior and QueryParams implementation.
 Any application following the convention recommended the past year should not have any issues with this.
@@ -7,10 +6,11 @@ Any application following the convention recommended the past year should not ha
 <h4>Early support for faceted search</h4>
 
 Faceted search is used by many UIs to allow users to quickly navigate data sets. For example, virtually every online shop makes
-use of the feature to show product categories and the number of products in that category. Those categories, denoted as
-facets, have a label, a set of values, a count for each value. Facets may also depend on each other, whereas later facets are filtered by former ones.
+use of this feature to show product categories and the number of products in that category. Those categories, denoted as
+facets, have a label, a set of values and a count for each value. Facets may also depend on each other, whereas later facets are filtered by former ones.
 <p>
-With FacetModule Crnk provides an out-of-the-box solution to implemented faceted search. For more information have a look at the new chapter in the documentation.
+	With FacetModule Crnk provides an out-of-the-box solution to implemented faceted search. For more information have a
+	look at the new chapter in the documentation.
 
 <h4>Documentation updates</h4>
 
@@ -18,10 +18,9 @@ The outline of the documentation has been revised. Some of the chapters have bee
 And there is now a cheatsheet giving an overview
 of the most important features and APIs.
 <p>
-The crnk-examples have been renamed to crnk-integration-examples to clearly distinguish from the main
-crnk-example application. The name change reflects the fact that those examples are only meant to showcase
-the integration of Crnk into various frameworks, not its entire feature set.
-
+	The crnk-examples have been renamed to crnk-integration-examples to clearly distinguish from the main
+	crnk-example application. The name change reflects the fact that those examples are only meant to showcase
+	the integration of Crnk into various frameworks, not its entire feature set.
 
 
 <h4>New UrlMapper default configuration</h4>
@@ -60,6 +59,44 @@ It offers various methods create new instances and can be used to quickly constr
 specifications.
 
 
+<h4>Relationships loading handled according to JSON API specification</h4>
+
+The specification from <a href="http://jsonapi.org/format/#fetching-relationships">http://jsonapi.org/format/#fetching-relationships</a>
+mandates two relationship links:
+
+<ul>
+	<li>
+		<pre class="prettyprint">
+				"self": "http://example.com/articles/1/relationships/author"
+		</pre>
+	</li>
+	<li>
+		<pre class="prettyprint">
+				"related": "http://example.com/articles/1/author"
+		</pre>
+	</li>
+</ul>
+
+With this release, Crnk properly handles GET request of self links by no longer returning the entire resources, but only the type and id:
+
+<pre class="prettyprint">
+HTTP/1.1 200 OK
+Content-Type: application/vnd.api+json
+
+{
+  "links": {
+    "self": "/articles/1/relationships/author",
+    "related": "/articles/1/author"
+  },
+  "data": {
+    "type": "people",
+    "id": "12"
+  }
+</pre>
+
+Behind the scenes, the same relationship repository implementation is called. The QuerySpec will specify that only the identifier is required through
+the <i>includedFields</i> property.
+
 <h4>QuerySpecVisitor</h4>
 
 The new QuerySpecVisitor and QuerySpecVisitorBase classes allow to visit
@@ -78,7 +115,8 @@ QueryParams has been deprecated since Crnk 0.x. So far both QuerySpec and QueryP
 for QueryParams has been refactored and remains support through the QuerySpec-to-QueryParams conversion process. That has been the recommended and
 only meaningful setup for a long time. The big benefit is a much lighter and more robust code base in the area.
 <p>
-	Future release either drop QueryParams support or move it out into a dedicated module. Contributes in the area would be welcomed. If it is no longer deemed useful
+	Future release either drop QueryParams support or move it out into a dedicated module. Contributes in the area would
+	be welcomed. If it is no longer deemed useful
 	by anybody, it will be removed sometime in Q1/Q2 2019.
 
 


### PR DESCRIPTION
self links no longer return entire Resource objects, but just the ResourceIdentifier
according to spec.