### PR TITLE
Fix issue with compact result where data is null.

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/DocumentMapper.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/DocumentMapper.java
@@ -116,9 +116,9 @@ public class DocumentMapper {
 			if (doc.getData().isPresent()) {
 				if (doc.isMultiple()) {
 					compact(doc.getCollectionData().get());
+				} else {
+					compact(doc.getSingleData().get());
 				}
-			} else {
-				compact(doc.getSingleData().get());
 			}
 		}
 	}

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/document/mapper/DocumentMapperTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/document/mapper/DocumentMapperTest.java
@@ -112,6 +112,17 @@ public class DocumentMapperTest extends AbstractDocumentMapperTest {
 		Assert.assertNull(projectResource.getRelationships().get("tasks"));
 	}
 
+	@Test
+	public void testCompactModeWithNullData() {
+		QuerySpecAdapter queryAdapter = (QuerySpecAdapter) toAdapter(new QuerySpec(Task.class));
+
+		queryAdapter.setCompactMode(true);
+		Document compactDocument = mapper.toDocument(new JsonApiResponse(), queryAdapter, mappingConfig).get();
+		queryAdapter.setCompactMode(false);
+		Document standardDocument = mapper.toDocument(new JsonApiResponse(), queryAdapter, mappingConfig).get();
+
+		Assert.assertEquals(standardDocument, compactDocument);
+	}
 
 	@Test
 	public void testDocumentInformation() {


### PR DESCRIPTION
When compact is true but the response data is null there is an exception due to doc.getData().isPresent() returning false but still continuing to try to access the data.

I believe the else statement is simply at the wrong level of indentation. The test added shows that the error occurs until the else block is moved.