### PR TITLE
Crnk spring actuator metrics support

### DIFF
--- a/crnk-setup/crnk-setup-spring-boot2/build.gradle
+++ b/crnk-setup/crnk-setup-spring-boot2/build.gradle
@@ -57,6 +57,7 @@ dependencies {
 	testCompile 'org.springframework.security:spring-security-core'
 	testCompile 'net.javacrumbs.json-unit:json-unit-fluent:1.5.3'
 	testCompile 'org.mockito:mockito-core:2.18.3'
+	testCompile 'pl.pragmatists:JUnitParams:1.1.1'
 }
 
 

--- a/crnk-setup/crnk-setup-spring-boot2/src/main/java/io/crnk/spring/setup/boot/metrics/CrnkSpringActuatorMetricsAutoConfiguration.java
+++ b/crnk-setup/crnk-setup-spring-boot2/src/main/java/io/crnk/spring/setup/boot/metrics/CrnkSpringActuatorMetricsAutoConfiguration.java
@@ -1,0 +1,21 @@
+package io.crnk.spring.setup.boot.metrics;
+
+import io.crnk.core.engine.registry.ResourceRegistry;
+import io.crnk.spring.setup.boot.metrics.CrnkWebMvcTagsProvider;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvcMetricsAutoConfiguration;
+import org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnClass(WebMvcMetricsAutoConfiguration.class)
+public class CrnkSpringActuatorMetricsAutoConfiguration {
+
+	@Bean
+	CrnkWebMvcTagsProvider crnkWebMvcTagsProvider(final ResourceRegistry resourceRegistry) {
+		return new CrnkWebMvcTagsProvider(resourceRegistry);
+	}
+}

--- a/crnk-setup/crnk-setup-spring-boot2/src/main/java/io/crnk/spring/setup/boot/metrics/CrnkWebMvcTagsProvider.java
+++ b/crnk-setup/crnk-setup-spring-boot2/src/main/java/io/crnk/spring/setup/boot/metrics/CrnkWebMvcTagsProvider.java
@@ -1,0 +1,66 @@
+package io.crnk.spring.setup.boot.metrics;
+
+import io.crnk.core.engine.registry.ResourceRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import org.apache.logging.log4j.util.Strings;
+import org.springframework.boot.actuate.metrics.web.servlet.DefaultWebMvcTagsProvider;
+import org.springframework.boot.actuate.metrics.web.servlet.WebMvcTags;
+import org.springframework.boot.actuate.metrics.web.servlet.WebMvcTagsProvider;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.regex.Pattern;
+
+/**
+ * Crnk {@link WebMvcTagsProvider} implementation extends built-in {@link DefaultWebMvcTagsProvider} and
+ * overrides uri tag recognition logic for resources in order to have proper `uri` value. Uses base class values as fallback.
+ */
+public class CrnkWebMvcTagsProvider extends DefaultWebMvcTagsProvider {
+
+	private static final String SEPARATOR = "/";
+
+	private static final Pattern SEPARATOR_PATTER = Pattern.compile(SEPARATOR);
+
+	private final ResourceRegistry resourceRegistry;
+
+	public CrnkWebMvcTagsProvider(final ResourceRegistry resourceRegistry) {
+		this.resourceRegistry = resourceRegistry;
+	}
+
+	@Override
+	public Iterable<Tag> getTags(HttpServletRequest request, HttpServletResponse response, Object handler, Throwable exception) {
+		Tag uri = uri(request);
+		if (uri != null) {
+			return Tags.of(WebMvcTags.method(request), uri(request), WebMvcTags.exception(exception), WebMvcTags.status(response));
+		}
+
+		return super.getTags(request, response, handler, exception);
+	}
+
+	@Override
+	public Iterable<Tag> getLongRequestTags(HttpServletRequest request, Object handler) {
+		Tag uri = uri(request);
+		if (uri != null) {
+			return Tags.of(WebMvcTags.method(request), uri);
+		}
+
+		return super.getLongRequestTags(request, handler);
+	}
+
+	private Tag uri(final HttpServletRequest request) {
+		String uri = request.getRequestURI();
+		if (uri.startsWith(SEPARATOR)) {
+			uri = uri.substring(1);
+		}
+		String[] segments = SEPARATOR_PATTER.split(uri);
+		if (segments.length == 0 || resourceRegistry.getEntryByPath(segments[0]) == null) {
+			return null;
+		}
+		if (segments.length > 1) {
+			segments[1] = "{id}";
+		}
+
+		return Tag.of("uri", SEPARATOR + String.join(SEPARATOR, segments));
+	}
+}

--- a/crnk-setup/crnk-setup-spring-boot2/src/main/resources/META-INF/spring.factories
+++ b/crnk-setup/crnk-setup-spring-boot2/src/main/resources/META-INF/spring.factories
@@ -13,4 +13,5 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   io.crnk.spring.setup.boot.mvc.CrnkErrorControllerAutoConfiguration,\
   io.crnk.spring.setup.boot.data.facet.CrnkFacetAutoConfiguration,\
   io.crnk.spring.setup.boot.format.PlainJsonFormatAutoConfiguration,\
-  io.crnk.spring.setup.boot.validation.CrnkValidationAutoConfiguration
+  io.crnk.spring.setup.boot.validation.CrnkValidationAutoConfiguration,\
+  io.crnk.spring.setup.boot.metrics.CrnkSpringActuatorMetricsAutoConfiguration

--- a/crnk-setup/crnk-setup-spring-boot2/src/test/java/io/crnk/spring/metrics/CrnkWebMvcTagsProviderTest.java
+++ b/crnk-setup/crnk-setup-spring-boot2/src/test/java/io/crnk/spring/metrics/CrnkWebMvcTagsProviderTest.java
@@ -1,0 +1,78 @@
+package io.crnk.spring.metrics;
+
+import com.google.common.collect.Iterators;
+import io.crnk.core.engine.registry.RegistryEntry;
+import io.crnk.core.engine.registry.ResourceRegistry;
+import io.crnk.spring.setup.boot.metrics.CrnkWebMvcTagsProvider;
+import io.micrometer.core.instrument.Tag;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(JUnitParamsRunner.class)
+public class CrnkWebMvcTagsProviderTest {
+
+    private ResourceRegistry resourceRegistry = mock(ResourceRegistry.class);
+
+    private CrnkWebMvcTagsProvider compositeTagsProvider = new CrnkWebMvcTagsProvider(resourceRegistry);
+
+    @Test
+    public void useFallbackIfNotCrnkResource() {
+        when(resourceRegistry.getEntryByPath(anyString())).thenReturn(null);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute("org.springframework.web.servlet.HandlerMapping.bestMatchingPattern", "/any");
+
+        Iterable<Tag> tags = compositeTagsProvider.getTags(request, new MockHttpServletResponse(), mock(Object.class), mock(Throwable.class));
+
+        assertEquals("/any", Iterators.get(tags.iterator(), 1).getValue());
+    }
+
+    @SuppressWarnings("unused")
+    private Object[] handleCrnkResourceParameters() {
+    	String id = UUID.randomUUID().toString();
+
+        return new Object[] {
+            new Object[] {
+                "/users",
+                "/users"
+            },
+            new Object[] {
+                "/users/" + id,
+                "/users/{id}"
+            },
+            new Object[] {
+                "/users/" + id + "/attribute",
+                "/users/{id}/attribute"
+            },
+            new Object[] {
+                "/users/" + id + "/relationships/relation",
+                "/users/{id}/relationships/relation"
+            }
+        };
+    }
+
+    @Test
+    @Parameters(method = "handleCrnkResourceParameters")
+    public void handleCrnkResource(final String requestUrl, final String expected) {
+        when(resourceRegistry.getEntryByPath(anyString())).thenReturn(mock(RegistryEntry.class));
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI(requestUrl);
+
+        Iterable<Tag> tags = compositeTagsProvider.getTags(request, new MockHttpServletResponse(), mock(Object.class), mock(Throwable.class));
+
+        assertEquals(expected, Iterators.get(tags.iterator(), 1).getValue());
+    }
+}


### PR DESCRIPTION
Added custom tags-provider and implementation auto-configuration to define it, which properly resolves uri for any crnk resource

Partially resolves #451 