### PR TITLE
Sanity null check for target relations

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/repository/foward/strategy/SetOwnerStrategy.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/foward/strategy/SetOwnerStrategy.java
@@ -82,7 +82,6 @@ public class SetOwnerStrategy<T, I extends Serializable, D, J extends Serializab
 			@SuppressWarnings("unchecked")
 			Collection<D> currentTargets = getOrCreateCollection(source, field);
 			if (targets != null) {
-			{
 				for (D target : targets) {
 					currentTargets.remove(target);
 				}

--- a/crnk-core/src/main/java/io/crnk/core/repository/foward/strategy/SetOwnerStrategy.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/foward/strategy/SetOwnerStrategy.java
@@ -58,8 +58,10 @@ public class SetOwnerStrategy<T, I extends Serializable, D, J extends Serializab
 			Iterable<D> targets = context.findAll(targetEntry, targetIds, queryContext);
 			@SuppressWarnings("unchecked")
 			Collection<D> currentTargets = getOrCreateCollection(source, field);
-			for (D target : targets) {
-				currentTargets.add(target);
+			if (targets != null) {
+				for (D target : targets) {
+					currentTargets.add(target);
+				}
 			}
 		}
 		sourceAdapter.update(source, context.createSaveQueryAdapter(fieldName, queryContext));
@@ -79,8 +81,11 @@ public class SetOwnerStrategy<T, I extends Serializable, D, J extends Serializab
 			Iterable<D> targets = context.findAll(targetEntry, targetIds, queryContext);
 			@SuppressWarnings("unchecked")
 			Collection<D> currentTargets = getOrCreateCollection(source, field);
-			for (D target : targets) {
-				currentTargets.remove(target);
+			if (targets != null) {
+			{
+				for (D target : targets) {
+					currentTargets.remove(target);
+				}
 			}
 		}
 		sourceAdapter.update(source, context.createSaveQueryAdapter(fieldName, queryContext));


### PR DESCRIPTION
Adding a sanity null check when adding or removing relations.
Issue reported: https://github.com/crnk-project/crnk-framework/issues/483