### PR TITLE
Recursive allocateMetaElement only for known Collections (backport for v2.x)

### DIFF
--- a/crnk-core/build.gradle
+++ b/crnk-core/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 dependencies {
-	compile 'net.jodah:typetools:0.6.1'
+	compile 'net.jodah:typetools:0.6.2'
 	compile 'org.slf4j:slf4j-api:1.7.25'
 	compile 'com.fasterxml.jackson.core:jackson-databind'
 	compile 'com.fasterxml.jackson.core:jackson-annotations'

--- a/crnk-meta/src/main/java/io/crnk/meta/provider/MetaPartitionBase.java
+++ b/crnk-meta/src/main/java/io/crnk/meta/provider/MetaPartitionBase.java
@@ -151,13 +151,19 @@ public abstract class MetaPartitionBase implements MetaPartition {
 
 		if (type instanceof ParameterizedType && ((ParameterizedType) type).getActualTypeArguments().length == 1) {
 			ParameterizedType paramType = (ParameterizedType) type;
+			boolean isSet = Set.class.isAssignableFrom((Class<?>) paramType.getRawType());
+			boolean isList = List.class.isAssignableFrom((Class<?>) paramType.getRawType());
+
+			if (!isSet && !isList) {
+				return Optional.empty();
+			}
+
+			// Only look at the type parameter if a Set or List was detected.
 			Optional<MetaType> elementType = (Optional) allocateMetaElement(paramType.getActualTypeArguments()[0]);
 			if (!elementType.isPresent()) {
 				return Optional.empty();
 			}
 
-			boolean isSet = Set.class.isAssignableFrom((Class<?>) paramType.getRawType());
-			boolean isList = List.class.isAssignableFrom((Class<?>) paramType.getRawType());
 			if (isSet) {
 				MetaSetType metaSet = new MetaSetType();
 				metaSet.setId(elementType.get().getId() + "$set");
@@ -165,8 +171,7 @@ public abstract class MetaPartitionBase implements MetaPartition {
 				metaSet.setImplementationType(paramType);
 				metaSet.setElementType(elementType.get());
 				return addElement(type, metaSet);
-			}
-			if (isList) {
+			} else {
 				PreconditionUtil.assertTrue("expected a list type", isList);
 				MetaListType metaList = new MetaListType();
 				metaList.setId(elementType.get().getId() + "list");

--- a/versions.properties
+++ b/versions.properties
@@ -1,5 +1,5 @@
 reflections.version=0.9.9
-typetools.version=0.6.1
+typetools.version=0.6.2
 jackson.version=2.8.7
 slf4j.version=1.7.13
 logback.version=1.1.7


### PR DESCRIPTION
We're using Crnk 2.x in a project and were running into issues with `crnk-meta` when resolving self-referential type-declarations such as `S extends Enum<S>`.

This requires:
 1. A fix in typetools, which is currently pending as jhalterman/typetools#53 and should reach Crnk as `net.jodah:typetools:0.6.2`.
 2. A fix in Crnk, which is included in this PR. The problem is that if Crnk *suspects* that a type `T<E>` might be a known collection type, it will recurse to analyze `E`, without checking that `T` actually is some `List` or `Set`. The culprit is, that for structures where `T<E>` is self-referential, and therefore `T` and `E` are indistinguishable, this process will loop and result in a stack overflow. An easy remedy is to check for `T` **before** the recursive call.

Note that these changes can also be integrated into Crnk 3 and I could provide a PR for that. However the system we are developing must go live soon, so from my point of view it is much more important to patch 2.x first. I hope you can understand that, and for the sake of simplicity let's first do 2.x and I will provide a patch for 3.x later on.