### PR TITLE
#532: AsciidocCaptureModule wrong decorate ManyRelationshipRepository

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/repository/decorate/WrappedOneManyRelationshipRepository.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/decorate/WrappedOneManyRelationshipRepository.java
@@ -1,0 +1,71 @@
+package io.crnk.core.repository.decorate;
+
+import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.repository.ManyRelationshipRepository;
+import io.crnk.core.repository.OneRelationshipRepository;
+import io.crnk.core.repository.RelationshipRepository;
+import io.crnk.core.resource.list.ResourceList;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Decorator combination of {@link OneRelationshipRepository} and {@link ManyRelationshipRepository} repositories.
+ *
+ * Can be used to combine implementations of {@link WrappedOneRelationshipRepository} and {@link WrappedOneRelationshipRepository}
+ * repositories when decorating a {@link RelationshipRepository}.
+ *
+ * @author Stas Melnichuk
+ */
+public class WrappedOneManyRelationshipRepository<T, I, D, J> extends WrappedRelationshipRepository<T, I, D, J> {
+
+	private final OneRelationshipRepository<T, I, D, J> oneRelationshipRepository;
+	private final ManyRelationshipRepository<T, I, D, J> manyRelationshipRepository;
+
+	public WrappedOneManyRelationshipRepository(RelationshipRepository<T, I, D, J> wrappedRepository,
+												OneRelationshipRepository<T, I, D, J> oneRelationshipRepository,
+												ManyRelationshipRepository<T, I, D, J> manyRelationshipRepository) {
+		super(wrappedRepository);
+		this.oneRelationshipRepository = oneRelationshipRepository;
+		this.manyRelationshipRepository = manyRelationshipRepository;
+	}
+
+	// region One Relationship Repository Methods
+
+	@Override
+	public void setRelation(T source, J targetId, String fieldName) {
+		oneRelationshipRepository.setRelation(source, targetId, fieldName);
+	}
+
+	@Override
+	public Map<I, D> findOneRelations(Collection<I> sourceIds, String fieldName, QuerySpec querySpec) {
+		return oneRelationshipRepository.findOneRelations(sourceIds, fieldName, querySpec);
+	}
+
+	// endregion
+
+	// region Many Relationship Repository Methods
+
+	@Override
+	public void setRelations(T source, Collection<J> targetIds, String fieldName) {
+		manyRelationshipRepository.setRelations(source, targetIds, fieldName);
+	}
+
+	@Override
+	public void addRelations(T source, Collection<J> targetIds, String fieldName) {
+		manyRelationshipRepository.addRelations(source, targetIds, fieldName);
+	}
+
+	@Override
+	public void removeRelations(T source, Collection<J> targetIds, String fieldName) {
+		manyRelationshipRepository.removeRelations(source, targetIds, fieldName);
+	}
+
+	@Override
+	public Map<I, ResourceList<D>> findManyRelations(Collection<I> sourceIds, String fieldName, QuerySpec querySpec) {
+		return manyRelationshipRepository.findManyRelations(sourceIds, fieldName, querySpec);
+	}
+
+	// endregion
+
+}

--- a/crnk-core/src/main/java/io/crnk/core/repository/decorate/WrappedOneManyRelationshipRepository.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/decorate/WrappedOneManyRelationshipRepository.java
@@ -29,12 +29,10 @@ public class WrappedOneManyRelationshipRepository<T, I, D, J, K extends OneRelat
 	protected final OneRelationshipRepository<T, I, D, J> wrappedOneRelationshipRepository;
 	protected final ManyRelationshipRepository<T, I, D, J> wrappedManyRelationshipRepository;
 
-	/**
-	 */
-	public WrappedOneManyRelationshipRepository(
-			K originalRepository,
-			OneRelationshipRepository<T, I, D, J> wrappedOneRelationshipRepository,
-			ManyRelationshipRepository<T, I, D, J> wrappedManyRelationshipRepository) {
+
+	public WrappedOneManyRelationshipRepository(K originalRepository,
+												OneRelationshipRepository<T, I, D, J> wrappedOneRelationshipRepository,
+												ManyRelationshipRepository<T, I, D, J> wrappedManyRelationshipRepository) {
 		this.originalRepository = originalRepository;
 		this.wrappedOneRelationshipRepository = wrappedOneRelationshipRepository;
 		this.wrappedManyRelationshipRepository = wrappedManyRelationshipRepository;

--- a/crnk-gen/crnk-gen-asciidoc/src/test/java/io/crnk/gen/asciidoc/AsciiDocCaptureTest.java
+++ b/crnk-gen/crnk-gen-asciidoc/src/test/java/io/crnk/gen/asciidoc/AsciiDocCaptureTest.java
@@ -6,12 +6,15 @@ import io.crnk.core.boot.CrnkBoot;
 import io.crnk.core.queryspec.FilterOperator;
 import io.crnk.core.queryspec.PathSpec;
 import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.repository.ManyRelationshipRepository;
+import io.crnk.core.repository.OneRelationshipRepository;
 import io.crnk.core.repository.ResourceRepository;
 import io.crnk.core.resource.list.ResourceList;
 import io.crnk.format.plainjson.PlainJsonFormatModule;
 import io.crnk.gen.asciidoc.capture.AsciidocCaptureConfig;
 import io.crnk.gen.asciidoc.capture.AsciidocCaptureModule;
 import io.crnk.test.mock.TestModule;
+import io.crnk.test.mock.models.Project;
 import io.crnk.test.mock.models.Task;
 import io.crnk.test.mock.models.TaskStatus;
 import org.junit.Assert;
@@ -19,10 +22,16 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
 
 public class AsciiDocCaptureTest {
 
-    private ResourceRepository<Task, Long> repository;
+    private ResourceRepository<Task, Long> taskRepository;
+    private ResourceRepository<Project, Long> projectRepository;
+
+    private OneRelationshipRepository<Task, Long, Project, Long> taskToProjectOneRelationRepository;
+    private ManyRelationshipRepository<Task, Long, Project, Long> taskToProjectManyRelationRepository;
 
     private AsciidocCaptureModule asciidoc;
 
@@ -32,7 +41,10 @@ public class AsciiDocCaptureTest {
 
         asciidoc = setupAsciidoc();
         CrnkClient client = setupClient(boot, asciidoc);
-        repository = client.getRepositoryForType(Task.class);
+        taskRepository = client.getRepositoryForType(Task.class);
+        projectRepository = client.getRepositoryForType(Project.class);
+        taskToProjectOneRelationRepository = client.getOneRepositoryForType(Task.class, Project.class);
+        taskToProjectManyRelationRepository = client.getManyRepositoryForType(Task.class, Project.class);
     }
 
     private CrnkClient setupClient(CrnkBoot boot, AsciidocCaptureModule module) {
@@ -67,18 +79,61 @@ public class AsciiDocCaptureTest {
         newTask.setName("Favorite Task");
         newTask.setStatus(TaskStatus.OPEN);
 
-        Task createdTask = asciidoc.capture("Create new Task").call(() -> repository.create(newTask));
+        Task createdTask = asciidoc.capture("Create new Task").call(() -> taskRepository.create(newTask));
 
         QuerySpec querySpec = new QuerySpec(Task.class);
         querySpec.addFilter(PathSpec.of("name").filter(FilterOperator.EQ, "Favorite Task"));
         querySpec.setOffset(0);
         querySpec.setLimit(5L);
-        ResourceList<Task> list = asciidoc.capture("Find Task by Name").call(() -> repository.findAll(querySpec));
+        ResourceList<Task> list = asciidoc.capture("Find Task by Name").call(() -> taskRepository.findAll(querySpec));
         Assert.assertNotEquals(0, list.size());
 
         createdTask.setName("Updated Task");
-        asciidoc.capture("Update a Task").call(() -> repository.save(createdTask));
+        asciidoc.capture("Update a Task").call(() -> taskRepository.save(createdTask));
 
-        asciidoc.capture("Delete a Task").call(() -> repository.delete(createdTask.getId()));
+        asciidoc.capture("Delete a Task").call(() -> taskRepository.delete(createdTask.getId()));
     }
+
+	@Test
+	public void checkOneRelationRepositoryAccess() {
+		Task newTask = new Task();
+		newTask.setName("Favorite Task");
+		newTask.setStatus(TaskStatus.OPEN);
+		Task createdTask = taskRepository.create(newTask);
+
+		Project newProject = new Project();
+		newProject.setName("Favorite Project");
+		newProject.setDescription("It's just for test");
+		Project createdProject = projectRepository.create(newProject);
+
+		asciidoc.capture("Link Project and Task").call(() -> taskToProjectOneRelationRepository.setRelation(createdTask, createdProject.getId(), "project"));
+
+		asciidoc.capture("Find Project by Task").call(() -> taskToProjectOneRelationRepository.findOneRelations(Collections.singleton(createdTask.getId()), "project", new QuerySpec(Task.class)));
+
+		asciidoc.capture("Delete Project from Task").call(() -> taskToProjectOneRelationRepository.setRelation(createdTask, null, "project"));
+	}
+
+	@Test
+	public void checkManyRelationRepositoryAccess() {
+		Task newTask = new Task();
+		newTask.setName("Favorite Task");
+		newTask.setStatus(TaskStatus.OPEN);
+		Task createdTask = taskRepository.create(newTask);
+
+		Project firstNewProject = new Project();
+		firstNewProject.setName("First Favorite Project");
+		firstNewProject.setDescription("It's just for test");
+		Project firstCreatedProject = projectRepository.create(firstNewProject);
+
+		Project secondNewProject = new Project();
+		secondNewProject.setName("Second Favorite Project");
+		secondNewProject.setDescription("It's just for test");
+		Project secondCreatedProject = projectRepository.create(secondNewProject);
+
+		asciidoc.capture("Link Task with several Projects").call(() -> taskToProjectManyRelationRepository.addRelations(createdTask, Arrays.asList(firstCreatedProject.getId(), secondCreatedProject.getId()), "projects"));
+
+		asciidoc.capture("Get Task relation Projects").call(() -> taskToProjectManyRelationRepository.findManyRelations(Collections.singleton(createdTask.getId()), "projects", new QuerySpec(Task.class)));
+
+		asciidoc.capture("Remove single Project from Task").call(() -> taskToProjectManyRelationRepository.removeRelations(createdTask, Collections.singleton(firstCreatedProject.getId()), "projects"));
+	}
 }


### PR DESCRIPTION
Add new decorator class for RelationshipRepository entity and redirect calss to one and many decorators.
Add some tests for check decoration correctness.

@remmeier, please see changes. I am not sure that I do right work with the problem.