### PR TITLE
ClassUtils getRawType function should check for WildcardType

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/utils/ClassUtils.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/utils/ClassUtils.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -354,6 +355,8 @@ public class ClassUtils {
 			return getRawType(((ParameterizedType) type).getRawType());
 		} else if (type instanceof TypeVariable<?>) {
 			return getRawType(((TypeVariable<?>) type).getBounds()[0]);
+		} else if (type instanceof WildcardType) {
+			return getRawType(((WildcardType) type).getUpperBounds()[0]);
 		}
 		throw new IllegalStateException("unknown type: " + type);
 	}


### PR DESCRIPTION
Hi,
I'm using Crnk with Kotlin. I've created a User model and assign it a set of Role. The signature of Set in Kotlin is Set<out E> and Role is a Java class so not final by default. 
At runtime it gives the following signatrue Set<? extends io.crnk.security.repository.Role>.
? extends io.crnk.security.repository.Role is a WildcardType and in ClassUtils getRawType it will throw an IllegalStateException with unknown type.
This pull request add the required conditional branch for WildcardType and solve the bug.
Best,
JB