### PR TITLE
Operations Including All Relationships Toggle

### DIFF
--- a/crnk-documentation/src/docs/asciidoc/operations.adoc
+++ b/crnk-documentation/src/docs/asciidoc/operations.adoc
@@ -40,6 +40,30 @@ There is further an operations client implementation that works along the regula
 include::../../../../crnk-operations/src/test/java/io/crnk/operations/OperationsPostTest.java[tags=client]
 ----
 
+## Operation Module Properties
+
+The operations module can be customized using one of the following properties:
+
+.Operation Module Properties
+|===
+|*Property Name* |*Description* |*Default Value*
+|resumeOnError | If an error occurs during the operation execution, continue the other operations. | False
+|includeAllRelationships | Toggle to include all relationships in the request by default. | True
+|displayResultsOnSuccess | If false, it will only display the data responses if an error has occured. Status code are still shown either way. | True
+|===
+
+Here is an example of how to set these properties:
+
+[source]
+----
+OperationsModule operationsModule = OperationsModule.create();
+operationsModule.setIncludeAllRelationships(false);
+operationsModule.resumeOnError(true);
+...
+----
+
+## Example Request and Response
+
 An example request in JSON looks like:
 
 [source]

--- a/crnk-documentation/src/docs/asciidoc/operations.adoc
+++ b/crnk-documentation/src/docs/asciidoc/operations.adoc
@@ -49,7 +49,7 @@ The operations module can be customized using one of the following properties:
 |*Property Name* |*Description* |*Default Value*
 |resumeOnError | If an error occurs during the operation execution, continue the other operations. | False
 |includeAllRelationships | Toggle to include all relationships in the request by default. | True
-|displayResultsOnSuccess | If false, it will only display the data responses if an error has occured. Status code are still shown either way. | True
+|displayOperationResponseOnSuccess | If true, the response will always be included. Otherwise, it only displays the status codes of the operation unless an error has occurred. | True
 |===
 
 Here is an example of how to set these properties:

--- a/crnk-documentation/src/docs/asciidoc/operations.adoc
+++ b/crnk-documentation/src/docs/asciidoc/operations.adoc
@@ -48,7 +48,7 @@ The operations module can be customized using one of the following properties:
 |===
 |*Property Name* |*Description* |*Default Value*
 |resumeOnError | If an error occurs during the operation execution, continue the other operations. | False
-|includeAllRelationships | Toggle to include all relationships in the request by default. | True
+|includeChangedRelationships | Toggle to include all changed relationships in the request by default. This only applies for POST and PATCH operation requests. | True
 |displayOperationResponseOnSuccess | If true, the response will always be included. Otherwise, it only displays the status codes of the operation unless an error has occurred. | True
 |===
 
@@ -57,7 +57,7 @@ Here is an example of how to set these properties:
 [source]
 ----
 OperationsModule operationsModule = OperationsModule.create();
-operationsModule.setIncludeAllRelationships(false);
+operationsModule.setIncludeChangedRelationships(false);
 operationsModule.resumeOnError(true);
 ...
 ----

--- a/crnk-operations/src/main/java/io/crnk/operations/server/OperationsModule.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/server/OperationsModule.java
@@ -46,7 +46,7 @@ public class OperationsModule implements Module {
 
     private boolean resumeOnError = false;
 
-    private boolean includeAllRelationships = true;
+    private boolean includeChangedRelationships = true;
 
     private boolean displayOperationResponseOnSuccess = true;
 
@@ -205,7 +205,7 @@ public class OperationsModule implements Module {
                 String method = HttpMethod.GET.toString();
 
                 Map<String, Set<String>> parameters = new HashMap<>();
-                if (includeAllRelationships) {
+                if (includeChangedRelationships) {
                     parameters.put("include", getLoadedRelationshipNames(resource));  
                 }
 
@@ -268,12 +268,12 @@ public class OperationsModule implements Module {
         this.resumeOnError = resumeOnError;
     }
 
-    public boolean isIncludeAllRelationships() {
-        return includeAllRelationships;
+    public boolean isIncludeChangedRelationships() {
+        return includeChangedRelationships;
     }
 
-    public void setIncludeAllRelationships(boolean includeAllRelationships) {
-        this.includeAllRelationships = includeAllRelationships;
+    public void setIncludeChangedRelationships(boolean includeChangedRelationships) {
+        this.includeChangedRelationships = includeChangedRelationships;
     }
 
     public boolean isDisplayOperationResponseOnSuccess() {

--- a/crnk-operations/src/main/java/io/crnk/operations/server/OperationsModule.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/server/OperationsModule.java
@@ -205,7 +205,7 @@ public class OperationsModule implements Module {
                 String method = HttpMethod.GET.toString();
 
                 Map<String, Set<String>> parameters = new HashMap<>();
-                if (includeAllRelationships == true) {
+                if (includeAllRelationships) {
                     parameters.put("include", getLoadedRelationshipNames(resource));  
                 }
 
@@ -233,7 +233,7 @@ public class OperationsModule implements Module {
 
         boolean success = response.getHttpStatus() < 400;
 
-        if (displayOperationResponseOnSuccess == true || !success) {
+        if (displayOperationResponseOnSuccess || !success) {
             copyDocument(operationResponse, response.getDocument());    
         }
         

--- a/crnk-operations/src/main/java/io/crnk/operations/server/OperationsModule.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/server/OperationsModule.java
@@ -48,7 +48,7 @@ public class OperationsModule implements Module {
 
     private boolean includeAllRelationships = true;
 
-    private boolean displayResultsOnSuccess = true;
+    private boolean displayOperationResponseOnSuccess = true;
 
     public static OperationsModule create() {
         return new OperationsModule();
@@ -179,7 +179,7 @@ public class OperationsModule implements Module {
             }
         }
 
-        if (orderedOperations.size() > 1 && ((!successful && resumeOnError) || (successful && displayResultsOnSuccess))) {
+        if (orderedOperations.size() > 1 && ((!successful && resumeOnError) || (successful && displayOperationResponseOnSuccess))) {
             fetchUpToDateResponses(orderedOperations, responses);
         }
 
@@ -231,10 +231,12 @@ public class OperationsModule implements Module {
         OperationResponse operationResponse = new OperationResponse();
         operationResponse.setStatus(response.getHttpStatus());
 
-        if (displayResultsOnSuccess == true) {
+        boolean success = response.getHttpStatus() < 400;
+
+        if (displayOperationResponseOnSuccess == true || !success) {
             copyDocument(operationResponse, response.getDocument());    
         }
-
+        
         return operationResponse;
     }
 
@@ -274,12 +276,12 @@ public class OperationsModule implements Module {
         this.includeAllRelationships = includeAllRelationships;
     }
 
-    public boolean isDisplayResultsOnSuccess() {
-        return displayResultsOnSuccess;
+    public boolean isDisplayOperationResponseOnSuccess() {
+        return displayOperationResponseOnSuccess;
     }
 
-    public void setDisplayResultsOnSuccess(boolean displayResultsOnSuccess) {
-        this.displayResultsOnSuccess = displayResultsOnSuccess;
+    public void setDisplayOperationResponseOnSuccess(boolean displayOperationResponseOnSuccess) {
+        this.displayOperationResponseOnSuccess = displayOperationResponseOnSuccess;
     }
 
     protected class DefaultOperationFilterContext implements OperationFilterContext {

--- a/crnk-operations/src/test/java/io/crnk/operations/OperationsDisplayOperationResponseOnSuccessTest.java
+++ b/crnk-operations/src/test/java/io/crnk/operations/OperationsDisplayOperationResponseOnSuccessTest.java
@@ -1,0 +1,73 @@
+package io.crnk.operations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crnk.core.engine.http.HttpMethod;
+import io.crnk.core.repository.ResourceRepository;
+import io.crnk.operations.client.OperationsCall;
+import io.crnk.operations.client.OperationsClient;
+import io.crnk.operations.model.PersonEntity;
+import io.crnk.operations.server.OperationsModule;
+
+public class OperationsDisplayOperationResponseOnSuccessTest extends AbstractOperationsTest {
+
+    protected ResourceRepository<PersonEntity, UUID> personRepo;
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		personRepo = client.getRepositoryForType(PersonEntity.class);
+    }
+    
+    @Test
+    public void testDefaultBehaviorDisplayOperationResponseOnSuccessTest() {
+        // Create person entities.
+        PersonEntity person1 = newPerson("1");
+        PersonEntity person2 = newPerson("2");
+        PersonEntity person3 = newPerson("3");
+
+        // Create operation and execute it.
+        OperationsClient operationsClient = new OperationsClient(client);
+		OperationsCall call = operationsClient.createCall();
+		call.add(HttpMethod.POST, person1);
+        call.add(HttpMethod.POST, person2);
+        call.add(HttpMethod.POST, person3);
+        call.execute();
+        
+        OperationResponse response = call.getResponse(0);
+		assertTrue(response.getData().isPresent());
+    }
+
+    @Test
+    public void testDeactivateDisplayOperationResponseOnSuccessTest() {
+        // Deactivate the displayOperationResponseOnSuccess property.
+        operationsModule.setDisplayOperationResponseOnSuccess(false);
+
+        // Create person entities.
+        PersonEntity person1 = newPerson("1");
+        PersonEntity person2 = newPerson("2");
+        PersonEntity person3 = newPerson("3");
+
+        // Create operation and execute it.
+        OperationsClient operationsClient = new OperationsClient(client);
+		OperationsCall call = operationsClient.createCall();
+		call.add(HttpMethod.POST, person1);
+        call.add(HttpMethod.POST, person2);
+        call.add(HttpMethod.POST, person3);
+        call.execute();
+        
+        OperationResponse response = call.getResponse(0);
+        assertFalse(response.getData().isPresent());
+        
+        // Reset the operations module...
+        operationsModule = OperationsModule.create();
+    }
+
+}

--- a/crnk-operations/src/test/java/io/crnk/operations/OperationsResumeOnErrorTest.java
+++ b/crnk-operations/src/test/java/io/crnk/operations/OperationsResumeOnErrorTest.java
@@ -1,0 +1,84 @@
+package io.crnk.operations;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crnk.core.engine.http.HttpMethod;
+import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.repository.ResourceRepository;
+import io.crnk.core.resource.list.ResourceList;
+import io.crnk.operations.client.OperationsCall;
+import io.crnk.operations.client.OperationsClient;
+import io.crnk.operations.model.PersonEntity;
+import io.crnk.operations.server.OperationsModule;
+
+public class OperationsResumeOnErrorTest extends AbstractOperationsTest {
+
+    protected ResourceRepository<PersonEntity, UUID> personRepo;
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		personRepo = client.getRepositoryForType(PersonEntity.class);
+    }
+    
+    @Test
+    public void testDefaultBehaviorResumeOnError() {
+        // Create person entities.
+        PersonEntity person1 = newPerson("1");
+        PersonEntity person2 = newPerson("2");
+        PersonEntity person3 = newPerson("3");
+        
+        // Cause a validation error.
+        person2.setName(null);
+
+        // Create operation and execute it.
+        OperationsClient operationsClient = new OperationsClient(client);
+		OperationsCall call = operationsClient.createCall();
+		call.add(HttpMethod.POST, person1);
+        call.add(HttpMethod.POST, person2);
+        call.add(HttpMethod.POST, person3);
+        call.execute();
+        
+        // Only one person should exist since it should not resume on error.
+        QuerySpec querySpec = new QuerySpec(PersonEntity.class);
+		ResourceList<PersonEntity> persons = personRepo.findAll(querySpec);
+		assertEquals(1, persons.size());
+    }
+
+    @Test
+    public void testActivateResumeOnError() {
+        // Activate the setResumeOnError.
+        operationsModule.setResumeOnError(true);
+
+        // Create person entities.
+        PersonEntity person1 = newPerson("1");
+        PersonEntity person2 = newPerson("2");
+        PersonEntity person3 = newPerson("3");
+        
+        // Cause a validation error.
+        person2.setName(null);
+
+        // Create operation and execute it.
+        OperationsClient operationsClient = new OperationsClient(client);
+		OperationsCall call = operationsClient.createCall();
+		call.add(HttpMethod.POST, person1);
+        call.add(HttpMethod.POST, person2);
+        call.add(HttpMethod.POST, person3);
+        call.execute();
+        
+        // Only two people should exist since it will resume the rest of the operation.
+        QuerySpec querySpec = new QuerySpec(PersonEntity.class);
+		ResourceList<PersonEntity> persons = personRepo.findAll(querySpec);
+        assertEquals(2, persons.size());
+        
+        // Reset the settings for other tests.
+        operationsModule = OperationsModule.create();
+    }
+
+}


### PR DESCRIPTION
Added a couple of toggles in the operations module to fix issues in #506. This greatly improves performance for entities which contain many foreign keys. Added a displayOperationResponseOnSuccess toggle which allows to only display the status to decrease the size of the response you get back. 

Also updated the documentation to reflect these changes. 

Thanks!