### PR TITLE
Add support for nestled self-referenced generics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ build
 node_modules
 
 temp
+
+# MacOS
+.DS_Store

--- a/crnk-core/build.gradle
+++ b/crnk-core/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 dependencies {
-    compile 'net.jodah:typetools:0.6.1'
+    compile 'net.jodah:typetools:0.6.2'
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile 'com.fasterxml.jackson.core:jackson-databind'
     compile 'com.fasterxml.jackson.core:jackson-annotations'

--- a/crnk-core/build.gradle
+++ b/crnk-core/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 dependencies {
-    compile 'net.jodah:typetools:0.6.2'
+    compile 'net.jodah:typetools:0.6.3'
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile 'com.fasterxml.jackson.core:jackson-databind'
     compile 'com.fasterxml.jackson.core:jackson-annotations'

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/ResourceInformationProviderBase.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/ResourceInformationProviderBase.java
@@ -174,7 +174,7 @@ public abstract class ResourceInformationProviderBase implements ResourceInforma
 				fieldBuilder.setMappedBy(true);
 			}
 
-			fieldBuilder.oppositeResourceType(getResourceType(genericType, context));
+			fieldBuilder.oppositeResourceType(getResourceType(attributeDesc.getType(), context));
 			fieldBuilder.oppositeName(getOppositeName(attributeDesc));
 
 			Optional<JsonApiRelation> relationAnnotation = attributeDesc.getAnnotation(JsonApiRelation.class);

--- a/crnk-data/crnk-data-jpa/src/test/java/io/crnk/data/jpa/information/JpaResourceInformationProviderTest.java
+++ b/crnk-data/crnk-data-jpa/src/test/java/io/crnk/data/jpa/information/JpaResourceInformationProviderTest.java
@@ -25,6 +25,7 @@ import io.crnk.data.jpa.model.RenamedTestEntity;
 import io.crnk.data.jpa.model.TestEmbeddable;
 import io.crnk.data.jpa.model.TestEntity;
 import io.crnk.data.jpa.model.TestMappedSuperclass;
+import io.crnk.data.jpa.model.TestSubclassWithSuperclassGenericsInterface;
 import io.crnk.data.jpa.model.VersionedEntity;
 import io.crnk.data.jpa.util.ResourceFieldComparator;
 import io.crnk.legacy.registry.DefaultResourceInformationProviderContext;
@@ -232,6 +233,17 @@ public class JpaResourceInformationProviderTest {
         Assert.assertEquals("testEntity", field.getOppositeName());
         Assert.assertEquals(RelationshipRepositoryBehavior.FORWARD_OPPOSITE, field.getRelationshipRepositoryBehavior());
     }
+	
+	@Test
+	public void testManyToOneRelationWithSuperclassGenericsInterface() {
+		ResourceInformation info = builder.build(TestSubclassWithSuperclassGenericsInterface.class);
+		ResourceField field = info.findRelationshipFieldByName("generic");
+		Assert.assertEquals(ResourceFieldType.RELATIONSHIP, field.getResourceFieldType());
+		Assert.assertEquals("testSubclassWithSuperclassGenericsInterface", field.getOppositeResourceType());
+		Assert.assertEquals(SerializeType.LAZY, field.getSerializeType());
+		Assert.assertNull(field.getOppositeName());
+		Assert.assertEquals(RelationshipRepositoryBehavior.FORWARD_OWNER, field.getRelationshipRepositoryBehavior());
+	}
 
     @Test
     public void testAttributeAnnotations() throws SecurityException, IllegalArgumentException {

--- a/crnk-data/crnk-data-jpa/src/test/java/io/crnk/data/jpa/model/TestInterfaceWithGenerics.java
+++ b/crnk-data/crnk-data-jpa/src/test/java/io/crnk/data/jpa/model/TestInterfaceWithGenerics.java
@@ -1,0 +1,8 @@
+package io.crnk.data.jpa.model;
+
+public interface TestInterfaceWithGenerics<T> {
+
+	T getGeneric();
+
+	void setGeneric(T generic);
+}

--- a/crnk-data/crnk-data-jpa/src/test/java/io/crnk/data/jpa/model/TestMappedSuperclassWithGenericsInterface.java
+++ b/crnk-data/crnk-data-jpa/src/test/java/io/crnk/data/jpa/model/TestMappedSuperclassWithGenericsInterface.java
@@ -1,0 +1,38 @@
+package io.crnk.data.jpa.model;
+
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public class TestMappedSuperclassWithGenericsInterface<T extends TestInterfaceWithGenerics<T>>
+		implements TestInterfaceWithGenerics<T> {
+
+	@Id
+	private Long id;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn
+	private T generic;
+
+	@Override
+	public T getGeneric() {
+		return generic;
+	}
+
+	@Override
+	public void setGeneric(T generic) {
+		this.generic = generic;
+	}
+
+}

--- a/crnk-data/crnk-data-jpa/src/test/java/io/crnk/data/jpa/model/TestSubclassWithSuperclassGenericsInterface.java
+++ b/crnk-data/crnk-data-jpa/src/test/java/io/crnk/data/jpa/model/TestSubclassWithSuperclassGenericsInterface.java
@@ -1,0 +1,9 @@
+package io.crnk.data.jpa.model;
+
+import javax.persistence.Entity;
+
+@Entity
+public class TestSubclassWithSuperclassGenericsInterface
+		extends TestMappedSuperclassWithGenericsInterface<TestSubclassWithSuperclassGenericsInterface> {
+
+}

--- a/versions.properties
+++ b/versions.properties
@@ -1,5 +1,5 @@
 reflections.version=0.9.9
-typetools.version=0.6.1
+typetools.version=0.6.2
 jackson.version=2.8.7
 slf4j.version=1.7.13
 logback.version=1.1.7

--- a/versions.properties
+++ b/versions.properties
@@ -1,5 +1,5 @@
 reflections.version=0.9.9
-typetools.version=0.6.2
+typetools.version=0.6.3
 jackson.version=2.8.7
 slf4j.version=1.7.13
 logback.version=1.1.7


### PR DESCRIPTION
This is a PR to resolve issue: #500

We are trying to use Crnk in a project and have some issues with crnk-core when resolving self-referential type-declarations on MappedSuperclasses used in crnk-data-jpa. Crnk cannot properly resolve MappedSuperclass of type: `class Foo<T extends Bar<T>> implements Bar<T>` for the opposite resource type.

This PR contains a correction for this, with included JUnit tests.

This PR also requires an updated TypeTools library, see PR jhalterman/typetools#53 that is pending approval. (Same update of TypeTooles is referenced in crnk-project/crnk-framework#512)


