### PR TITLE
Added support for OpenAPI generation into crnk-gen-gradle.

### DIFF
--- a/crnk-gen/crnk-gen-gradle/src/main/java/io/crnk/gen/gradle/GeneratorExtension.java
+++ b/crnk-gen/crnk-gen-gradle/src/main/java/io/crnk/gen/gradle/GeneratorExtension.java
@@ -5,6 +5,8 @@ import io.crnk.gen.asciidoc.AsciidocGeneratorConfig;
 import io.crnk.gen.asciidoc.internal.AsciidocGeneratorModule;
 import io.crnk.gen.base.GeneratorConfig;
 import io.crnk.gen.base.RuntimeConfiguration;
+import io.crnk.gen.openapi.OpenAPIGeneratorConfig;
+import io.crnk.gen.openapi.OpenAPIGeneratorModule;
 import io.crnk.gen.typescript.TSGeneratorConfig;
 import io.crnk.gen.typescript.TSGeneratorModule;
 import org.gradle.api.Project;
@@ -46,5 +48,13 @@ public class GeneratorExtension extends GeneratorConfig {
 
     public AsciidocGeneratorConfig asciidoc(Closure<AsciidocGeneratorConfig> closure) {
         return (AsciidocGeneratorConfig) project.configure(getAsciidoc(), closure);
+    }
+
+    public OpenAPIGeneratorConfig getOpenapi() {
+        return (OpenAPIGeneratorConfig) getModuleConfig(OpenAPIGeneratorModule.NAME);
+    }
+
+    public OpenAPIGeneratorConfig openapi(Closure<OpenAPIGeneratorConfig> closure) {
+        return (OpenAPIGeneratorConfig) project.configure(getOpenapi(), closure);
     }
 }

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/OpenAPIGeneratorModule.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/OpenAPIGeneratorModule.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 
 public class OpenAPIGeneratorModule implements GeneratorModule {
 
-  private static final String NAME = "openapi";
+  public static final String NAME = "openapi";
 
   private OpenAPIGeneratorConfig config = new OpenAPIGeneratorConfig();
 


### PR DESCRIPTION
Regarding #581 there was missing implementation on crnk-gen-gradle module which allows to put configuration into gradle file.

Here is the missing part