### PR TITLE
Experimental BulkResourceRepository interface #597

### DIFF
--- a/crnk-client/src/main/java/io/crnk/client/CrnkClient.java
+++ b/crnk-client/src/main/java/io/crnk/client/CrnkClient.java
@@ -391,8 +391,9 @@ public class CrnkClient {
 		DefaultRegistryEntryBuilder.contributeFields(moduleRegistry, resourceInformation);
 		ModuleUtils.adaptInformation(resourceInformation, moduleRegistry);
 
-		final ResourceRepository repositoryStub = (ResourceRepository)
-				decorate(new ResourceRepositoryStubImpl<T, I>(this, resourceClass, resourceInformation, urlBuilder));
+		final ResourceRepository repositoryStub = (ResourceRepository) decorate(
+				new ResourceRepositoryStubImpl<T, I>(this, resourceClass, resourceInformation, urlBuilder)
+		);
 
 		// create interface for it!
 		ResourceRepositoryInformation repositoryInformation =
@@ -470,11 +471,10 @@ public class CrnkClient {
 	public <R extends ResourceRepository<?, ?>> R getRepositoryForInterface(Class<R> repositoryInterfaceClass) {
 		init();
 		RepositoryInformationProvider informationBuilder = moduleRegistry.getRepositoryInformationBuilder();
-		PreconditionUtil.verify(informationBuilder.accept(repositoryInterfaceClass), "%s is not a valid repository interface",
-				repositoryInterfaceClass);
-		ResourceRepositoryInformation repositoryInformation = (ResourceRepositoryInformation) informationBuilder
-				.build(repositoryInterfaceClass, new DefaultRepositoryInformationProviderContext(moduleRegistry));
-		Class<?> resourceClass = repositoryInformation.getResourceInformation().get().getResourceClass();
+		PreconditionUtil.verify(informationBuilder.accept(repositoryInterfaceClass), "%s is not a valid repository interface", repositoryInterfaceClass);
+		ResourceRepositoryInformation repositoryInformation =
+				(ResourceRepositoryInformation) informationBuilder.build(repositoryInterfaceClass, new DefaultRepositoryInformationProviderContext(moduleRegistry));
+		Class<?> resourceClass = repositoryInformation.getResource().getResourceClass();
 
 		Object actionStub = actionStubFactory != null ? actionStubFactory.createStub(repositoryInterfaceClass) : null;
 		ResourceRepository<?, Serializable> repositoryStub = getRepositoryForType(resourceClass);

--- a/crnk-client/src/main/java/io/crnk/client/internal/ClientDocumentMapper.java
+++ b/crnk-client/src/main/java/io/crnk/client/internal/ClientDocumentMapper.java
@@ -1,10 +1,12 @@
 package io.crnk.client.internal;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.crnk.client.internal.proxy.ClientProxyFactory;
 import io.crnk.client.internal.proxy.ObjectProxy;
-import io.crnk.core.resource.meta.JsonLinksInformation;
-import io.crnk.core.resource.meta.JsonMetaInformation;
 import io.crnk.core.engine.document.Document;
 import io.crnk.core.engine.document.Relationship;
 import io.crnk.core.engine.document.Resource;
@@ -24,142 +26,148 @@ import io.crnk.core.engine.result.ImmediateResultFactory;
 import io.crnk.core.module.ModuleRegistry;
 import io.crnk.core.resource.annotations.SerializeType;
 import io.crnk.core.resource.list.DefaultResourceList;
+import io.crnk.core.resource.meta.JsonLinksInformation;
+import io.crnk.core.resource.meta.JsonMetaInformation;
 import io.crnk.core.utils.Nullable;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 public class ClientDocumentMapper extends DocumentMapper {
 
-    private final ModuleRegistry moduleRegistry;
+	private final ModuleRegistry moduleRegistry;
 
-    private ClientProxyFactory proxyFactory;
+	private ClientProxyFactory proxyFactory;
 
-    private ObjectMapper objectMapper;
+	private ObjectMapper objectMapper;
 
-    private ResourceRegistry resourceRegistry;
+	private ResourceRegistry resourceRegistry;
 
-    private TypeParser typeParser;
+	private TypeParser typeParser;
 
-    public ClientDocumentMapper(ModuleRegistry moduleRegistry, ObjectMapper objectMapper, PropertiesProvider
-            propertiesProvider) {
-        super(moduleRegistry.getResourceRegistry(), objectMapper, propertiesProvider, null, new ImmediateResultFactory(), null, true);
-        this.moduleRegistry = moduleRegistry;
-        this.resourceRegistry = moduleRegistry.getResourceRegistry();
-        this.typeParser = moduleRegistry.getTypeParser();
-        this.objectMapper = objectMapper;
-    }
+	public ClientDocumentMapper(ModuleRegistry moduleRegistry, ObjectMapper objectMapper, PropertiesProvider
+			propertiesProvider) {
+		super(moduleRegistry.getResourceRegistry(), objectMapper, propertiesProvider, null, new ImmediateResultFactory(), null, true);
+		this.moduleRegistry = moduleRegistry;
+		this.resourceRegistry = moduleRegistry.getResourceRegistry();
+		this.typeParser = moduleRegistry.getTypeParser();
+		this.objectMapper = objectMapper;
+	}
 
-    @Override
-    protected ResourceMapper newResourceMapper(final DocumentMapperUtil util, boolean client, ObjectMapper objectMapper) {
-        return new ResourceMapper(util, client, objectMapper, null) {
+	@Override
+	protected ResourceMapper newResourceMapper(final DocumentMapperUtil util, boolean client, ObjectMapper objectMapper) {
+		return new ResourceMapper(util, client, objectMapper, null) {
 
-            @Override
-            protected void setRelationship(Resource resource, ResourceField field, Object entity,
-                                           ResourceInformation resourceInformation, QueryAdapter queryAdapter,
-                                           ResourceMappingConfig mappingConfig) {
-                // we also include relationship data if it is not null and not a
-                // unloaded proxy
-                boolean includeRelation;
+			@Override
+			protected void setRelationship(Resource resource, ResourceField field, Object entity,
+					ResourceInformation resourceInformation, QueryAdapter queryAdapter,
+					ResourceMappingConfig mappingConfig) {
+				// we also include relationship data if it is not null and not a
+				// unloaded proxy
+				boolean includeRelation;
 
-                Object relationshipId = null;
+				Object relationshipId = null;
 
-                if (field.hasIdField()) {
-                    Object relationshipValue = field.getIdAccessor().getValue(entity);
+				if (field.hasIdField()) {
+					Object relationshipValue = field.getIdAccessor().getValue(entity);
 
-                    ResourceInformation oppositeInformation =
-                            resourceRegistry.getEntry(field.getOppositeResourceType()).getResourceInformation();
+					ResourceInformation oppositeInformation =
+							resourceRegistry.getEntry(field.getOppositeResourceType()).getResourceInformation();
 
-                    if (relationshipValue instanceof Collection) {
-                        List ids = new ArrayList();
-                        for (Object elem : (Collection<?>) relationshipValue) {
-                            ids.add(oppositeInformation.toResourceIdentifier(elem));
-                        }
-                        relationshipId = ids;
-                    } else if (relationshipValue != null) {
-                        relationshipId = oppositeInformation.toResourceIdentifier(relationshipValue);
-                    }
+					if (relationshipValue instanceof Collection) {
+						List ids = new ArrayList();
+						for (Object elem : (Collection<?>) relationshipValue) {
+							ids.add(oppositeInformation.toResourceIdentifier(elem));
+						}
+						relationshipId = ids;
+					}
+					else if (relationshipValue != null) {
+						relationshipId = oppositeInformation.toResourceIdentifier(relationshipValue);
+					}
 
-                    includeRelation = relationshipId != null || field.getSerializeType() != SerializeType.LAZY;
-                } else {
-                    Object relationshipValue = field.getAccessor().getValue(entity);
-                    if (relationshipValue instanceof ObjectProxy) {
-                        includeRelation = ((ObjectProxy) relationshipValue).isLoaded();
-                    } else {
-                        // TODO for fieldSets handling in the future the lazy
-                        // handling must be different
-                        includeRelation = relationshipValue != null || field.getSerializeType() != SerializeType.LAZY && !field
-                                .isCollection();
-                    }
+					includeRelation = relationshipId != null || field.getSerializeType() != SerializeType.LAZY;
+				}
+				else {
+					Object relationshipValue = field.getAccessor().getValue(entity);
+					if (relationshipValue instanceof ObjectProxy) {
+						includeRelation = ((ObjectProxy) relationshipValue).isLoaded();
+					}
+					else {
+						// TODO for fieldSets handling in the future the lazy
+						// handling must be different
+						includeRelation = relationshipValue != null || field.getSerializeType() != SerializeType.LAZY && !field
+								.isCollection();
+					}
 
-                    if (relationshipValue != null && includeRelation) {
-                        if (relationshipValue instanceof Collection) {
-                            relationshipId = util.toResourceIds((Collection<?>) relationshipValue);
-                        } else {
-                            relationshipId = util.toResourceId(relationshipValue);
-                        }
-                    }
-                }
+					if (relationshipValue != null && includeRelation) {
+						if (relationshipValue instanceof Collection) {
+							relationshipId = util.toResourceIds((Collection<?>) relationshipValue);
+						}
+						else {
+							relationshipId = util.toResourceId(relationshipValue);
+						}
+					}
+				}
 
-                if (includeRelation && (!mappingConfig.isIgnoreDefaults() || !isDefault(relationshipId))) {
-                    Relationship relationship = new Relationship();
-                    relationship.setData(Nullable.of(relationshipId));
-                    resource.getRelationships().put(field.getJsonName(), relationship);
-                }
-            }
-        };
-    }
+				if (includeRelation && (!mappingConfig.isIgnoreDefaults() || !isDefault(relationshipId))) {
+					Relationship relationship = new Relationship();
+					relationship.setData(Nullable.of(relationshipId));
+					resource.getRelationships().put(field.getJsonName(), relationship);
+				}
+			}
+		};
+	}
 
-    private boolean isDefault(Object relationshipId) {
-        return relationshipId == null || (relationshipId instanceof Collection) && ((Collection) relationshipId).isEmpty();
-    }
+	private boolean isDefault(Object relationshipId) {
+		return relationshipId == null || (relationshipId instanceof Collection) && ((Collection) relationshipId).isEmpty();
+	}
 
-    public void setProxyFactory(ClientProxyFactory proxyFactory) {
-        this.proxyFactory = proxyFactory;
-    }
+	public void setProxyFactory(ClientProxyFactory proxyFactory) {
+		this.proxyFactory = proxyFactory;
+	}
 
-    public Object fromDocument(Document document, boolean getList) {
-        ControllerContext controllerContext = new ControllerContext(moduleRegistry, () -> this);
-        ClientResourceUpsert upsert = new ClientResourceUpsert(proxyFactory);
-        upsert.init(controllerContext);
+	public Object fromDocument(Document document, boolean getList) {
+		ControllerContext controllerContext = new ControllerContext(moduleRegistry, () -> this);
+		ClientResourceUpsert upsert = new ClientResourceUpsert(proxyFactory);
+		upsert.init(controllerContext);
 
-        PreconditionUtil.verify(document.getErrors() == null || document.getErrors().isEmpty(), "document contains json api errors and cannot be processed, use exception mapper instead");
+		PreconditionUtil.verify(document.getErrors() == null || document.getErrors().isEmpty(), "document contains json api errors and cannot be processed, use exception mapper instead");
 
-        if (!document.getData().isPresent()) {
-            return null;
-        }
+		if (!document.getData().isPresent()) {
+			return null;
+		}
 
-        List<Resource> included = document.getIncluded();
-        List<Resource> data = document.getCollectionData().get();
+		List<Resource> included = document.getIncluded();
+		List<Resource> data = document.getCollectionData().get();
 
-        List<Object> dataObjects = upsert.allocateResources(data);
-        if (included != null) {
-            upsert.allocateResources(included);
-        }
+		List<Object> dataObjects = upsert.allocateResources(data);
+		if (included != null) {
+			upsert.allocateResources(included);
+		}
 
-        upsert.setRelations(data);
-        if (included != null) {
-            upsert.setRelations(included);
-        }
+		upsert.setRelations(data);
+		if (included != null) {
+			upsert.setRelations(included);
+		}
 
-        if (getList) {
-            DefaultResourceList<Object> resourceList = new DefaultResourceList();
-            resourceList.addAll(dataObjects);
-            if (document.getLinks() != null) {
-                resourceList.setLinks(new JsonLinksInformation(document.getLinks(), objectMapper));
-            }
-            if (document.getMeta() != null) {
-                resourceList.setMeta(new JsonMetaInformation(document.getMeta(), objectMapper));
-            }
-            return resourceList;
-        } else {
-            if (dataObjects.isEmpty()) {
-                return null;
-            }
-            PreconditionUtil.verify(dataObjects.size() == 1, "expected unique result, got %s", dataObjects);
-            return dataObjects.get(0);
-        }
-    }
+		if (getList) {
+			DefaultResourceList<Object> resourceList = new DefaultResourceList();
+			resourceList.addAll(dataObjects);
+			if (document.getLinks() != null) {
+				resourceList.setLinks(new JsonLinksInformation(document.getLinks(), objectMapper));
+			}
+			if (document.getMeta() != null) {
+				resourceList.setMeta(new JsonMetaInformation(document.getMeta(), objectMapper));
+			}
+			return resourceList;
+		}
+		else {
+			if (dataObjects.isEmpty()) {
+				return null;
+			}
+			if (document.isMultiple()) {
+				return dataObjects;
+			}
+			PreconditionUtil.verify(dataObjects.size() == 1, "expected unique result, got %s", dataObjects);
+			return dataObjects.get(0);
+		}
+	}
 
 }

--- a/crnk-client/src/main/java/io/crnk/client/internal/ClientStubInvocationHandler.java
+++ b/crnk-client/src/main/java/io/crnk/client/internal/ClientStubInvocationHandler.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
+import io.crnk.core.repository.BulkResourceRepository;
 import io.crnk.core.repository.ResourceRepository;
 import io.crnk.core.repository.decorate.Wrapper;
 import io.crnk.core.resource.list.DefaultResourceList;
@@ -46,7 +47,7 @@ public class ClientStubInvocationHandler implements InvocationHandler {
 			if(method.getDeclaringClass().isAssignableFrom(Wrapper.class) && method.getName().equals("getWrappedObject")){
 				return repositoryStub;
 			}
-			if (method.getDeclaringClass().isAssignableFrom(ResourceRepository.class)) {
+			if (method.getDeclaringClass().isAssignableFrom(ResourceRepository.class) || method.getDeclaringClass().isAssignableFrom(BulkResourceRepository.class)) {
 				// execute document method
 				return method.invoke(repositoryStub, args);
 			} else if (interfaceStubMethodMap.containsKey(method)) {

--- a/crnk-client/src/test/java/io/crnk/client/BulkClientTest.java
+++ b/crnk-client/src/test/java/io/crnk/client/BulkClientTest.java
@@ -1,0 +1,39 @@
+package io.crnk.client;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.crnk.test.mock.models.BulkTask;
+import io.crnk.test.mock.repository.BulkTaskRepository;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BulkClientTest extends AbstractClientTest {
+
+	private static final String EXPECTED_CONTENT_TYPE = "application/vnd.api+json";
+
+	protected BulkTaskRepository taskRepo;
+
+	@Before
+	public void setup() {
+		super.setup();
+
+		taskRepo = client.getRepositoryForInterface(BulkTaskRepository.class);
+	}
+
+	@Test
+	public void test() {
+		List<BulkTask> tasks = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			BulkTask task = new BulkTask();
+			task.setId((long) i);
+			task.setName("task" + i);
+			tasks.add(task);
+		}
+
+		List<BulkTask> createdTasks = taskRepo.create(tasks);
+		Assert.assertEquals(10, createdTasks.size());
+		Assert.assertEquals("task0", createdTasks.get(0).getName());
+	}
+}

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/BaseController.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/BaseController.java
@@ -15,7 +15,6 @@ import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.engine.result.Result;
 import io.crnk.core.exception.BadRequestException;
 import io.crnk.core.exception.RequestBodyException;
-import io.crnk.core.utils.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,13 +81,13 @@ public abstract class BaseController implements Controller {
 		Integer httpStatus = response.getHttpStatus();
 		Document document = response.getDocument();
 		if (httpStatus == HttpStatus.CREATED_201) {
-			Nullable<Resource> singleData = document.getSingleData();
-			if (!singleData.isPresent()) {
+			if (!document.getData().isPresent()) {
 				throw new IllegalStateException("upon POST with status 201 a resource must be returned");
 			}
-			Resource resource = singleData.get();
-			if (resource.getId() == null) {
-				throw new IllegalStateException("upon POST with status 201 the resource must have an ID, consider 202 otherwise");
+			for (Resource resource : document.getCollectionData().get()) {
+				if (resource.getId() == null) {
+					throw new IllegalStateException("upon POST with status 201 the resource must have an ID, consider 202 otherwise");
+				}
 			}
 		}
 	}

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/ResourcePostController.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/controller/ResourcePostController.java
@@ -1,5 +1,8 @@
 package io.crnk.core.engine.internal.dispatcher.controller;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import io.crnk.core.engine.dispatcher.Response;
@@ -16,6 +19,7 @@ import io.crnk.core.engine.query.QueryAdapter;
 import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.result.Result;
+import io.crnk.core.engine.result.ResultFactory;
 import io.crnk.core.repository.response.JsonApiResponse;
 
 public class ResourcePostController extends ResourceUpsert {
@@ -36,33 +40,39 @@ public class ResourcePostController extends ResourceUpsert {
 	@Override
 	public Result<Response> handleAsync(JsonPath jsonPath, QueryAdapter queryAdapter, Document requestDocument) {
 		RegistryEntry endpointRegistryEntry = jsonPath.getRootEntry();
-		Resource requestResource = getRequestBody(requestDocument, jsonPath, HttpMethod.POST);
-		RegistryEntry registryEntry = getRegistryEntry(requestResource.getType());
-		logger.debug("using registry entry {}", registryEntry);
-		ResourceInformation resourceInformation = registryEntry.getResourceInformation();
-		verifyTypes(HttpMethod.POST, endpointRegistryEntry, registryEntry);
+		List<Resource> resourceBodies = getRequestBodys(requestDocument, jsonPath, HttpMethod.POST);
+		ResultFactory resultFactory = context.getResultFactory();
+
+		List<Result<Object>> entityResults = new ArrayList<>();
+		Set<String> loadedRelationshipNames = new HashSet<>();
+		for (Resource resourceBody : resourceBodies) {
+			RegistryEntry registryEntry = getRegistryEntry(resourceBody.getType());
+			logger.debug("using registry entry {}", registryEntry);
+			ResourceInformation resourceInformation = registryEntry.getResourceInformation();
+			verifyTypes(HttpMethod.POST, endpointRegistryEntry, registryEntry);
+
+			loadedRelationshipNames.addAll(getLoadedRelationshipNames(resourceBody));
+
+			QueryContext queryContext = queryAdapter.getQueryContext();
+			if (Resource.class.equals(resourceInformation.getImplementationClass())) {
+				entityResults.add(resultFactory.just(resourceBody));
+			}
+			else {
+				Object entity = newEntity(resourceInformation, resourceBody);
+				setId(resourceBody, entity, resourceInformation);
+				setType(resourceBody, entity);
+				setAttributes(resourceBody, entity, resourceInformation, queryContext);
+				setMeta(resourceBody, entity, resourceInformation);
+				setLinks(resourceBody, entity, resourceInformation);
+				Result zipped = setRelationsAsync(entity, registryEntry, resourceBody, queryAdapter, false);
+				entityResults.add(zipped.map(it -> entity));
+			}
+		}
 
 		ResourceRepositoryAdapter resourceRepository = endpointRegistryEntry.getResourceRepository();
+		Result<List<Object>> result = resultFactory.all(entityResults);
 
-		Set<String> loadedRelationshipNames = getLoadedRelationshipNames(requestResource);
-
-		QueryContext queryContext = queryAdapter.getQueryContext();
-		Result<JsonApiResponse> response;
-		if (Resource.class.equals(resourceInformation.getImplementationClass())) {
-			response = resourceRepository.create(requestResource, queryAdapter);
-		}
-		else {
-			Object entity = newEntity(resourceInformation, requestResource);
-			setId(requestResource, entity, resourceInformation);
-			setType(requestResource, entity);
-			setAttributes(requestResource, entity, resourceInformation, queryContext);
-			setMeta(requestResource, entity, resourceInformation);
-			setLinks(requestResource, entity, resourceInformation);
-			Result zipped =
-					setRelationsAsync(entity, registryEntry, requestResource, queryAdapter, false);
-			response = zipped.merge(it -> resourceRepository.create(entity, queryAdapter));
-		}
-
+		Result<JsonApiResponse> response = result.merge(entities -> resourceRepository.create(collectionOrSingleton(entities), queryAdapter));
 		DocumentMappingConfig mappingConfig = context.getMappingConfig().clone()
 				.setFieldsWithEnforcedIdSerialization(loadedRelationshipNames);
 		DocumentMapper documentMapper = this.context.getDocumentMapper();
@@ -70,6 +80,10 @@ public class ResourcePostController extends ResourceUpsert {
 		return response
 				.merge(it -> documentMapper.toDocument(it, queryAdapter, mappingConfig))
 				.map(this::toResponse);
+	}
+
+	private Object collectionOrSingleton(List<Object> entities) {
+		return entities.size() == 1 ? entities.get(0) : entities;
 	}
 
 	private Response toResponse(Document responseDocument) {

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/http/JsonApiRequestProcessor.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/http/JsonApiRequestProcessor.java
@@ -1,5 +1,9 @@
 package io.crnk.core.engine.internal.http;
 
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.crnk.core.engine.dispatcher.RequestDispatcher;
 import io.crnk.core.engine.dispatcher.Response;
@@ -10,13 +14,11 @@ import io.crnk.core.engine.http.HttpMethod;
 import io.crnk.core.engine.http.HttpRequestContext;
 import io.crnk.core.engine.http.HttpRequestProcessor;
 import io.crnk.core.engine.http.HttpResponse;
-import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.dispatcher.ControllerRegistry;
 import io.crnk.core.engine.internal.dispatcher.controller.Controller;
 import io.crnk.core.engine.internal.dispatcher.path.ActionPath;
 import io.crnk.core.engine.internal.dispatcher.path.JsonPath;
 import io.crnk.core.engine.query.QueryAdapter;
-import io.crnk.core.engine.query.QueryAdapterBuilder;
 import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.result.ImmediateResultFactory;
 import io.crnk.core.engine.result.Result;
@@ -30,171 +32,175 @@ import java.util.Set;
 
 public class JsonApiRequestProcessor extends JsonApiRequestProcessorBase implements HttpRequestProcessor {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(JsonApiRequestProcessor.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(JsonApiRequestProcessor.class);
+
+	public JsonApiRequestProcessor(Module.ModuleContext moduleContext) {
+		super(moduleContext);
+	}
+
+	public static boolean matchesContentTypeHeader(HttpRequestContext requestContext, boolean acceptPlainJson) {
+		String method = requestContext.getMethod().toUpperCase();
+		boolean isPatch = method.equals(HttpMethod.PATCH.toString());
+		boolean isPost = method.equals(HttpMethod.POST.toString());
+		if (isPatch || isPost) {
+			String contentType = requestContext.getRequestHeader(HttpHeaders.HTTP_CONTENT_TYPE);
+			if (contentType == null || !contentType.startsWith(HttpHeaders.JSONAPI_CONTENT_TYPE)) {
+				LOGGER.debug("not a JSON-API request due to content type {}", contentType);
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public static boolean matchesAcceptHeader(HttpRequestContext requestContext, boolean acceptPlainJson) {
+		// short-circuit each of the possible Accept MIME type checks, so that we don't keep comparing after we have already
+		// found a match. Intentionally kept as separate statements (instead of a big, chained ||) to ease debugging/maintenance.
+		boolean acceptsJsonApi = requestContext.accepts(HttpHeaders.JSONAPI_CONTENT_TYPE);
+		boolean acceptsAny = acceptsJsonApi || requestContext.acceptsAny();
+
+		boolean acceptsPlainJson = acceptsAny || (acceptPlainJson && requestContext.accepts("application/json"));
+		LOGGER.debug("accepting request as JSON-API: {}", acceptPlainJson);
+		return acceptsPlainJson;
+	}
 
 
-    public JsonApiRequestProcessor(Module.ModuleContext moduleContext) {
-        super(moduleContext);
-    }
-
-    public static boolean matchesContentTypeHeader(HttpRequestContext requestContext, boolean acceptPlainJson) {
-        String method = requestContext.getMethod().toUpperCase();
-        boolean isPatch = method.equals(HttpMethod.PATCH.toString());
-        boolean isPost = method.equals(HttpMethod.POST.toString());
-        if (isPatch || isPost) {
-            String contentType = requestContext.getRequestHeader(HttpHeaders.HTTP_CONTENT_TYPE);
-            if (contentType == null || !contentType.startsWith(HttpHeaders.JSONAPI_CONTENT_TYPE)) {
-                LOGGER.debug("not a JSON-API request due to content type {}", contentType);
-                return false;
-            }
-        }
-        return true;
-    }
-
-    public static boolean matchesAcceptHeader(HttpRequestContext requestContext, boolean acceptPlainJson) {
-        // short-circuit each of the possible Accept MIME type checks, so that we don't keep comparing after we have already
-        // found a match. Intentionally kept as separate statements (instead of a big, chained ||) to ease debugging/maintenance.
-        boolean acceptsJsonApi = requestContext.accepts(HttpHeaders.JSONAPI_CONTENT_TYPE);
-        boolean acceptsAny = acceptsJsonApi || requestContext.acceptsAny();
-
-        boolean acceptsPlainJson = acceptsAny || (acceptPlainJson && requestContext.accepts("application/json"));
-        LOGGER.debug("accepting request as JSON-API: {}", acceptPlainJson);
-        return acceptsPlainJson;
-    }
+	/**
+	 * Determines whether the supplied HTTP request is considered a JSON-API request.
+	 *
+	 * @param requestContext The HTTP request
+	 * @param acceptPlainJson Whether a plain JSON request should also be considered a JSON-API request
+	 * @return <code>true</code> if it is a JSON-API request; <code>false</code> otherwise
+	 * @since 2.4
+	 */
+	@SuppressWarnings("UnnecessaryLocalVariable")
+	public static boolean isJsonApiRequest(HttpRequestContext requestContext, boolean acceptPlainJson) {
+		return matchesContentTypeHeader(requestContext, acceptPlainJson) && matchesAcceptHeader(requestContext, acceptPlainJson);
+	}
 
 
-    /**
-     * Determines whether the supplied HTTP request is considered a JSON-API request.
-     *
-     * @param requestContext  The HTTP request
-     * @param acceptPlainJson Whether a plain JSON request should also be considered a JSON-API request
-     * @return <code>true</code> if it is a JSON-API request; <code>false</code> otherwise
-     * @since 2.4
-     */
-    @SuppressWarnings("UnnecessaryLocalVariable")
-    public static boolean isJsonApiRequest(HttpRequestContext requestContext, boolean acceptPlainJson) {
-        return matchesContentTypeHeader(requestContext, acceptPlainJson) && matchesAcceptHeader(requestContext, acceptPlainJson);
-    }
+	@Override
+	public boolean supportsAsync() {
+		return true;
+	}
+
+	@Override
+	public boolean accepts(HttpRequestContext context) {
+		boolean acceptingPlainJson = isAcceptingPlainJson();
+		boolean acceptHeaderMatch = matchesAcceptHeader(context, acceptingPlainJson);
+		if (acceptHeaderMatch) {
+			boolean contentTypeHeaderMatch = matchesContentTypeHeader(context, acceptingPlainJson);
+			JsonPath jsonPath = helper.getJsonPath(context);
+			if (jsonPath == null) {
+				LOGGER.debug("request not served since no matching repository defined for {}", context.getPath());
+				return false;
+			}
+			if (!contentTypeHeaderMatch) {
+				LOGGER.warn("request not served due to content-type header mismatch, " + HttpHeaders.JSONAPI_CONTENT_TYPE + " missing?");
+				return false;
+			}
+			LOGGER.debug("request {} accepted", jsonPath);
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public Result<HttpResponse> processAsync(HttpRequestContext requestContext) {
+		Result<HttpResponse> response = checkMethod(requestContext);
+		if (response != null) {
+			return response;
+		}
+
+		String method = requestContext.getMethod();
+		ResultFactory resultFactory = moduleContext.getResultFactory();
+
+		JsonPath jsonPath = helper.getJsonPath(requestContext);
+		LOGGER.debug("processing JSON API request path={}, method={}", jsonPath, method);
+		Map<String, Set<String>> parameters = requestContext.getRequestParameters();
+
+		if (jsonPath instanceof ActionPath) {
+			// inital implementation, has to improve
+			String path = requestContext.getPath();
+			RequestDispatcher requestDispatcher = moduleContext.getRequestDispatcher();
+			requestDispatcher.dispatchAction(path, method, parameters);
+			return null;
+		}
+		else if (jsonPath != null) {
+			Document requestDocument;
+			try {
+				requestDocument = getRequestDocument(requestContext);
+			}
+			catch (JsonProcessingException e) {
+				return resultFactory.just(getErrorResponse(e));
+			}
+			QueryContext queryContext = requestContext.getQueryContext();
+			return processAsync(jsonPath, method, parameters, requestDocument, queryContext)
+					.map(this::toHttpResponse);
+		}
+		return resultFactory.just(buildMethodNotAllowedResponse(method));
+	}
+
+	private Result<HttpResponse> checkMethod(HttpRequestContext requestContext) {
+		String method = requestContext.getMethod();
+		boolean isPatch = method.equals(HttpMethod.PATCH.toString());
+		boolean isPost = method.equals(HttpMethod.POST.toString());
+		boolean isGet = method.equals(HttpMethod.GET.toString());
+		boolean isDelete = method.equals(HttpMethod.DELETE.toString());
+		boolean acceptsMethod = isGet || isDelete || isPatch || isPost;
+		if (!acceptsMethod) {
+			ResultFactory resultFactory = moduleContext.getResultFactory();
+			return resultFactory.just(buildMethodNotAllowedResponse(method));
+		}
+		return null;
+	}
 
 
-    @Override
-    public boolean supportsAsync() {
-        return true;
-    }
+	public Result<Response> processAsync(JsonPath jsonPath, String method, Map<String, Set<String>> parameters,
+			Document requestDocument, QueryContext queryContext) {
+		try {
+			ResultFactory resultFactory = moduleContext.getResultFactory();
+			QueryAdapter queryAdapter = helper.toQueryAdapter(parameters, jsonPath, queryContext);
 
-    @Override
-    public boolean accepts(HttpRequestContext context) {
-        boolean acceptingPlainJson = isAcceptingPlainJson();
-        boolean acceptHeaderMatch = matchesAcceptHeader(context, acceptingPlainJson);
-        if (acceptHeaderMatch) {
-            boolean contentTypeHeaderMatch = matchesContentTypeHeader(context, acceptingPlainJson);
-            JsonPath jsonPath = getJsonPath(context);
-            if (jsonPath == null) {
-                LOGGER.debug("request not served since no matching repository defined for {}", context.getPath());
-                return false;
-            }
-            if (!contentTypeHeaderMatch) {
-                LOGGER.warn("request not served due to content-type header mismatch, " + HttpHeaders.JSONAPI_CONTENT_TYPE + " missing?");
-                return false;
-            }
-            LOGGER.debug("request {} accepted", jsonPath);
-            return true;
-        }
-        return false;
-    }
-
-    @Override
-    public Result<HttpResponse> processAsync(HttpRequestContext requestContext) {
-        Result<HttpResponse> response = checkMethod(requestContext);
-        if (response != null) {
-            return response;
-        }
-
-        String method = requestContext.getMethod();
-        ResultFactory resultFactory = moduleContext.getResultFactory();
-        String path = requestContext.getPath();
-        JsonPath jsonPath = getJsonPath(requestContext);
-        LOGGER.debug("processing JSON API request path={}, method={}", jsonPath, method);
-        Map<String, Set<String>> parameters = requestContext.getRequestParameters();
-
-        if (jsonPath instanceof ActionPath) {
-            // inital implementation, has to improve
-            RequestDispatcher requestDispatcher = moduleContext.getRequestDispatcher();
-            requestDispatcher.dispatchAction(path, method, parameters);
-            return null;
-        } else if (jsonPath != null) {
-            Document requestDocument;
-            try {
-                requestDocument = getRequestDocument(requestContext);
-            } catch (JsonProcessingException e) {
-                return resultFactory.just(getErrorResponse(e));
-            }
-            QueryContext queryContext = requestContext.getQueryContext();
-            return processAsync(jsonPath, method, parameters, requestDocument, queryContext)
-                    .map(this::toHttpResponse);
-        }
-        return resultFactory.just(buildMethodNotAllowedResponse(method));
-    }
-
-    private Result<HttpResponse> checkMethod(HttpRequestContext requestContext) {
-        String method = requestContext.getMethod();
-        boolean isPatch = method.equals(HttpMethod.PATCH.toString());
-        boolean isPost = method.equals(HttpMethod.POST.toString());
-        boolean isGet = method.equals(HttpMethod.GET.toString());
-        boolean isDelete = method.equals(HttpMethod.DELETE.toString());
-        boolean acceptsMethod = isGet || isDelete || isPatch || isPost;
-        if (!acceptsMethod) {
-            ResultFactory resultFactory = moduleContext.getResultFactory();
-            return resultFactory.just(buildMethodNotAllowedResponse(method));
-        }
-        return null;
-    }
-
-
-    public Result<Response> processAsync(JsonPath jsonPath, String method, Map<String, Set<String>> parameters,
-                                         Document requestDocument, QueryContext queryContext) {
-        try {
-            ResultFactory resultFactory = moduleContext.getResultFactory();
-            ResourceInformation resourceInformation = getRequestedResource(jsonPath);
-            QueryAdapterBuilder queryAdapterBuilder = moduleContext.getModuleRegistry().getQueryAdapterBuilder();
-            QueryAdapter queryAdapter = queryAdapterBuilder.build(resourceInformation, parameters, queryContext);
-
-            if (resultFactory instanceof ImmediateResultFactory) {
-                LOGGER.debug("processing synchronously");
-                // not that document filters are not compatible with async programming
-                DocumentFilterContextImpl filterContext =
-                        new DocumentFilterContextImpl(jsonPath, queryAdapter, requestDocument, method);
-                try {
-                    DocumentFilterChain filterChain = getFilterChain(jsonPath, method);
-                    Response response = filterChain.doFilter(filterContext);
-                    return resultFactory.just(response);
-                } catch (Exception e) {
-                    Response response = toErrorResponse(e);
-                    return resultFactory.just(response);
-                }
-            } else {
-                LOGGER.debug("processing asynchronously");
-                ControllerRegistry controllerRegistry = moduleContext.getModuleRegistry().getControllerRegistry();
-                Controller controller = controllerRegistry.getController(jsonPath, method);
-                Result<Response> responseResult =
-                        controller.handleAsync(jsonPath, queryAdapter, requestDocument);
-                return responseResult.onErrorResume(this::toErrorResponse);
-            }
-        } catch (Exception e) {
-            ResultFactory resultFactory = moduleContext.getResultFactory();
-            return resultFactory.just(toErrorResponse(e));
-        }
-    }
+			if (resultFactory instanceof ImmediateResultFactory) {
+				LOGGER.debug("processing synchronously");
+				// not that document filters are not compatible with async programming
+				DocumentFilterContextImpl filterContext =
+						new DocumentFilterContextImpl(jsonPath, queryAdapter, requestDocument, method);
+				try {
+					DocumentFilterChain filterChain = getFilterChain(jsonPath, method);
+					Response response = filterChain.doFilter(filterContext);
+					return resultFactory.just(response);
+				}
+				catch (Exception e) {
+					Response response = toErrorResponse(e);
+					return resultFactory.just(response);
+				}
+			}
+			else {
+				LOGGER.debug("processing asynchronously");
+				ControllerRegistry controllerRegistry = moduleContext.getModuleRegistry().getControllerRegistry();
+				Controller controller = controllerRegistry.getController(jsonPath, method);
+				Result<Response> responseResult =
+						controller.handleAsync(jsonPath, queryAdapter, requestDocument);
+				return responseResult.onErrorResume(this::toErrorResponse);
+			}
+		}
+		catch (Exception e) {
+			ResultFactory resultFactory = moduleContext.getResultFactory();
+			return resultFactory.just(toErrorResponse(e));
+		}
+	}
 
     private Response toErrorResponse(Throwable e) {
         return moduleContext.getExceptionMapperRegistry().toErrorResponse(e);
     }
 
-    protected DocumentFilterChain getFilterChain(JsonPath jsonPath, String method) {
-        ControllerRegistry controllerRegistry = moduleContext.getModuleRegistry().getControllerRegistry();
-        Controller controller = controllerRegistry.getController(jsonPath, method);
-        return new DocumentFilterChainImpl(moduleContext, controller);
+	protected DocumentFilterChain getFilterChain(JsonPath jsonPath, String method) {
+		ControllerRegistry controllerRegistry = moduleContext.getModuleRegistry().getControllerRegistry();
+		Controller controller = controllerRegistry.getController(jsonPath, method);
+		return new DocumentFilterChainImpl(moduleContext, controller);
 
-    }
+	}
+
 
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/http/JsonApiRequestProcessorBase.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/http/JsonApiRequestProcessorBase.java
@@ -13,15 +13,6 @@ import io.crnk.core.engine.http.HttpHeaders;
 import io.crnk.core.engine.http.HttpRequestContext;
 import io.crnk.core.engine.http.HttpResponse;
 import io.crnk.core.engine.http.HttpStatus;
-import io.crnk.core.engine.information.resource.ResourceField;
-import io.crnk.core.engine.information.resource.ResourceInformation;
-import io.crnk.core.engine.internal.dispatcher.path.FieldPath;
-import io.crnk.core.engine.internal.dispatcher.path.JsonPath;
-import io.crnk.core.engine.internal.dispatcher.path.PathBuilder;
-import io.crnk.core.engine.internal.dispatcher.path.RelationshipsPath;
-import io.crnk.core.engine.parser.TypeParser;
-import io.crnk.core.engine.registry.RegistryEntry;
-import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.exception.MethodNotAllowedException;
 import io.crnk.core.module.Module;
 import org.slf4j.Logger;
@@ -35,8 +26,11 @@ public class JsonApiRequestProcessorBase {
 
 	private Boolean acceptingPlainJson;
 
+	protected JsonApiRequestProcessorHelper helper;
+
 	public JsonApiRequestProcessorBase(Module.ModuleContext moduleContext) {
 		this.moduleContext = moduleContext;
+		helper = new JsonApiRequestProcessorHelper(moduleContext);
 	}
 
 	protected boolean isAcceptingPlainJson() {
@@ -100,28 +94,5 @@ public class JsonApiRequestProcessorBase {
 				.setDetail(detail)
 				.build()));
 		return new Response(responseDocument, 400);
-	}
-
-
-	protected JsonPath getJsonPath(HttpRequestContext requestContext) {
-		String path = requestContext.getPath();
-		ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
-		TypeParser typeParser = moduleContext.getTypeParser();
-		return new PathBuilder(resourceRegistry, typeParser).build(path);
-	}
-
-	protected ResourceInformation getRequestedResource(JsonPath jsonPath) {
-		ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
-		RegistryEntry registryEntry = jsonPath.getRootEntry();
-
-		ResourceField field = (jsonPath instanceof RelationshipsPath) ? ((RelationshipsPath) jsonPath).getRelationship()
-				: jsonPath instanceof FieldPath ? ((FieldPath) jsonPath).getField() : null;
-		if (field != null) {
-			String oppositeResourceType = field.getOppositeResourceType();
-			return resourceRegistry.getEntry(oppositeResourceType).getResourceInformation();
-		}
-		else {
-			return registryEntry.getResourceInformation();
-		}
 	}
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/http/JsonApiRequestProcessorHelper.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/http/JsonApiRequestProcessorHelper.java
@@ -1,0 +1,59 @@
+package io.crnk.core.engine.internal.http;
+
+import java.util.Map;
+import java.util.Set;
+
+import io.crnk.core.engine.http.HttpRequestContext;
+import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.internal.dispatcher.path.FieldPath;
+import io.crnk.core.engine.internal.dispatcher.path.JsonPath;
+import io.crnk.core.engine.internal.dispatcher.path.PathBuilder;
+import io.crnk.core.engine.internal.dispatcher.path.RelationshipsPath;
+import io.crnk.core.engine.parser.TypeParser;
+import io.crnk.core.engine.query.QueryAdapter;
+import io.crnk.core.engine.query.QueryAdapterBuilder;
+import io.crnk.core.engine.query.QueryContext;
+import io.crnk.core.engine.registry.RegistryEntry;
+import io.crnk.core.engine.registry.ResourceRegistry;
+import io.crnk.core.module.Module;
+
+public class JsonApiRequestProcessorHelper {
+
+	private Module.ModuleContext moduleContext;
+
+	public JsonApiRequestProcessorHelper(Module.ModuleContext moduleContext) {
+		this.moduleContext = moduleContext;
+	}
+
+	public JsonPath getJsonPath(HttpRequestContext requestContext) {
+		ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
+		TypeParser typeParser = moduleContext.getTypeParser();
+		PathBuilder pathBuilder = new PathBuilder(resourceRegistry, typeParser);
+		String path = requestContext.getPath();
+		return pathBuilder.build(path);
+	}
+
+	public QueryAdapter toQueryAdapter(Map<String, Set<String>> parameters, JsonPath jsonPath, QueryContext queryContext) {
+		ResourceInformation resourceInformation = getRequestedResource(jsonPath);
+		QueryAdapterBuilder queryAdapterBuilder = moduleContext.getModuleRegistry().getQueryAdapterBuilder();
+		return queryAdapterBuilder.build(resourceInformation, parameters, queryContext);
+	}
+
+
+	protected ResourceInformation getRequestedResource(JsonPath jsonPath) {
+		ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
+		RegistryEntry registryEntry = jsonPath.getRootEntry();
+
+		ResourceField field = (jsonPath instanceof RelationshipsPath) ? ((RelationshipsPath) jsonPath).getRelationship()
+				: jsonPath instanceof FieldPath ? ((FieldPath) jsonPath).getField() : null;
+		if (field != null) {
+			String oppositeResourceType = field.getOppositeResourceType();
+			return resourceRegistry.getEntry(oppositeResourceType).getResourceInformation();
+		}
+		else {
+			return registryEntry.getResourceInformation();
+		}
+	}
+
+}

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/repository/ResourceRepositoryAdapterImpl.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/repository/ResourceRepositoryAdapterImpl.java
@@ -1,5 +1,9 @@
 package io.crnk.core.engine.internal.repository;
 
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+
 import io.crnk.core.boot.CrnkProperties;
 import io.crnk.core.engine.dispatcher.RepositoryRequestSpec;
 import io.crnk.core.engine.filter.RepositoryFilterContext;
@@ -9,17 +13,16 @@ import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.query.QueryAdapter;
 import io.crnk.core.engine.result.ImmediateResult;
 import io.crnk.core.engine.result.Result;
+import io.crnk.core.exception.BadRequestException;
 import io.crnk.core.exception.MethodNotAllowedException;
 import io.crnk.core.exception.ResourceNotFoundException;
 import io.crnk.core.module.ModuleRegistry;
 import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.repository.BulkResourceRepository;
 import io.crnk.core.repository.ResourceRepository;
 import io.crnk.core.repository.response.JsonApiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.Serializable;
-import java.util.Collection;
 
 /**
  * A repository adapter for resource repository
@@ -27,168 +30,187 @@ import java.util.Collection;
 @SuppressWarnings("unchecked")
 public class ResourceRepositoryAdapterImpl extends ResponseRepositoryAdapter implements ResourceRepositoryAdapter {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceRepositoryAdapterImpl.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(ResourceRepositoryAdapterImpl.class);
 
-    private final ResourceRepository resourceRepository;
+	private final ResourceRepository resourceRepository;
 
-    private final ResourceRepositoryInformation repositoryInformation;
-    private final ResourceInformation resourceInformation;
+	private final ResourceRepositoryInformation repositoryInformation;
 
-    private boolean return404OnNull;
+	private final ResourceInformation resourceInformation;
 
-    public ResourceRepositoryAdapterImpl(ResourceRepositoryInformation repositoryInformation, ModuleRegistry moduleRegistry,
-                                         ResourceRepository resourceRepository) {
-        super(moduleRegistry);
-        this.resourceInformation = repositoryInformation.getResource();
-        this.repositoryInformation = repositoryInformation;
-        this.resourceRepository = resourceRepository;
-        return404OnNull =
-                Boolean.parseBoolean(moduleRegistry.getPropertiesProvider().getProperty(CrnkProperties.RETURN_404_ON_NULL));
-    }
+	private boolean return404OnNull;
 
-
-    @Override
-    public ResourceRepositoryInformation getRepositoryInformation() {
-        return repositoryInformation;
-    }
-
-    @Override
-    public Result<JsonApiResponse> findOne(Object id, QueryAdapter queryAdapter) {
-        if (!resourceInformation.getAccess().isReadable()) {
-            throw new MethodNotAllowedException(HttpMethod.GET.toString());
-        }
-        RepositoryRequestFilterChainImpl chain = new RepositoryRequestFilterChainImpl() {
-
-            @SuppressWarnings("rawtypes")
-            @Override
-            protected JsonApiResponse invoke(RepositoryFilterContext context) {
-                RepositoryRequestSpec request = context.getRequest();
-                Serializable id = request.getId();
-                Object resource = ((ResourceRepository) resourceRepository).findOne(id, request.getQuerySpec
-                        (resourceInformation));
-                if (resource == null && return404OnNull) {
-                    throw new ResourceNotFoundException(resourceInformation.getResourceType());
-                }
-                return getResponse(resourceRepository, resource, request);
-            }
-
-        };
-        RepositoryRequestSpec requestSpec = RepositoryRequestSpecImpl.forFindId(moduleRegistry, resourceInformation,
-                queryAdapter, (Serializable) id);
-        return new ImmediateResult<>(chain.doFilter(newRepositoryFilterContext(requestSpec)));
-    }
-
-    @Override
-    public Result<JsonApiResponse> findAll(QueryAdapter queryAdapter) {
-        if (!resourceInformation.getAccess().isReadable()) {
-            throw new MethodNotAllowedException(HttpMethod.GET.toString());
-        }
-        RepositoryRequestFilterChainImpl chain = new RepositoryRequestFilterChainImpl() {
-
-            @SuppressWarnings("rawtypes")
-            @Override
-            protected JsonApiResponse invoke(RepositoryFilterContext context) {
-                RepositoryRequestSpec request = context.getRequest();
-                QuerySpec querySpec = request.getQuerySpec(resourceInformation);
-                Object resources = (resourceRepository).findAll(querySpec);
-                return getResponse(resourceRepository, resources, request);
-            }
-
-        };
-        RepositoryRequestSpec requestSpec = RepositoryRequestSpecImpl.forFindAll(moduleRegistry, resourceInformation,
-                queryAdapter);
-        return new ImmediateResult<>(chain.doFilter(newRepositoryFilterContext(requestSpec)));
-    }
-
-    @Override
-    public Result<JsonApiResponse> findAll(Collection ids, QueryAdapter queryAdapter) {
-        if (!resourceInformation.getAccess().isReadable()) {
-            throw new MethodNotAllowedException(HttpMethod.GET.toString());
-        }
-        RepositoryRequestFilterChainImpl chain = new RepositoryRequestFilterChainImpl() {
-
-            @SuppressWarnings("rawtypes")
-            @Override
-            protected JsonApiResponse invoke(RepositoryFilterContext context) {
-                RepositoryRequestSpec request = context.getRequest();
-                Collection<?> ids = request.getIds();
-                Object resources = resourceRepository.findAll(ids, request.getQuerySpec(resourceInformation));
-                return getResponse(resourceRepository, resources, request);
-            }
-
-        };
-        RepositoryRequestSpec requestSpec =
-                RepositoryRequestSpecImpl.forFindIds(moduleRegistry, resourceInformation, queryAdapter, ids);
-        return new ImmediateResult<>(chain.doFilter(newRepositoryFilterContext(requestSpec)));
-    }
-
-    @Override
-    public Result<JsonApiResponse> update(Object entity, QueryAdapter queryAdapter) {
-        return save(entity, queryAdapter, HttpMethod.PATCH);
-    }
-
-    @Override
-    public Result<JsonApiResponse> create(Object entity, QueryAdapter queryAdapter) {
-        return save(entity, queryAdapter, HttpMethod.POST);
-    }
-
-    private Result<JsonApiResponse> save(Object entity, QueryAdapter queryAdapter, final HttpMethod method) {
-        if (method == HttpMethod.POST && !resourceInformation.getAccess().isPostable()) {
-            throw new MethodNotAllowedException(method.toString());
-        } else if (method == HttpMethod.PATCH && !resourceInformation.getAccess().isPatchable()) {
-            throw new MethodNotAllowedException(method.toString());
-        }
-
-        RepositoryRequestFilterChainImpl chain = new RepositoryRequestFilterChainImpl() {
-
-            @SuppressWarnings("rawtypes")
-            @Override
-            protected JsonApiResponse invoke(RepositoryFilterContext context) {
-                RepositoryRequestSpec request = context.getRequest();
-                Object entity = request.getEntity();
-
-                Object resource;
-                if (method == HttpMethod.POST) {
-                    resource = ((ResourceRepository) resourceRepository).create(entity);
-                } else {
-                    resource = ((ResourceRepository) resourceRepository).save(entity);
-                }
-                return getResponse(resourceRepository, resource, request);
-            }
-
-        };
-        RepositoryRequestSpec requestSpec =
-                RepositoryRequestSpecImpl.forSave(moduleRegistry, method, resourceInformation, queryAdapter, entity);
-        return new ImmediateResult<>(chain.doFilter(newRepositoryFilterContext(requestSpec)));
-    }
-
-    @Override
-    public Result<JsonApiResponse> delete(Object id, QueryAdapter queryAdapter) {
-        if (!resourceInformation.getAccess().isDeletable()) {
-            throw new MethodNotAllowedException(HttpMethod.DELETE.toString());
-        }
-        RepositoryRequestFilterChainImpl chain = new RepositoryRequestFilterChainImpl() {
-
-            @SuppressWarnings("rawtypes")
-            @Override
-            protected JsonApiResponse invoke(RepositoryFilterContext context) {
-                RepositoryRequestSpec request = context.getRequest();
-                Serializable id = request.getId();
-                ((ResourceRepository) resourceRepository).delete(id);
-                return new JsonApiResponse();
-            }
-        };
-        RepositoryRequestSpec requestSpec =
-                RepositoryRequestSpecImpl.forDelete(moduleRegistry, resourceInformation, queryAdapter, (Serializable) id);
-        return new ImmediateResult<>(chain.doFilter(newRepositoryFilterContext(requestSpec)));
-    }
-
-    public Object getImplementation() {
-        return resourceRepository;
-    }
+	public ResourceRepositoryAdapterImpl(ResourceRepositoryInformation repositoryInformation, ModuleRegistry moduleRegistry,
+			ResourceRepository resourceRepository) {
+		super(moduleRegistry);
+		this.resourceInformation = repositoryInformation.getResource();
+		this.repositoryInformation = repositoryInformation;
+		this.resourceRepository = resourceRepository;
+		return404OnNull =
+				Boolean.parseBoolean(moduleRegistry.getPropertiesProvider().getProperty(CrnkProperties.RETURN_404_ON_NULL));
+	}
 
 
-    public Class<?> getResourceClass() {
-        return resourceInformation.getResourceClass();
-    }
+	@Override
+	public ResourceRepositoryInformation getRepositoryInformation() {
+		return repositoryInformation;
+	}
+
+	@Override
+	public Result<JsonApiResponse> findOne(Object id, QueryAdapter queryAdapter) {
+		if (!resourceInformation.getAccess().isReadable()) {
+			throw new MethodNotAllowedException(HttpMethod.GET.toString());
+		}
+		RepositoryRequestFilterChainImpl chain = new RepositoryRequestFilterChainImpl() {
+
+			@SuppressWarnings("rawtypes")
+			@Override
+			protected JsonApiResponse invoke(RepositoryFilterContext context) {
+				RepositoryRequestSpec request = context.getRequest();
+				Serializable id = request.getId();
+				Object resource = ((ResourceRepository) resourceRepository).findOne(id, request.getQuerySpec
+						(resourceInformation));
+				if (resource == null && return404OnNull) {
+					throw new ResourceNotFoundException(resourceInformation.getResourceType());
+				}
+				return getResponse(resourceRepository, resource, request);
+			}
+
+		};
+		RepositoryRequestSpec requestSpec = RepositoryRequestSpecImpl.forFindId(moduleRegistry, resourceInformation,
+				queryAdapter, (Serializable) id);
+		return new ImmediateResult<>(chain.doFilter(newRepositoryFilterContext(requestSpec)));
+	}
+
+	@Override
+	public Result<JsonApiResponse> findAll(QueryAdapter queryAdapter) {
+		if (!resourceInformation.getAccess().isReadable()) {
+			throw new MethodNotAllowedException(HttpMethod.GET.toString());
+		}
+		RepositoryRequestFilterChainImpl chain = new RepositoryRequestFilterChainImpl() {
+
+			@SuppressWarnings("rawtypes")
+			@Override
+			protected JsonApiResponse invoke(RepositoryFilterContext context) {
+				RepositoryRequestSpec request = context.getRequest();
+				QuerySpec querySpec = request.getQuerySpec(resourceInformation);
+				Object resources = (resourceRepository).findAll(querySpec);
+				return getResponse(resourceRepository, resources, request);
+			}
+
+		};
+		RepositoryRequestSpec requestSpec = RepositoryRequestSpecImpl.forFindAll(moduleRegistry, resourceInformation,
+				queryAdapter);
+		return new ImmediateResult<>(chain.doFilter(newRepositoryFilterContext(requestSpec)));
+	}
+
+	@Override
+	public Result<JsonApiResponse> findAll(Collection ids, QueryAdapter queryAdapter) {
+		if (!resourceInformation.getAccess().isReadable()) {
+			throw new MethodNotAllowedException(HttpMethod.GET.toString());
+		}
+		RepositoryRequestFilterChainImpl chain = new RepositoryRequestFilterChainImpl() {
+
+			@SuppressWarnings("rawtypes")
+			@Override
+			protected JsonApiResponse invoke(RepositoryFilterContext context) {
+				RepositoryRequestSpec request = context.getRequest();
+				Collection<?> ids = request.getIds();
+				Object resources = resourceRepository.findAll(ids, request.getQuerySpec(resourceInformation));
+				return getResponse(resourceRepository, resources, request);
+			}
+
+		};
+		RepositoryRequestSpec requestSpec =
+				RepositoryRequestSpecImpl.forFindIds(moduleRegistry, resourceInformation, queryAdapter, ids);
+		return new ImmediateResult<>(chain.doFilter(newRepositoryFilterContext(requestSpec)));
+	}
+
+	@Override
+	public Result<JsonApiResponse> update(Object entity, QueryAdapter queryAdapter) {
+		return save(entity, queryAdapter, HttpMethod.PATCH);
+	}
+
+	@Override
+	public Result<JsonApiResponse> create(Object entity, QueryAdapter queryAdapter) {
+		return save(entity, queryAdapter, HttpMethod.POST);
+	}
+
+	private Result<JsonApiResponse> save(Object entity, QueryAdapter queryAdapter, final HttpMethod method) {
+		if (method == HttpMethod.POST && !resourceInformation.getAccess().isPostable()) {
+			throw new MethodNotAllowedException(method.toString());
+		}
+		else if (method == HttpMethod.PATCH && !resourceInformation.getAccess().isPatchable()) {
+			throw new MethodNotAllowedException(method.toString());
+		}
+
+		RepositoryRequestFilterChainImpl chain = new RepositoryRequestFilterChainImpl() {
+
+			@SuppressWarnings("rawtypes")
+			@Override
+			protected JsonApiResponse invoke(RepositoryFilterContext context) {
+				RepositoryRequestSpec request = context.getRequest();
+				Object entity = request.getEntity();
+
+				Object resource;
+				if (method == HttpMethod.POST) {
+					if (entity instanceof Collection) {
+						if (!(resourceRepository instanceof BulkResourceRepository)) {
+							throw new BadRequestException("no bulk operations implemented");
+						}
+						resource = ((BulkResourceRepository) resourceRepository).create((List) entity);
+					}
+					else {
+						resource = resourceRepository.create(entity);
+					}
+				}
+				else {
+					if (entity instanceof Collection) {
+						if (!(resourceRepository instanceof BulkResourceRepository)) {
+							throw new BadRequestException("no bulk operations implemented");
+						}
+						resource = ((BulkResourceRepository) resourceRepository).save((List) entity);
+					}
+					else {
+						resource = resourceRepository.save(entity);
+					}
+				}
+				return getResponse(resourceRepository, resource, request);
+			}
+
+		};
+		RepositoryRequestSpec requestSpec =
+				RepositoryRequestSpecImpl.forSave(moduleRegistry, method, resourceInformation, queryAdapter, entity);
+		return new ImmediateResult<>(chain.doFilter(newRepositoryFilterContext(requestSpec)));
+	}
+
+	@Override
+	public Result<JsonApiResponse> delete(Object id, QueryAdapter queryAdapter) {
+		if (!resourceInformation.getAccess().isDeletable()) {
+			throw new MethodNotAllowedException(HttpMethod.DELETE.toString());
+		}
+		RepositoryRequestFilterChainImpl chain = new RepositoryRequestFilterChainImpl() {
+
+			@SuppressWarnings("rawtypes")
+			@Override
+			protected JsonApiResponse invoke(RepositoryFilterContext context) {
+				RepositoryRequestSpec request = context.getRequest();
+				Serializable id = request.getId();
+				((ResourceRepository) resourceRepository).delete(id);
+				return new JsonApiResponse();
+			}
+		};
+		RepositoryRequestSpec requestSpec =
+				RepositoryRequestSpecImpl.forDelete(moduleRegistry, resourceInformation, queryAdapter, (Serializable) id);
+		return new ImmediateResult<>(chain.doFilter(newRepositoryFilterContext(requestSpec)));
+	}
+
+	public Object getImplementation() {
+		return resourceRepository;
+	}
+
+
+	public Class<?> getResourceClass() {
+		return resourceInformation.getResourceClass();
+	}
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/result/ImmediateResultFactory.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/result/ImmediateResultFactory.java
@@ -58,4 +58,13 @@ public class ImmediateResultFactory implements ResultFactory {
 	public <T> Result<T> attachContext(Result<T> result, Object context) {
 		return result;
 	}
+
+	@Override
+	public <T> Result<List<T>> all(List<Result<T>> results) {
+		List<T> list = new ArrayList<>();
+		for (Result<T> result : results) {
+			list.add(result.get());
+		}
+		return just(list);
+	}
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/result/ResultFactory.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/result/ResultFactory.java
@@ -21,4 +21,6 @@ public interface ResultFactory {
 	boolean hasThreadContext();
 
 	<T> Result<T> attachContext(Result<T> result, Object context);
+
+	<T> Result<List<T>> all(List<Result<T>> results);
 }

--- a/crnk-core/src/main/java/io/crnk/core/repository/BulkResourceRepository.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/BulkResourceRepository.java
@@ -1,0 +1,61 @@
+package io.crnk.core.repository;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.crnk.core.engine.internal.utils.PreconditionUtil;
+
+/**
+ * Bulk-flavor of {@link ResourceRepository} to modify multiple resource simultaneously. Can be used
+ * together with {link OperationsModule} to gain performance with bulk imports.
+ * <p>
+ * This feature is experimental supporting only POST as of yet.
+ *
+ * @param <T> Type of an entity
+ * @param <I> Type of Identifier of an entity
+ */
+public interface BulkResourceRepository<T, I> extends ResourceRepository<T, I>, Repository {
+
+	default <S extends T> S save(S resource) {
+		List<S> results = save(Arrays.asList(resource));
+		PreconditionUtil.verifyEquals(1, results.size(), "expected single result");
+		return results.get(0);
+	}
+
+
+	default <S extends T> S create(S resource) {
+		List<S> results = create(Arrays.asList(resource));
+		PreconditionUtil.verifyEquals(1, results.size(), "expected single result");
+		return results.get(0);
+	}
+
+	default void delete(I id) {
+		delete(Arrays.asList(id));
+	}
+
+	/**
+	 * Bulk saves resources. A Returning resources must include assigned identifier created for the instance of resource.
+	 *
+	 * @param resources to be saved
+	 * @param <S> type of the resource
+	 * @return saved resource. Must include set identifier.
+	 */
+	<S extends T> List<S> save(List<S> resources);
+
+	/**
+	 * Bulk creates resources. A Returning resources must include assigned identifier created for the instance of resource.
+	 *
+	 * @param resources to be saved
+	 * @param <S> type of the resource
+	 * @return saved resource. Must include set identifier.
+	 */
+	<S extends T> List<S> create(List<S> resources);
+
+	/**
+	 * Bulk removes resources identified by id.
+	 *
+	 * @param ids identified of the resource to be removed
+	 */
+	void delete(List<I> ids);
+
+}

--- a/crnk-core/src/main/java/io/crnk/core/repository/ResourceRepository.java
+++ b/crnk-core/src/main/java/io/crnk/core/repository/ResourceRepository.java
@@ -1,10 +1,10 @@
 package io.crnk.core.repository;
 
+import java.util.Collection;
+
 import io.crnk.core.exception.ResourceNotFoundException;
 import io.crnk.core.queryspec.QuerySpec;
 import io.crnk.core.resource.list.ResourceList;
-
-import java.util.Collection;
 
 /**
  * Base repository which is used to operate on the resources. Each resource should have a corresponding resource
@@ -68,7 +68,7 @@ public interface ResourceRepository<T, I> extends Repository {
     <S extends T> S create(S resource);
 
     /**
-     * Removes a resource identified by id legacy.
+     * Removes a resource identified by id.
      *
      * @param id identified of the resource to be removed
      */

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/ResourcePostControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/ResourcePostControllerTest.java
@@ -20,9 +20,9 @@ import io.crnk.core.engine.information.resource.ResourceField;
 import io.crnk.core.engine.internal.dispatcher.path.JsonPath;
 import io.crnk.core.engine.properties.PropertiesProvider;
 import io.crnk.core.engine.properties.ResourceFieldImmutableWriteBehavior;
+import io.crnk.core.exception.BadRequestException;
 import io.crnk.core.exception.ForbiddenException;
 import io.crnk.core.exception.RepositoryNotFoundException;
-import io.crnk.core.exception.RequestBodyException;
 import io.crnk.core.exception.RequestBodyNotFoundException;
 import io.crnk.core.exception.ResourceException;
 import io.crnk.core.mock.models.Pojo;
@@ -99,7 +99,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         sut.init(controllerContext);
 
         // THEN
-        expectedException.expect(RequestBodyException.class);
+        expectedException.expect(BadRequestException.class);
 
         // WHEN
         sut.handle(projectPath, emptyTaskQuery, newProjectBody);

--- a/crnk-documentation/src/docs/asciidoc/operations.adoc
+++ b/crnk-documentation/src/docs/asciidoc/operations.adoc
@@ -1,4 +1,6 @@
 
+anchor:operations[]
+
 # Bulk Updates with Operations Module
 
 By its nature RESTful applications are limited to the insertion, update and deletion of single resources. As such, developers
@@ -172,5 +174,8 @@ The current limitations of the implementation are:
 
 With support for `POST`, `PATCH` and `DELETE` operations the most important building blocks should be in place.
 The limitations are expected to be addressed at some point as well, contributions welcomed.
+
+There is experimental support for <<resource_bulk_repository,BulkResourceRepository>>. If multiple changes to the
+same repository are detected, it can make use of the appropriate bulk methods.
 
 

--- a/crnk-documentation/src/docs/asciidoc/repositories.adoc
+++ b/crnk-documentation/src/docs/asciidoc/repositories.adoc
@@ -133,9 +133,19 @@ the create, delete and update methods. `crnk-meta` accordingly reports
 insertable, updateable, deltable for such repositories as false.
 
 
+anchor:resource_bulk_repository[]
 
+## BulkResourceRepository
 
+WARNING: Experimental and only supports POST
 
+Similar to `ResourceRepository` but takes a list of resources for `create(...)`, `save(...)` and `delete(...)`.
+Allows a repository to process multiple resources at the same time. A request can be made in two ways:
+
+- The data section of the request document must includes a collection rather than a single data item.
+- A JSON Patch request whereas multiple changes to the same repository then access the bulk methods.
+
+For more information about bulk processing can be found <<operations,here>>.
 
 
 ## Query parameters with QuerySpec

--- a/crnk-format/crnk-format-plain-json/src/main/java/io/crnk/format/plainjson/internal/PlainJsonRequestProcessor.java
+++ b/crnk-format/crnk-format-plain-json/src/main/java/io/crnk/format/plainjson/internal/PlainJsonRequestProcessor.java
@@ -50,7 +50,7 @@ public class PlainJsonRequestProcessor extends JsonApiRequestProcessor implement
 	@Override
 	public boolean accepts(HttpRequestContext context) {
 		if (isPlainJsonRequest(context, isAcceptingPlainJson())) {
-			JsonPath jsonPath = getJsonPath(context);
+			JsonPath jsonPath = helper.getJsonPath(context);
 			LOGGER.debug("resource path: {}", jsonPath);
 			return jsonPath != null;
 		}

--- a/crnk-format/crnk-format-plain-json/src/test/java/io/crnk/data/PlainJsonBulkText.java
+++ b/crnk-format/crnk-format-plain-json/src/test/java/io/crnk/data/PlainJsonBulkText.java
@@ -1,0 +1,45 @@
+package io.crnk.data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.crnk.test.mock.models.BulkTask;
+import io.crnk.test.mock.repository.BulkTaskRepository;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PlainJsonBulkText {
+
+	protected BulkTaskRepository taskRepo;
+
+	private PlainJsonTestContainer container;
+
+	@Before
+	public void setup() {
+		container = new PlainJsonTestContainer();
+		container.start();
+		taskRepo = container.getClient().getRepositoryForInterface(BulkTaskRepository.class);
+	}
+
+	@After
+	public void tearDown() {
+		container.stop();
+	}
+
+	@Test
+	public void test() {
+		List<BulkTask> tasks = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			BulkTask task = new BulkTask();
+			task.setId((long) i);
+			task.setName("bulkTask" + i);
+			tasks.add(task);
+		}
+
+		List<BulkTask> createdTasks = taskRepo.create(tasks);
+		Assert.assertEquals(10, createdTasks.size());
+		Assert.assertEquals("bulkTask0", createdTasks.get(0).getName());
+	}
+}

--- a/crnk-gen/crnk-gen-asciidoc/src/main/java/io/crnk/gen/asciidoc/capture/AsciidocCaptureModule.java
+++ b/crnk-gen/crnk-gen-asciidoc/src/main/java/io/crnk/gen/asciidoc/capture/AsciidocCaptureModule.java
@@ -12,367 +12,401 @@ import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.module.Module;
 import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.repository.BulkResourceRepository;
 import io.crnk.core.repository.ManyRelationshipRepository;
 import io.crnk.core.repository.OneRelationshipRepository;
 import io.crnk.core.repository.ResourceRepository;
-import io.crnk.core.repository.decorate.*;
+import io.crnk.core.repository.decorate.RepositoryDecoratorFactory;
+import io.crnk.core.repository.decorate.WrappedManyRelationshipRepository;
+import io.crnk.core.repository.decorate.WrappedOneManyRelationshipRepository;
+import io.crnk.core.repository.decorate.WrappedOneRelationshipRepository;
+import io.crnk.core.repository.decorate.WrappedResourceRepository;
 import io.crnk.core.resource.list.ResourceList;
 import io.crnk.gen.asciidoc.internal.AsciidocBuilder;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public class AsciidocCaptureModule implements Module, HttpAdapterAware {
 
 
-	private ThreadLocal<RequestCaptor> threadLocal = new ThreadLocal<>();
+    private ThreadLocal<RequestCaptor> threadLocal = new ThreadLocal<>();
 
-	private AsciidocCaptureConfig config;
+    private AsciidocCaptureConfig config;
 
-	public AsciidocCaptureModule(AsciidocCaptureConfig config) {
-		this.config = config;
+    public AsciidocCaptureModule(AsciidocCaptureConfig config) {
+        this.config = config;
 
-		PreconditionUtil.verify(config.getGenDir() != null, "outputDir not set in config");
-	}
+        PreconditionUtil.verify(config.getGenDir() != null, "outputDir not set in config");
+    }
 
-	@Override
-	public String getModuleName() {
-		return "asciidoc";
-	}
+    @Override
+    public String getModuleName() {
+        return "asciidoc";
+    }
 
-	@Override
-	public void setupModule(ModuleContext context) {
-		context.addRepositoryDecoratorFactory(new AsciidocDecoratorFactory(context));
-	}
+    @Override
+    public void setupModule(ModuleContext context) {
+        context.addRepositoryDecoratorFactory(new AsciidocDecoratorFactory(context));
+    }
 
-	private int nextCaptureNum = 0;
+    private int nextCaptureNum = 0;
 
-	public RequestCaptor capture(String title) {
-		String key = nextCaptureNum++ + "_" + title.toLowerCase().replace(" ", "_");
+    public RequestCaptor capture(String title) {
+        String key = nextCaptureNum++ + "_" + title.toLowerCase().replace(" ", "_");
 
-		RequestCaptor doc = new RequestCaptor(threadLocal);
-		doc.setKey(key);
-		doc.setTitle(title);
-		return doc;
-	}
+        RequestCaptor doc = new RequestCaptor(threadLocal);
+        doc.setKey(key);
+        doc.setTitle(title);
+        return doc;
+    }
 
-	@Override
-	public void setHttpAdapter(HttpAdapter httpAdapter) {
-		httpAdapter.addListener(new HttpAdapterListener() {
-			@Override
-			public void onRequest(HttpAdapterRequest request) {
-				RequestCaptor requestCaptor = threadLocal.get();
-				if (requestCaptor != null) {
-					requestCaptor.setRequest(request);
-				}
-			}
+    @Override
+    public void setHttpAdapter(HttpAdapter httpAdapter) {
+        httpAdapter.addListener(new HttpAdapterListener() {
+            @Override
+            public void onRequest(HttpAdapterRequest request) {
+                RequestCaptor requestCaptor = threadLocal.get();
+                if (requestCaptor != null) {
+                    requestCaptor.setRequest(request);
+                }
+            }
 
-			@Override
-			public void onResponse(HttpAdapterRequest request, HttpAdapterResponse response) {
-				RequestCaptor requestCaptor = threadLocal.get();
-				if (requestCaptor != null) {
-					requestCaptor.setResponse(response);
-				}
-			}
-		});
-	}
+            @Override
+            public void onResponse(HttpAdapterRequest request, HttpAdapterResponse response) {
+                RequestCaptor requestCaptor = threadLocal.get();
+                if (requestCaptor != null) {
+                    requestCaptor.setResponse(response);
+                }
+            }
+        });
+    }
 
-	private class AsciidocDecoratorFactory implements RepositoryDecoratorFactory {
+    private class AsciidocDecoratorFactory implements RepositoryDecoratorFactory {
 
-		private final ModuleContext context;
+        private final ModuleContext context;
 
-		public AsciidocDecoratorFactory(ModuleContext context) {
-			this.context = context;
-		}
+        public AsciidocDecoratorFactory(ModuleContext context) {
+            this.context = context;
+        }
 
-		@Override
-		public Object decorateRepository(Object repository) {
-			if (repository instanceof ResourceRepository) {
-				return new AsciidocResourceDecorator((ResourceRepository) repository, this);
-			}
-			if (repository instanceof OneRelationshipRepository && repository instanceof ManyRelationshipRepository) {
-				return new WrappedOneManyRelationshipRepository((OneRelationshipRepository & ManyRelationshipRepository)repository,
-						new AsciidocOneRelationshipDecorator((OneRelationshipRepository) repository, this),
-						new AsciidocManyRelationshipDecorator((ManyRelationshipRepository) repository, this));
-			}
-			if (repository instanceof OneRelationshipRepository) {
-				return new AsciidocOneRelationshipDecorator((OneRelationshipRepository) repository, this);
-			}
-			if (repository instanceof ManyRelationshipRepository) {
-				return new AsciidocManyRelationshipDecorator((ManyRelationshipRepository) repository, this);
-			}
-			return repository;
-		}
+        @Override
+        public Object decorateRepository(Object repository) {
+            if (repository instanceof BulkResourceRepository) {
+                return new AsciidocBulkResourceDecorator((ResourceRepository) repository, this);
+            }
+            if (repository instanceof ResourceRepository) {
+                return new AsciidocResourceDecorator((ResourceRepository) repository, this);
+            }
+            if (repository instanceof OneRelationshipRepository && repository instanceof ManyRelationshipRepository) {
+                return new WrappedOneManyRelationshipRepository((OneRelationshipRepository & ManyRelationshipRepository) repository,
+                        new AsciidocOneRelationshipDecorator((OneRelationshipRepository) repository, this),
+                        new AsciidocManyRelationshipDecorator((ManyRelationshipRepository) repository, this));
+            }
+            if (repository instanceof OneRelationshipRepository) {
+                return new AsciidocOneRelationshipDecorator((OneRelationshipRepository) repository, this);
+            }
+            if (repository instanceof ManyRelationshipRepository) {
+                return new AsciidocManyRelationshipDecorator((ManyRelationshipRepository) repository, this);
+            }
+            return repository;
+        }
 
-		private void finalizeDoc(Class resourceClass) {
-			ResourceRegistry resourceRegistry = context.getResourceRegistry();
-			RegistryEntry entry = resourceRegistry.findEntry(resourceClass);
-			ResourceInformation resourceInformation = entry.getResourceInformation();
+        private void finalizeDoc(Class resourceClass) {
+            ResourceRegistry resourceRegistry = context.getResourceRegistry();
+            RegistryEntry entry = resourceRegistry.findEntry(resourceClass);
+            ResourceInformation resourceInformation = entry.getResourceInformation();
 
-			RequestCaptor requestCaptor = threadLocal.get();
-			if (requestCaptor != null) {
-				threadLocal.remove();
+            RequestCaptor requestCaptor = threadLocal.get();
+            if (requestCaptor != null) {
+                threadLocal.remove();
 
-				// in case of internal errors a response might not be available since called by finally {}
-				if (requestCaptor.getResponse() != null) {
-					requestCaptor.setResourceInformation(resourceInformation);
-					String resourceType = resourceInformation.getResourceType();
-					File resourceDir = new File(config.getGenDir(), resourceType);
-					resourceDir.mkdirs();
+                // in case of internal errors a response might not be available since called by finally {}
+                if (requestCaptor.getResponse() != null) {
+                    requestCaptor.setResourceInformation(resourceInformation);
+                    String resourceType = resourceInformation.getResourceType();
+                    File resourceDir = new File(config.getGenDir(), resourceType);
+                    resourceDir.mkdirs();
 
-					writeUrlFile(resourceDir, requestCaptor);
-					writeTitleFile(resourceDir, requestCaptor);
-					writeDescriptionFile(resourceDir, requestCaptor);
-					writeRequestFile(resourceDir, requestCaptor);
-					writeResponseFile(resourceDir, requestCaptor);
-				}
-			}
-		}
+                    writeUrlFile(resourceDir, requestCaptor);
+                    writeTitleFile(resourceDir, requestCaptor);
+                    writeDescriptionFile(resourceDir, requestCaptor);
+                    writeRequestFile(resourceDir, requestCaptor);
+                    writeResponseFile(resourceDir, requestCaptor);
+                }
+            }
+        }
 
-		private void writeTitleFile(File resourceDir, RequestCaptor captor) {
-			File file = new File(resourceDir, "captured_" + captor.getKey() + "_title.txt");
-			IOUtils.writeFile(file, captor.getTitle());
-		}
+        private void writeTitleFile(File resourceDir, RequestCaptor captor) {
+            File file = new File(resourceDir, "captured_" + captor.getKey() + "_title.txt");
+            IOUtils.writeFile(file, captor.getTitle());
+        }
 
-		private void writeDescriptionFile(File resourceDir, RequestCaptor captor) {
-			if (captor.getDescription() != null) {
-				File file = new File(resourceDir, "captured_" + captor.getKey() + "_description.txt");
-				IOUtils.writeFile(file, captor.getDescription());
-			}
-		}
+        private void writeDescriptionFile(File resourceDir, RequestCaptor captor) {
+            if (captor.getDescription() != null) {
+                File file = new File(resourceDir, "captured_" + captor.getKey() + "_description.txt");
+                IOUtils.writeFile(file, captor.getDescription());
+            }
+        }
 
-		private void writeUrlFile(File resourceDir, RequestCaptor captor) {
-			HttpAdapterRequest request = captor.getRequest();
-			AsciidocBuilder builder = newBuilder();
-			builder.startSource("bash");
-			builder.append(request.getHttpMethod().toString());
-			builder.append(" ");
-			builder.append(request.getUrl());
-			builder.appendLineBreak();
-			builder.endSource();
+        private void writeUrlFile(File resourceDir, RequestCaptor captor) {
+            HttpAdapterRequest request = captor.getRequest();
+            AsciidocBuilder builder = newBuilder();
+            builder.startSource("bash");
+            builder.append(request.getHttpMethod().toString());
+            builder.append(" ");
+            builder.append(request.getUrl());
+            builder.appendLineBreak();
+            builder.endSource();
 
-			File file = new File(resourceDir, "captured_" + captor.getKey() + "_url.adoc");
-			builder.write(file);
-		}
+            File file = new File(resourceDir, "captured_" + captor.getKey() + "_url.adoc");
+            builder.write(file);
+        }
 
-	}
-
-
-	private AsciidocBuilder newBuilder() {
-		return new AsciidocBuilder(null, config.getBaseDepth());
-	}
+    }
 
 
-	private void writeRequestFile(File resourceDir, RequestCaptor captor) {
-		HttpAdapterRequest request = captor.getRequest();
-		AsciidocBuilder builder = new AsciidocBuilder(null, config.getBaseDepth());
-		builder.startSource("json");
-		builder.append(request.getHttpMethod().toString());
-		builder.append(" ");
-		builder.append(request.getUrl());
-		builder.append(" HTTP/1.1");
-		builder.appendLineBreak();
-		request.getHeadersNames().stream().sorted()
-				.forEach(name -> builder.appendLine(name + ": " + request.getHeaderValue(name)));
-
-		String body = request.getBody();
-		if (body != null) {
-			builder.appendLineBreak();
-			builder.append(body);
-			builder.appendLineBreak();
-		}
-		builder.endSource();
-
-		File file = new File(resourceDir, "captured_" + captor.getKey() + "_request.adoc");
-		builder.write(file);
-	}
-
-	private void writeResponseFile(File resourceDir, RequestCaptor captor) {
-		HttpAdapterResponse response = captor.getResponse();
-		AsciidocBuilder builder = new AsciidocBuilder(null, config.getBaseDepth());
-		builder.startSource("json");
-
-		builder.append("HTTP/1.1 ");
-		builder.append(Integer.toString(response.code()));
-		builder.append(" ");
-		builder.append(response.message());
-		builder.appendLineBreak();
-
-		response.getHeaderNames().stream().sorted()
-				.forEach(name -> builder.appendLine(name + ": " + response.getResponseHeader(name)));
-
-		String body;
-		try {
-			body = response.body();
-		}
-		catch (IOException e) {
-			throw new IllegalStateException(e);
-		}
-		if (body != null) {
-			builder.appendLineBreak();
-			builder.append(body);
-			builder.appendLineBreak();
-		}
-		builder.endSource();
-
-		File file = new File(resourceDir, "captured_" + captor.getKey() + "_response.adoc");
-		builder.write(file);
-	}
-
-	class AsciidocResourceDecorator<T, I> extends WrappedResourceRepository<T, I> {
-
-		private final AsciidocDecoratorFactory factory;
-
-		public AsciidocResourceDecorator(ResourceRepository<T, I> wrappedRepository, AsciidocDecoratorFactory factory) {
-			super(wrappedRepository);
-			this.factory = factory;
-		}
-
-		@Override
-		public T findOne(I id, QuerySpec querySpec) {
-			try {
-				return super.findOne(id, querySpec);
-			}
-			finally {
-				factory.finalizeDoc(getResourceClass());
-			}
-		}
+    private AsciidocBuilder newBuilder() {
+        return new AsciidocBuilder(null, config.getBaseDepth());
+    }
 
 
-		@Override
-		public ResourceList<T> findAll(QuerySpec querySpec) {
-			try {
-				return super.findAll(querySpec);
-			}
-			finally {
-				factory.finalizeDoc(getResourceClass());
-			}
-		}
+    private void writeRequestFile(File resourceDir, RequestCaptor captor) {
+        HttpAdapterRequest request = captor.getRequest();
+        AsciidocBuilder builder = new AsciidocBuilder(null, config.getBaseDepth());
+        builder.startSource("json");
+        builder.append(request.getHttpMethod().toString());
+        builder.append(" ");
+        builder.append(request.getUrl());
+        builder.append(" HTTP/1.1");
+        builder.appendLineBreak();
+        request.getHeadersNames().stream().sorted()
+                .forEach(name -> builder.appendLine(name + ": " + request.getHeaderValue(name)));
 
-		@Override
-		public ResourceList<T> findAll(Collection<I> ids, QuerySpec querySpec) {
-			try {
-				return super.findAll(ids, querySpec);
-			}
-			finally {
-				factory.finalizeDoc(getResourceClass());
-			}
-		}
+        String body = request.getBody();
+        if (body != null) {
+            builder.appendLineBreak();
+            builder.append(body);
+            builder.appendLineBreak();
+        }
+        builder.endSource();
 
-		@Override
-		public <S extends T> S save(S entity) {
-			try {
-				return super.save(entity);
-			}
-			finally {
-				factory.finalizeDoc(getResourceClass());
-			}
-		}
+        File file = new File(resourceDir, "captured_" + captor.getKey() + "_request.adoc");
+        builder.write(file);
+    }
 
-		@Override
-		public <S extends T> S create(S entity) {
-			try {
-				return super.create(entity);
-			}
-			finally {
-				factory.finalizeDoc(getResourceClass());
-			}
-		}
+    private void writeResponseFile(File resourceDir, RequestCaptor captor) {
+        HttpAdapterResponse response = captor.getResponse();
+        AsciidocBuilder builder = new AsciidocBuilder(null, config.getBaseDepth());
+        builder.startSource("json");
 
-		@Override
-		public void delete(I id) {
-			try {
-				super.delete(id);
-			}
-			finally {
-				factory.finalizeDoc(getResourceClass());
-			}
-		}
-	}
+        builder.append("HTTP/1.1 ");
+        builder.append(Integer.toString(response.code()));
+        builder.append(" ");
+        builder.append(response.message());
+        builder.appendLineBreak();
 
-	class AsciidocOneRelationshipDecorator<T, I, D, J> extends WrappedOneRelationshipRepository<T, I, D, J> {
+        response.getHeaderNames().stream().sorted()
+                .forEach(name -> builder.appendLine(name + ": " + response.getResponseHeader(name)));
 
-		private final AsciidocDecoratorFactory factory;
+        String body;
+        try {
+            body = response.body();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        if (body != null) {
+            builder.appendLineBreak();
+            builder.append(body);
+            builder.appendLineBreak();
+        }
+        builder.endSource();
 
-		public AsciidocOneRelationshipDecorator(OneRelationshipRepository<T, I, D, J> decoratedObject,
-				AsciidocDecoratorFactory factory) {
-			super(decoratedObject);
-			this.factory = factory;
-		}
+        File file = new File(resourceDir, "captured_" + captor.getKey() + "_response.adoc");
+        builder.write(file);
+    }
 
-		@Override
-		public void setRelation(T source, J targetId, String fieldName) {
-			try {
-				super.setRelation(source, targetId, fieldName);
-			}
-			finally {
-				factory.finalizeDoc(source.getClass());
-			}
-		}
+    class AsciidocBulkResourceDecorator<T, I> extends AsciidocResourceDecorator<T, I> implements BulkResourceRepository<T, I> {
 
-		@Override
-		public Map<I, D> findOneRelations(Collection<I> sourceIds, String fieldName, QuerySpec querySpec) {
-			try {
-				return super.findOneRelations(sourceIds, fieldName, querySpec);
-			}
-			finally {
-				factory.finalizeDoc(querySpec.getResourceClass());
-			}
-		}
-	}
+        public AsciidocBulkResourceDecorator(ResourceRepository<T, I> wrappedRepository, AsciidocDecoratorFactory factory) {
+            super(wrappedRepository, factory);
+        }
 
+        private BulkResourceRepository<T, I> getWrapped() {
+            return (BulkResourceRepository<T, I>) super.wrappedRepository;
+        }
 
-	class AsciidocManyRelationshipDecorator<T, I, D, J> extends WrappedManyRelationshipRepository<T, I, D, J> {
+        @Override
+        public <S extends T> List<S> save(List<S> resources) {
+            try {
+                return getWrapped().save(resources);
+            } finally {
+                factory.finalizeDoc(getResourceClass());
+            }
+        }
 
-		private final AsciidocDecoratorFactory factory;
+        @Override
+        public <S extends T> List<S> create(List<S> resources) {
+            try {
+                return getWrapped().create(resources);
+            } finally {
+                factory.finalizeDoc(getResourceClass());
+            }
+        }
 
-		public AsciidocManyRelationshipDecorator(ManyRelationshipRepository<T, I, D, J> decoratedObject,
-				AsciidocDecoratorFactory factory) {
-			super(decoratedObject);
-			this.factory = factory;
-		}
+        @Override
+        public void delete(List<I> ids) {
+            try {
+                getWrapped().delete(ids);
+            } finally {
+                factory.finalizeDoc(getResourceClass());
+            }
+        }
+    }
 
-		@Override
-		public void setRelations(T source, Collection<J> targetIds, String fieldName) {
-			try {
-				super.setRelations(source, targetIds, fieldName);
-			}
-			finally {
-				factory.finalizeDoc(source.getClass());
-			}
-		}
+    class AsciidocResourceDecorator<T, I> extends WrappedResourceRepository<T, I> {
 
-		@Override
-		public void addRelations(T source, Collection<J> targetIds, String fieldName) {
-			try {
-				super.addRelations(source, targetIds, fieldName);
-			}
-			finally {
-				factory.finalizeDoc(source.getClass());
-			}
-		}
+        protected final AsciidocDecoratorFactory factory;
 
-		@Override
-		public void removeRelations(T source, Collection<J> targetIds, String fieldName) {
-			try {
-				super.removeRelations(source, targetIds, fieldName);
-			}
-			finally {
-				factory.finalizeDoc(source.getClass());
-			}
-		}
+        public AsciidocResourceDecorator(ResourceRepository<T, I> wrappedRepository, AsciidocDecoratorFactory factory) {
+            super(wrappedRepository);
+            this.factory = factory;
+        }
+
+        @Override
+        public T findOne(I id, QuerySpec querySpec) {
+            try {
+                return super.findOne(id, querySpec);
+            } finally {
+                factory.finalizeDoc(getResourceClass());
+            }
+        }
 
 
-		@Override
-		public Map<I, ResourceList<D>> findManyRelations(Collection<I> sourceIds, String fieldName, QuerySpec querySpec) {
-			try {
-				return super.findManyRelations(sourceIds, fieldName, querySpec);
-			}
-			finally {
-				factory.finalizeDoc(querySpec.getResourceClass());
-			}
-		}
-	}
+        @Override
+        public ResourceList<T> findAll(QuerySpec querySpec) {
+            try {
+                return super.findAll(querySpec);
+            } finally {
+                factory.finalizeDoc(getResourceClass());
+            }
+        }
+
+        @Override
+        public ResourceList<T> findAll(Collection<I> ids, QuerySpec querySpec) {
+            try {
+                return super.findAll(ids, querySpec);
+            } finally {
+                factory.finalizeDoc(getResourceClass());
+            }
+        }
+
+        @Override
+        public <S extends T> S save(S entity) {
+            try {
+                return super.save(entity);
+            } finally {
+                factory.finalizeDoc(getResourceClass());
+            }
+        }
+
+        @Override
+        public <S extends T> S create(S entity) {
+            try {
+                return super.create(entity);
+            } finally {
+                factory.finalizeDoc(getResourceClass());
+            }
+        }
+
+        @Override
+        public void delete(I id) {
+            try {
+                super.delete(id);
+            } finally {
+                factory.finalizeDoc(getResourceClass());
+            }
+        }
+    }
+
+    class AsciidocOneRelationshipDecorator<T, I, D, J> extends WrappedOneRelationshipRepository<T, I, D, J> {
+
+        private final AsciidocDecoratorFactory factory;
+
+        public AsciidocOneRelationshipDecorator(OneRelationshipRepository<T, I, D, J> decoratedObject,
+                                                AsciidocDecoratorFactory factory) {
+            super(decoratedObject);
+            this.factory = factory;
+        }
+
+        @Override
+        public void setRelation(T source, J targetId, String fieldName) {
+            try {
+                super.setRelation(source, targetId, fieldName);
+            } finally {
+                factory.finalizeDoc(source.getClass());
+            }
+        }
+
+        @Override
+        public Map<I, D> findOneRelations(Collection<I> sourceIds, String fieldName, QuerySpec querySpec) {
+            try {
+                return super.findOneRelations(sourceIds, fieldName, querySpec);
+            } finally {
+                factory.finalizeDoc(querySpec.getResourceClass());
+            }
+        }
+    }
+
+
+    class AsciidocManyRelationshipDecorator<T, I, D, J> extends WrappedManyRelationshipRepository<T, I, D, J> {
+
+        private final AsciidocDecoratorFactory factory;
+
+        public AsciidocManyRelationshipDecorator(ManyRelationshipRepository<T, I, D, J> decoratedObject,
+                                                 AsciidocDecoratorFactory factory) {
+            super(decoratedObject);
+            this.factory = factory;
+        }
+
+        @Override
+        public void setRelations(T source, Collection<J> targetIds, String fieldName) {
+            try {
+                super.setRelations(source, targetIds, fieldName);
+            } finally {
+                factory.finalizeDoc(source.getClass());
+            }
+        }
+
+        @Override
+        public void addRelations(T source, Collection<J> targetIds, String fieldName) {
+            try {
+                super.addRelations(source, targetIds, fieldName);
+            } finally {
+                factory.finalizeDoc(source.getClass());
+            }
+        }
+
+        @Override
+        public void removeRelations(T source, Collection<J> targetIds, String fieldName) {
+            try {
+                super.removeRelations(source, targetIds, fieldName);
+            } finally {
+                factory.finalizeDoc(source.getClass());
+            }
+        }
+
+
+        @Override
+        public Map<I, ResourceList<D>> findManyRelations(Collection<I> sourceIds, String fieldName, QuerySpec querySpec) {
+            try {
+                return super.findManyRelations(sourceIds, fieldName, querySpec);
+            } finally {
+                factory.finalizeDoc(querySpec.getResourceClass());
+            }
+        }
+    }
 }

--- a/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/OpenAPIGeneratorComplexTest.java
+++ b/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/OpenAPIGeneratorComplexTest.java
@@ -1,5 +1,9 @@
 package io.crnk.gen.openapi;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
 import io.crnk.client.CrnkClient;
 import io.crnk.client.http.inmemory.InMemoryHttpAdapter;
 import io.crnk.core.boot.CrnkBoot;
@@ -19,10 +23,6 @@ import io.swagger.v3.parser.OpenAPIV3Parser;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Map;
 
 public class OpenAPIGeneratorComplexTest extends OpenAPIGeneratorTestBase {
   private MetaModule metaModule;
@@ -61,7 +61,7 @@ public class OpenAPIGeneratorComplexTest extends OpenAPIGeneratorTestBase {
 
     CrnkBoot boot = new CrnkBoot();
     boot.setServiceDiscovery(new EmptyServiceDiscovery());
-    boot.addModule(new TestModule());
+    boot.addModule(new TestModule().setBulk(false));
     boot.addModule(metaModule);
     boot.boot();
     return boot;

--- a/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/OASGeneratorTest.java
+++ b/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/OASGeneratorTest.java
@@ -1,5 +1,10 @@
 package io.crnk.gen.openapi.internal;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.Objects;
+
 import io.crnk.gen.openapi.OutputFormat;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
@@ -7,11 +12,6 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.Charset;
-import java.util.Objects;
 
 public class OASGeneratorTest {
 
@@ -22,6 +22,7 @@ public class OASGeneratorTest {
     String templatePath = Objects.requireNonNull(
         getClass().getClassLoader().getResource("openapi-template.yml")
     ).getPath();
+    templatePath = templatePath.replace("/C:/", "C:/"); // windows fix
     openApi = new OpenAPIV3Parser().read(templatePath);
   }
 
@@ -63,6 +64,7 @@ public class OASGeneratorTest {
     }
 
     expectedSource = expectedSource.replace("\r\n", "\n");
+	actualSource = actualSource.replace("\r\n", "\n"); // TODO maybe update the generator part?
 
     String[] expectedLines = org.apache.commons.lang3.StringUtils.split(expectedSource, '\n');
     String[] actualLines = org.apache.commons.lang3.StringUtils.split(actualSource, '\n');

--- a/crnk-operations/src/main/java/io/crnk/operations/server/order/OrderedOperation.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/server/order/OrderedOperation.java
@@ -1,5 +1,6 @@
 package io.crnk.operations.server.order;
 
+import io.crnk.core.engine.internal.dispatcher.path.JsonPath;
 import io.crnk.operations.Operation;
 
 public class OrderedOperation {
@@ -7,6 +8,8 @@ public class OrderedOperation {
 	private Operation operation;
 
 	private int ordinal;
+
+	private JsonPath path;
 
 	public OrderedOperation(Operation operation, int ordinal) {
 		this.operation = operation;
@@ -19,5 +22,13 @@ public class OrderedOperation {
 
 	public int getOrdinal() {
 		return ordinal;
+	}
+
+	public JsonPath getPath() {
+		return path;
+	}
+
+	public void setPath(JsonPath path) {
+		this.path = path;
 	}
 }

--- a/crnk-operations/src/test/java/io/crnk/operations/AbstractOperationsTest.java
+++ b/crnk-operations/src/test/java/io/crnk/operations/AbstractOperationsTest.java
@@ -1,5 +1,16 @@
 package io.crnk.operations;
 
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.metamodel.ManagedType;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
 import io.crnk.client.CrnkClient;
 import io.crnk.client.action.JerseyActionStubFactory;
 import io.crnk.client.http.okhttp.OkHttpAdapter;
@@ -24,6 +35,7 @@ import io.crnk.rs.CrnkFeature;
 import io.crnk.spring.internal.SpringServiceDiscovery;
 import io.crnk.spring.jpa.SpringTransactionRunner;
 import io.crnk.test.JerseyTestBase;
+import io.crnk.test.mock.models.Task;
 import io.crnk.validation.ValidationModule;
 import okhttp3.OkHttpClient.Builder;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -32,184 +44,180 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.metamodel.ManagedType;
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-
 public abstract class AbstractOperationsTest extends JerseyTestBase {
 
-    protected CrnkClient client;
+	protected CrnkClient client;
 
-    protected AnnotationConfigApplicationContext context;
+	protected AnnotationConfigApplicationContext context;
 
-    protected OperationsModule operationsModule;
+	protected OperationsModule operationsModule;
 
-    public static void setNetworkTimeout(CrnkClient client, final int timeout, final TimeUnit timeUnit) {
-        OkHttpAdapter httpAdapter = (OkHttpAdapter) client.getHttpAdapter();
-        httpAdapter.addListener(new OkHttpAdapterListenerBase() {
+	public static void setNetworkTimeout(CrnkClient client, final int timeout, final TimeUnit timeUnit) {
+		OkHttpAdapter httpAdapter = (OkHttpAdapter) client.getHttpAdapter();
+		httpAdapter.addListener(new OkHttpAdapterListenerBase() {
 
-            @Override
-            public void onBuild(Builder builder) {
-                builder.readTimeout(timeout, timeUnit);
-            }
-        });
-    }
+			@Override
+			public void onBuild(Builder builder) {
+				builder.readTimeout(timeout, timeUnit);
+			}
+		});
+	}
 
-    public static void clear(EntityManager em) {
-        clear(em, JpaCriteriaQueryFactory.newInstance());
-    }
+	public static void clear(EntityManager em) {
+		clear(em, JpaCriteriaQueryFactory.newInstance());
+	}
 
-    public static void clear(final EntityManager em, JpaQueryFactory factory) {
-        factory.initalize(new JpaQueryFactoryContext() {
-            @Override
-            public MetaPartition getMetaPartition() {
-                MetaLookupImpl metaLookup = new MetaLookupImpl();
-                JpaMetaProvider metaProvider = new JpaMetaProvider(em.getEntityManagerFactory());
-                metaLookup.addProvider(metaProvider);
-                metaLookup.initialize();
-                return metaProvider.getPartition();
-            }
+	public static void clear(final EntityManager em, JpaQueryFactory factory) {
+		factory.initalize(new JpaQueryFactoryContext() {
+			@Override
+			public MetaPartition getMetaPartition() {
+				MetaLookupImpl metaLookup = new MetaLookupImpl();
+				JpaMetaProvider metaProvider = new JpaMetaProvider(em.getEntityManagerFactory());
+				metaLookup.addProvider(metaProvider);
+				metaLookup.initialize();
+				return metaProvider.getPartition();
+			}
 
-            @Override
-            public EntityManager getEntityManager() {
-                return em;
-            }
-        });
-        clear(em, factory.query(MovieEntity.class).buildExecutor().getResultList());
-        clear(em, factory.query(PersonEntity.class).buildExecutor().getResultList());
-        em.flush();
-        em.clear();
-    }
+			@Override
+			public EntityManager getEntityManager() {
+				return em;
+			}
+		});
+		clear(em, factory.query(MovieEntity.class).buildExecutor().getResultList());
+		clear(em, factory.query(PersonEntity.class).buildExecutor().getResultList());
+		em.flush();
+		em.clear();
+	}
 
-    private static void clear(EntityManager em, List<?> list) {
-        for (Object obj : list) {
-            em.remove(obj);
-        }
-    }
+	private static void clear(EntityManager em, List<?> list) {
+		for (Object obj : list) {
+			em.remove(obj);
+		}
+	}
 
-    @Before
-    public void setup() {
-        clear();
-        client = new CrnkClient(getBaseUri().toString());
-        client.setActionStubFactory(JerseyActionStubFactory.newInstance());
-        client.getHttpAdapter().setReceiveTimeout(10000000, TimeUnit.MILLISECONDS);
+	@Before
+	public void setup() {
+		clear();
+		client = new CrnkClient(getBaseUri().toString());
+		client.setActionStubFactory(JerseyActionStubFactory.newInstance());
+		client.getHttpAdapter().setReceiveTimeout(10000000, TimeUnit.MILLISECONDS);
 
-        MetaModuleConfig config = new MetaModuleConfig();
-        config.addMetaProvider(new ResourceMetaProvider());
-        MetaModule metaModule = MetaModule.createServerModule(config);
-        client.addModule(metaModule);
+		MetaModuleConfig config = new MetaModuleConfig();
+		config.addMetaProvider(new ResourceMetaProvider());
+		MetaModule metaModule = MetaModule.createServerModule(config);
+		client.addModule(metaModule);
 
-        JpaModule module = JpaModule.newClientModule();
-        setupModule(module, false);
-        client.addModule(module);
+		JpaModule module = JpaModule.newClientModule();
+		setupModule(module, false);
+		client.addModule(module);
 
-        setNetworkTimeout(client, 10000, TimeUnit.SECONDS);
-    }
+		setNetworkTimeout(client, 10000, TimeUnit.SECONDS);
+	}
 
-    protected MovieEntity newMovie(String title) {
-        MovieEntity movie = new MovieEntity();
-        movie.setId(UUID.randomUUID());
-        movie.setImdbId(title);
-        movie.setTitle(title);
-        return movie;
-    }
+	protected MovieEntity newMovie(String title) {
+		MovieEntity movie = new MovieEntity();
+		movie.setId(UUID.randomUUID());
+		movie.setImdbId(title);
+		movie.setTitle(title);
+		return movie;
+	}
 
-    protected PersonEntity newPerson(String name) {
-        PersonEntity person = new PersonEntity();
-        person.setId(UUID.randomUUID());
-        person.setName(name);
-        return person;
-    }
-
-    protected void setupModule(JpaModule module, boolean server) {
-    }
-
-    @Override
-    @After
-    public void tearDown() throws Exception {
-        super.tearDown();
-
-        clear();
-
-        if (context != null) {
-            context.destroy();
-        }
-    }
-
-    protected void clear() {
-        SpringTransactionRunner transactionRunner = context.getBean(SpringTransactionRunner.class);
-        transactionRunner.doInTransaction(() -> {
-            EntityManager em = context.getBean(EntityManagerProducer.class).getEntityManager();
-            clear(em);
-            return null;
-        });
-    }
-
-    @Override
-    protected Application configure() {
-        return new TestApplication();
-    }
-
-    @ApplicationPath("/")
-    private class TestApplication extends ResourceConfig {
+	protected PersonEntity newPerson(String name) {
+		PersonEntity person = new PersonEntity();
+		person.setId(UUID.randomUUID());
+		person.setName(name);
+		return person;
+	}
 
 
-        public TestApplication() {
-            Assert.assertNull(context);
+	protected Task newTask(String name) {
+		Task person = new Task();
+		person.setId(UUID.randomUUID().getLeastSignificantBits());
+		person.setName(name);
+		return person;
+	}
 
-            context = new AnnotationConfigApplicationContext(io.crnk.operations.OperationsTestConfig.class);
-            context.start();
-            EntityManagerFactory emFactory = context.getBean(EntityManagerFactory.class);
-            EntityManager em = context.getBean(io.crnk.operations.EntityManagerProducer.class).getEntityManager();
-            SpringServiceDiscovery serviceDiscovery = context.getBean(SpringServiceDiscovery.class);
-            SpringTransactionRunner transactionRunner = context.getBean(SpringTransactionRunner.class);
+	protected void setupModule(JpaModule module, boolean server) {
+	}
 
-            CrnkFeature feature = new CrnkFeature();
-            feature.getBoot().setServiceDiscovery(serviceDiscovery);
+	@Override
+	@After
+	public void tearDown() throws Exception {
+		super.tearDown();
 
-            JpaModuleConfig config = new JpaModuleConfig();
-            Set<ManagedType<?>> managedTypes = emFactory.getMetamodel().getManagedTypes();
-            for (ManagedType<?> managedType : managedTypes) {
-                Class<?> managedJavaType = managedType.getJavaType();
-                if (managedJavaType.getAnnotation(Entity.class) != null) {
-                    if (!config.hasRepository(managedJavaType)) {
-                        config.addRepository(JpaRepositoryConfig.builder(managedJavaType).build());
-                    }
-                }
-            }
+		clear();
 
-            JpaModule jpaModule = JpaModule.createServerModule(config, em, transactionRunner);
-            setupModule(jpaModule, true);
+		if (context != null) {
+			context.destroy();
+		}
+	}
 
-            operationsModule = OperationsModule.create();
+	protected void clear() {
+		SpringTransactionRunner transactionRunner = context.getBean(SpringTransactionRunner.class);
+		transactionRunner.doInTransaction(() -> {
+			EntityManager em = context.getBean(EntityManagerProducer.class).getEntityManager();
+			clear(em);
+			return null;
+		});
+	}
 
-            // tag::transaction[]
+	@Override
+	protected Application configure() {
+		return new TestApplication();
+	}
+
+	@ApplicationPath("/")
+	private class TestApplication extends ResourceConfig {
+
+
+		public TestApplication() {
+			Assert.assertNull(context);
+
+			context = new AnnotationConfigApplicationContext(io.crnk.operations.OperationsTestConfig.class);
+			context.start();
+			EntityManagerFactory emFactory = context.getBean(EntityManagerFactory.class);
+			EntityManager em = context.getBean(io.crnk.operations.EntityManagerProducer.class).getEntityManager();
+			SpringServiceDiscovery serviceDiscovery = context.getBean(SpringServiceDiscovery.class);
+			SpringTransactionRunner transactionRunner = context.getBean(SpringTransactionRunner.class);
+
+			CrnkFeature feature = new CrnkFeature();
+			feature.getBoot().setServiceDiscovery(serviceDiscovery);
+
+			JpaModuleConfig config = new JpaModuleConfig();
+			Set<ManagedType<?>> managedTypes = emFactory.getMetamodel().getManagedTypes();
+			for (ManagedType<?> managedType : managedTypes) {
+				Class<?> managedJavaType = managedType.getJavaType();
+				if (managedJavaType.getAnnotation(Entity.class) != null) {
+					if (!config.hasRepository(managedJavaType)) {
+						config.addRepository(JpaRepositoryConfig.builder(managedJavaType).build());
+					}
+				}
+			}
+
+			JpaModule jpaModule = JpaModule.createServerModule(config, em, transactionRunner);
+			setupModule(jpaModule, true);
+
+			operationsModule = OperationsModule.create();
+
+			// tag::transaction[]
             if (isTransactional()) {
-                operationsModule.addFilter(new TransactionOperationFilter());
-            }
-            // end::transaction[]
-
-            feature.addModule(jpaModule);
-            feature.addModule(operationsModule);
-            feature.addModule(ValidationModule.create());
-            setupServer(feature);
-            register(feature);
-        }
-    }
+				operationsModule.addFilter(new TransactionOperationFilter());
+			}
+			// end::transaction[]
+			feature.addModule(jpaModule);
+			feature.addModule(operationsModule);
+			feature.addModule(ValidationModule.create());
+			setupServer(feature);
+			register(feature);
+		}
+	}
 
     protected boolean isTransactional() {
         return true;
     }
 
-    protected void setupServer(CrnkFeature feature) {
-        // noting to do, override if necessary
-    }
+	protected void setupServer(CrnkFeature feature) {
+		// noting to do, override if necessary
+	}
 
 }

--- a/crnk-reactive/src/main/java/io/crnk/reactive/internal/MonoResultFactory.java
+++ b/crnk-reactive/src/main/java/io/crnk/reactive/internal/MonoResultFactory.java
@@ -1,13 +1,13 @@
 package io.crnk.reactive.internal;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import io.crnk.core.engine.result.Result;
 import io.crnk.core.engine.result.ResultFactory;
 import reactor.core.publisher.Mono;
 import reactor.util.context.Context;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Implementation based on Reactor library. Attempts to pass along request context in subscriber context using {@value SUBSCRIBER_CONTEXT_KEY}.
@@ -68,6 +68,14 @@ public class MonoResultFactory implements ResultFactory {
 	public <T> Result<T> attachContext(Result<T> result, Object context) {
 		MonoResult monoResult = (MonoResult) result;
 		return new MonoResult<>(monoResult.getMono().subscriberContext(Context.of(SUBSCRIBER_CONTEXT_KEY, context)));
+	}
+
+	@Override
+	public <T> Result<List<T>> all(List<Result<T>> results) {
+		if (results.size() == 1) {
+			return results.get(0).map(it -> Arrays.asList(it));
+		}
+		throw new UnsupportedOperationException("bulk support not yet implemented");
 	}
 
 	@Override

--- a/crnk-security/src/main/java/io/crnk/security/SecurityModule.java
+++ b/crnk-security/src/main/java/io/crnk/security/SecurityModule.java
@@ -8,11 +8,13 @@ import io.crnk.core.engine.security.SecurityProvider;
 import io.crnk.core.engine.security.SecurityProviderContext;
 import io.crnk.core.exception.RepositoryNotFoundException;
 import io.crnk.core.module.Module;
+import io.crnk.core.repository.BulkResourceRepository;
 import io.crnk.core.repository.ManyRelationshipRepository;
 import io.crnk.core.repository.OneRelationshipRepository;
 import io.crnk.core.repository.ResourceRepository;
 import io.crnk.core.repository.foward.ForwardingRelationshipRepository;
 import io.crnk.core.utils.Supplier;
+import io.crnk.security.internal.DataRoomBulkResourceFilter;
 import io.crnk.security.internal.DataRoomMatcher;
 import io.crnk.security.internal.DataRoomRelationshipFilter;
 import io.crnk.security.internal.DataRoomResourceFilter;
@@ -199,6 +201,9 @@ public class SecurityModule implements Module {
                 matcher = new DataRoomMatcher(() -> config.getDataRoomFilter(), callerSecurityProvider);
                 LOGGER.debug("registering dataroom filter {}", config.getDataRoomFilter());
                 context.addRepositoryDecoratorFactory(repository -> {
+                    if (repository instanceof BulkResourceRepository) {
+                        return new DataRoomBulkResourceFilter((BulkResourceRepository) repository, matcher);
+                    }
                     if (repository instanceof ResourceRepository) {
                         return new DataRoomResourceFilter((ResourceRepository) repository, matcher);
                     }

--- a/crnk-security/src/main/java/io/crnk/security/internal/DataRoomBulkResourceFilter.java
+++ b/crnk-security/src/main/java/io/crnk/security/internal/DataRoomBulkResourceFilter.java
@@ -1,0 +1,70 @@
+package io.crnk.security.internal;
+
+import io.crnk.core.engine.http.HttpMethod;
+import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.internal.utils.PreconditionUtil;
+import io.crnk.core.engine.registry.RegistryEntry;
+import io.crnk.core.exception.ForbiddenException;
+import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.repository.BulkResourceRepository;
+import io.crnk.core.repository.ResourceRepository;
+import io.crnk.core.resource.list.ResourceList;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DataRoomBulkResourceFilter<T, I extends Serializable> extends DataRoomResourceFilter<T, I> implements BulkResourceRepository<T, I> {
+
+
+    public DataRoomBulkResourceFilter(ResourceRepository<T, I> wrappedRepository, DataRoomMatcher matcher) {
+        super(wrappedRepository, matcher);
+    }
+
+    private BulkResourceRepository<T, I> getWrapped() {
+        return (BulkResourceRepository<T, I>) wrappedRepository;
+    }
+
+    @Override
+    public <S extends T> List<S> save(List<S> resources) {
+        for (S resource : resources) {
+            matcher.verifyMatch(resource, HttpMethod.PATCH);
+        }
+
+        // verify access to unchanged state
+        RegistryEntry entry = resourceRegistry.getEntry(getResourceClass());
+        PreconditionUtil.verify(entry != null, "unknown resource class %s", getResourceClass());
+        ResourceInformation resourceInformation = entry.getResourceInformation();
+
+        List<I> ids = resources.stream().map(resource -> (I) resourceInformation.getId(resource)).collect(Collectors.toList());
+        ResourceList<T> currentResources = wrappedRepository.findAll(ids, new QuerySpec(getResourceClass()));
+        if (currentResources.size() != ids.size()) {
+            throw new ForbiddenException("not allowed to access resource");
+        }
+        for (T currentResource : currentResources) {
+            matcher.verifyMatch(currentResource, HttpMethod.PATCH);
+        }
+
+        return getWrapped().save(resources);
+    }
+
+    @Override
+    public <S extends T> List<S> create(List<S> resources) {
+        for (S resource : resources) {
+            matcher.verifyMatch(resource, HttpMethod.POST);
+        }
+        return getWrapped().create(resources);
+    }
+
+    @Override
+    public void delete(List<I> ids) {
+        List<T> resources = getWrapped().findAll(ids, new QuerySpec(getResourceClass()));
+        for (T resource : resources) {
+            matcher.verifyMatch(resource, HttpMethod.DELETE);
+        }
+        if (resources.size() != ids.size()) {
+            throw new ForbiddenException("not allowed to access resource");
+        }
+        getWrapped().delete(ids);
+    }
+}

--- a/crnk-security/src/main/java/io/crnk/security/internal/DataRoomResourceFilter.java
+++ b/crnk-security/src/main/java/io/crnk/security/internal/DataRoomResourceFilter.java
@@ -20,9 +20,9 @@ public class DataRoomResourceFilter<T, I extends Serializable> extends WrappedRe
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DataRoomResourceFilter.class);
 
-    private final DataRoomMatcher matcher;
+    protected final DataRoomMatcher matcher;
 
-    private ResourceRegistry resourceRegistry;
+    protected ResourceRegistry resourceRegistry;
 
 
     public DataRoomResourceFilter(ResourceRepository<T, I> wrappedRepository, DataRoomMatcher matcher) {

--- a/crnk-test/src/main/java/io/crnk/test/mock/TestModule.java
+++ b/crnk-test/src/main/java/io/crnk/test/mock/TestModule.java
@@ -2,7 +2,9 @@ package io.crnk.test.mock;
 
 import io.crnk.core.module.Module;
 import io.crnk.core.repository.InMemoryResourceRepository;
+import io.crnk.test.mock.models.BulkTask;
 import io.crnk.test.mock.models.RelocatedTask;
+import io.crnk.test.mock.repository.BulkInMemoryRepository;
 import io.crnk.test.mock.repository.HistoricTaskRepository;
 import io.crnk.test.mock.repository.PrimitiveAttributeRepository;
 import io.crnk.test.mock.repository.ProjectRepository;
@@ -24,72 +26,88 @@ import io.crnk.test.mock.repository.nested.RelatedRepository;
 
 public class TestModule implements Module {
 
-	private static ManyNestedRepository manyNestedRepository = new ManyNestedRepository();
+    private static ManyNestedRepository manyNestedRepository = new ManyNestedRepository();
 
-	private static OneNestedRepository oneNestedRepository = new OneNestedRepository();
+    private static OneNestedRepository oneNestedRepository = new OneNestedRepository();
 
-	private static RelatedRepository relatedRepository = new RelatedRepository();
+    private static RelatedRepository relatedRepository = new RelatedRepository();
 
-	private static ParentRepository parentRepository = new ParentRepository();
+    private static ParentRepository parentRepository = new ParentRepository();
 
-	private static NestedManyRelationshipRepository nestedManyRelationshipRepository = new NestedManyRelationshipRepository();
+    private static NestedManyRelationshipRepository nestedManyRelationshipRepository = new NestedManyRelationshipRepository();
 
-	private static NestedOneRelationshipRepository nestedOneRelationshipRepository = new NestedOneRelationshipRepository();
+    private static NestedOneRelationshipRepository nestedOneRelationshipRepository = new NestedOneRelationshipRepository();
 
-	private ProjectRepository projects = new ProjectRepository();
+    private ProjectRepository projects = new ProjectRepository();
 
-	private TaskRepository tasks = new TaskRepository();
+    private TaskRepository tasks = new TaskRepository();
 
-	@Override
-	public String getModuleName() {
-		return "test";
-	}
+    private boolean bulk = true;
 
-	@Override
-	public void setupModule(ModuleContext context) {
-		context.addRepository(tasks);
-		context.addRepository(projects);
-		context.addRepository(new ScheduleRepositoryImpl());
-		context.addRepository(new TaskSubtypeRepository());
-		context.addRepository(new ProjectToTaskRepository());
-		context.addRepository(new TaskToProjectRepository());
-		context.addRepository(new PrimitiveAttributeRepository());
-		context.addRepository(new RelationIdTestRepository());
-		context.addRepository(new RenamedIdRepository());
-		context.addRepository(new ScheduleStatusRepositoryImpl());
-		context.addRepository(new ReadOnlyTaskRepository());
-		context.addRepository(new HistoricTaskRepository());
-		context.addRepository(new InMemoryResourceRepository<>(RelocatedTask.class));
+    private BulkInMemoryRepository<BulkTask, Object> bulkTasks = new BulkInMemoryRepository<>(BulkTask.class);
 
-		context.addRepository(manyNestedRepository);
-		context.addRepository(oneNestedRepository);
-		context.addRepository(relatedRepository);
-		context.addRepository(parentRepository);
-		context.addRepository(nestedManyRelationshipRepository);
-		context.addRepository(nestedOneRelationshipRepository);
+    @Override
+    public String getModuleName() {
+        return "test";
+    }
 
-		context.addNamingStrategy(new TestNamingStrategy());
-		context.addExceptionMapper(new TestExceptionMapper());
-	}
+    @Override
+    public void setupModule(ModuleContext context) {
+        context.addRepository(tasks);
+        context.addRepository(projects);
+        context.addRepository(new ScheduleRepositoryImpl());
+        context.addRepository(new TaskSubtypeRepository());
+        context.addRepository(new ProjectToTaskRepository());
+        context.addRepository(new TaskToProjectRepository());
+        context.addRepository(new PrimitiveAttributeRepository());
+        context.addRepository(new RelationIdTestRepository());
+        context.addRepository(new RenamedIdRepository());
+        context.addRepository(new ScheduleStatusRepositoryImpl());
+        context.addRepository(new ReadOnlyTaskRepository());
+        context.addRepository(new HistoricTaskRepository());
+        context.addRepository(new InMemoryResourceRepository<>(RelocatedTask.class));
+        if (bulk) {
+            context.addRepository(bulkTasks);
+        }
 
-	public ProjectRepository getProjects() {
-		return projects;
-	}
+        context.addRepository(manyNestedRepository);
+        context.addRepository(oneNestedRepository);
+        context.addRepository(relatedRepository);
+        context.addRepository(parentRepository);
+        context.addRepository(nestedManyRelationshipRepository);
+        context.addRepository(nestedOneRelationshipRepository);
 
-	public TaskRepository getTasks() {
-		return tasks;
-	}
+        context.addNamingStrategy(new TestNamingStrategy());
+        context.addExceptionMapper(new TestExceptionMapper());
+    }
 
-	public static void clear() {
-		TaskRepository.clear();
-		ProjectRepository.clear();
-		TaskToProjectRepository.clear();
-		ProjectToTaskRepository.clear();
-		ScheduleRepositoryImpl.clear();
-		RelationIdTestRepository.clear();
+    public TestModule setBulk(boolean bulk) {
+        this.bulk = bulk;
+        return this;
+    }
 
-		manyNestedRepository.clear();
-		relatedRepository.clear();
-		parentRepository.clear();
-	}
+    public ProjectRepository getProjects() {
+        return projects;
+    }
+
+    public TaskRepository getTasks() {
+        return tasks;
+    }
+
+    public BulkInMemoryRepository<BulkTask, Object> getBulkTasks() {
+        return bulkTasks;
+    }
+
+    public static void clear() {
+        TaskRepository.clear();
+        ProjectRepository.clear();
+        TaskToProjectRepository.clear();
+        ProjectToTaskRepository.clear();
+        ScheduleRepositoryImpl.clear();
+        RelationIdTestRepository.clear();
+
+        manyNestedRepository.clear();
+        relatedRepository.clear();
+        parentRepository.clear();
+    }
 }

--- a/crnk-test/src/main/java/io/crnk/test/mock/models/BulkTask.java
+++ b/crnk-test/src/main/java/io/crnk/test/mock/models/BulkTask.java
@@ -1,0 +1,30 @@
+package io.crnk.test.mock.models;
+
+import io.crnk.core.queryspec.pagingspec.OffsetLimitPagingSpec;
+import io.crnk.core.resource.annotations.JsonApiId;
+import io.crnk.core.resource.annotations.JsonApiResource;
+
+@JsonApiResource(type = "bulkTasks", pagingSpec = OffsetLimitPagingSpec.class)
+public class BulkTask {
+
+	@JsonApiId
+	private Long id;
+
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/crnk-test/src/main/java/io/crnk/test/mock/repository/BulkInMemoryRepository.java
+++ b/crnk-test/src/main/java/io/crnk/test/mock/repository/BulkInMemoryRepository.java
@@ -1,0 +1,39 @@
+package io.crnk.test.mock.repository;
+
+import io.crnk.core.repository.BulkResourceRepository;
+import io.crnk.core.repository.InMemoryResourceRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BulkInMemoryRepository<T, I> extends InMemoryResourceRepository<T, I> implements BulkResourceRepository<T, I> {
+
+    public BulkInMemoryRepository(Class<T> resourceClass) {
+        super(resourceClass);
+    }
+
+    @Override
+    public <S extends T> List<S> save(List<S> resources) {
+        List<S> results = new ArrayList<>();
+        for (S resource : resources) {
+            results.add(save(resource));
+        }
+        return results;
+    }
+
+    @Override
+    public <S extends T> List<S> create(List<S> resources) {
+        List<S> results = new ArrayList<>();
+        for (S resource : resources) {
+            results.add(create(resource));
+        }
+        return results;
+    }
+
+    @Override
+    public void delete(List<I> ids) {
+        for (I id : ids) {
+            delete(id);
+        }
+    }
+}

--- a/crnk-test/src/main/java/io/crnk/test/mock/repository/BulkTaskRepository.java
+++ b/crnk-test/src/main/java/io/crnk/test/mock/repository/BulkTaskRepository.java
@@ -1,0 +1,8 @@
+package io.crnk.test.mock.repository;
+
+import io.crnk.core.repository.BulkResourceRepository;
+import io.crnk.test.mock.models.BulkTask;
+
+public interface BulkTaskRepository extends BulkResourceRepository<BulkTask, Long> {
+
+}

--- a/crnk-ui/package-lock.json
+++ b/crnk-ui/package-lock.json
@@ -470,15 +470,13 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
 			"integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"are-we-there-yet": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"delegates": "1.0.0",
 				"readable-stream": "2.3.3"
@@ -1522,8 +1520,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -1919,8 +1916,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"denodeify": {
 			"version": "1.2.1",
@@ -2733,7 +2729,6 @@
 			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"inherits": "2.0.3",
@@ -2752,7 +2747,6 @@
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"aproba": "1.1.2",
 				"console-control-strings": "1.1.0",
@@ -2769,7 +2763,6 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -2779,7 +2772,6 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -2808,8 +2800,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
 			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -3015,8 +3006,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"hash-base": {
 			"version": "2.0.2",
@@ -4554,8 +4544,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
 			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"matcher-collection": {
 			"version": "1.0.4",
@@ -7281,6 +7270,15 @@
 			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
 			"dev": true
 		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -7306,15 +7304,6 @@
 						"ansi-regex": "3.0.0"
 					}
 				}
-			}
-		},
-		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "5.1.1"
 			}
 		},
 		"stringstream": {


### PR DESCRIPTION
Allows a repository to perform updates on multiple resources simultaneously.

Can be accessed in two ways:

- In crnk-client a BulkResourceRepository stub can be created to  send collections rather than single resources in the Document.data section.
- OperationsModule will automatically make use of it if multiple changes to the same repository are detected.

Considered experimental. Only POST is supported. PATCH and DELETE to follow.