### PR TITLE
ErrorResponse.getResponse() serializes as "entity" instead of "errors"

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/error/ErrorResponse.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/error/ErrorResponse.java
@@ -41,7 +41,7 @@ public final class ErrorResponse {
 
 	public JsonApiResponse getResponse() {
 		return new JsonApiResponse()
-				.setEntity(data);
+				.setErrors(data);
 	}
 
 	@Override

--- a/crnk-core/src/test/java/io/crnk/core/engine/error/ErrorResponseBuilderTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/error/ErrorResponseBuilderTest.java
@@ -24,7 +24,7 @@ public class ErrorResponseBuilderTest {
 				.setSingleErrorData(ErrorDataMother.fullyPopulatedErrorData())
 				.build();
 
-		assertThat((Iterable<ErrorData>) response.getResponse().getEntity())
+		assertThat((Iterable<ErrorData>) response.getResponse().getErrors())
 				.hasSize(1)
 				.containsExactly(ErrorDataMother.fullyPopulatedErrorData());
 	}
@@ -35,7 +35,7 @@ public class ErrorResponseBuilderTest {
 				.setErrorData(ErrorDataMother.oneSizeCollectionOfErrorData())
 				.build();
 
-		assertThat((Iterable<ErrorData>) response.getResponse().getEntity())
+		assertThat((Iterable<ErrorData>) response.getResponse().getErrors())
 				.hasSize(1)
 				.containsExactly(ErrorDataMother.fullyPopulatedErrorData());
 	}

--- a/crnk-core/src/test/java/io/crnk/core/exception/CrnkExceptionMapperTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/exception/CrnkExceptionMapperTest.java
@@ -21,7 +21,7 @@ public class CrnkExceptionMapperTest {
 		ErrorResponse response = mapper.toErrorResponse(new SampleCrnkException());
 
 		assertThat(response.getHttpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR_500);
-		assertThat((Iterable<?>) response.getResponse().getEntity()).hasSize(1).extracting("title", "detail")
+		assertThat((Iterable<?>) response.getResponse().getErrors()).hasSize(1).extracting("title", "detail")
 				.containsExactly(tuple(TITLE1, DETAIL1));
 	}
 

--- a/crnk-test/src/main/java/io/crnk/test/mock/TestExceptionMapper.java
+++ b/crnk-test/src/main/java/io/crnk/test/mock/TestExceptionMapper.java
@@ -20,7 +20,7 @@ public class TestExceptionMapper implements ExceptionMapper<TestException> {
 	@Override
 	public TestException fromErrorResponse(ErrorResponse errorResponse) {
 		JsonApiResponse response = errorResponse.getResponse();
-		List<ErrorData> errors = (List<ErrorData>) response.getEntity();
+		List<ErrorData> errors = (List<ErrorData>) response.getErrors();
 		StringBuilder message = new StringBuilder();
 		for (ErrorData error : errors) {
 			String title = error.getDetail();


### PR DESCRIPTION
Not sure if this is by design, so ignore this pull request if I'm in error. not sure if this was a design decision or an oversight, as the git history of the ErrorResponse method getResponse() from day one has always been returning "new JsonApiResponse().setEntity(data);" instead of "new JsonApiResponse().setErrors(data);". 

At the same time even though it has always been calling setEntity, I think this might be an oversight since the online [spec](https://jsonapi.org/format/#error-objects) currently states: "Error objects MUST be returned as an array keyed by errors in the top level of a JSON:API document." 