### PR TITLE
Support versioning trough content type #238

### DIFF
--- a/crnk-client/src/main/java/io/crnk/client/CrnkClient.java
+++ b/crnk-client/src/main/java/io/crnk/client/CrnkClient.java
@@ -4,7 +4,6 @@ import java.io.Serializable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -21,9 +20,11 @@ import io.crnk.client.http.HttpAdapterProvider;
 import io.crnk.client.http.apache.HttpClientAdapterProvider;
 import io.crnk.client.http.okhttp.OkHttpAdapterProvider;
 import io.crnk.client.internal.ClientDocumentMapper;
+import io.crnk.client.internal.ClientHttpRequestContext;
 import io.crnk.client.internal.ClientStubInvocationHandler;
 import io.crnk.client.internal.RelationshipRepositoryStubImpl;
 import io.crnk.client.internal.ResourceRepositoryStubImpl;
+import io.crnk.client.internal.SingletonResultFactory;
 import io.crnk.client.internal.proxy.BasicProxyFactory;
 import io.crnk.client.internal.proxy.ClientProxyFactory;
 import io.crnk.client.internal.proxy.ClientProxyFactoryContext;
@@ -85,6 +86,7 @@ import io.crnk.core.repository.RelationshipRepository;
 import io.crnk.core.repository.ResourceRepository;
 import io.crnk.core.repository.decorate.Wrapper;
 import io.crnk.core.resource.annotations.JsonApiResource;
+import io.crnk.core.resource.annotations.JsonApiVersion;
 import io.crnk.core.resource.list.DefaultResourceList;
 
 /**
@@ -92,632 +94,648 @@ import io.crnk.core.resource.list.DefaultResourceList;
  */
 public class CrnkClient {
 
-	private static final String REST_TEMPLATE_PROVIDER_NAME = "io.crnk.spring.client.RestTemplateAdapterProvider";
+    private static final String REST_TEMPLATE_PROVIDER_NAME = "io.crnk.spring.client.RestTemplateAdapterProvider";
 
-	private final ClientType clientType;
+    private final ClientType clientType;
 
-	private HttpAdapter httpAdapter;
+    private HttpAdapter httpAdapter;
 
-	private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper;
 
-	private ResourceRegistry resourceRegistry;
+    private ResourceRegistry resourceRegistry;
 
-	private ModuleRegistry moduleRegistry;
+    private ModuleRegistry moduleRegistry;
 
-	private JsonApiUrlBuilder urlBuilder;
+    private JsonApiUrlBuilder urlBuilder;
 
-	private boolean initialized = false;
+    private boolean initialized = false;
 
-	private ExceptionMapperRegistry exceptionMapperRegistry;
+    private ExceptionMapperRegistry exceptionMapperRegistry;
 
-	private ActionStubFactory actionStubFactory;
+    private ActionStubFactory actionStubFactory;
 
-	private ClientDocumentMapper documentMapper;
+    private ClientDocumentMapper documentMapper;
 
-	private ServiceDiscovery serviceDiscovery;
+    private ServiceDiscovery serviceDiscovery;
 
-	private ServiceDiscoveryFactory serviceDiscoveryFactory = new DefaultServiceDiscoveryFactory();
+    private ServiceDiscoveryFactory serviceDiscoveryFactory = new DefaultServiceDiscoveryFactory();
 
-	private PropertiesProvider propertiesProvider = new SystemPropertiesProvider();
+    private PropertiesProvider propertiesProvider = new SystemPropertiesProvider();
 
-	private Long defaultPageLimit = null;
+    private Long defaultPageLimit = null;
 
-	private Long maxPageLimit = null;
+    private Long maxPageLimit = null;
 
-	private QueryContext queryContext = new QueryContext();
+    private QueryContext queryContext = new QueryContext().setRequestVersion(Integer.MAX_VALUE);
 
-	private List<HttpAdapterProvider> httpAdapterProviders = new ArrayList<>();
+    private List<HttpAdapterProvider> httpAdapterProviders = new ArrayList<>();
 
-	private ClientFormat format = ClientFormat.JSONAPI;
+    private ClientFormat format = ClientFormat.JSONAPI;
 
-	private ClientProxyFactory configuredProxyFactory;
+    private ClientProxyFactory configuredProxyFactory;
 
-	public enum ClientType {
-		SIMPLE_lINKS,
+    public enum ClientType {
+        SIMPLE_lINKS,
 
-		/**
-		 * @deprecated currently barely used, speak up if still necessary
-		 */
-		@Deprecated
-		OBJECT_LINKS
-	}
+        /**
+         * @deprecated currently barely used, speak up if still necessary
+         */
+        @Deprecated
+        OBJECT_LINKS
+    }
 
-	public CrnkClient(String serviceUrl) {
-		this(new ConstantServiceUrlProvider(UrlUtils.removeTrailingSlash(serviceUrl)), ClientType.SIMPLE_lINKS);
-	}
+    public CrnkClient(String serviceUrl) {
+        this(new ConstantServiceUrlProvider(UrlUtils.removeTrailingSlash(serviceUrl)), ClientType.SIMPLE_lINKS);
+    }
 
-	public CrnkClient(String serviceUrl, ClientType clientType) {
-		this(new ConstantServiceUrlProvider(UrlUtils.removeTrailingSlash(serviceUrl)), clientType);
-	}
+    public CrnkClient(String serviceUrl, ClientType clientType) {
+        this(new ConstantServiceUrlProvider(UrlUtils.removeTrailingSlash(serviceUrl)), clientType);
+    }
 
-	public CrnkClient(ServiceUrlProvider serviceUrlProvider, ClientType clientType) {
-		this.clientType = clientType;
-		if (ClassUtils.existsClass(REST_TEMPLATE_PROVIDER_NAME)) {
-			ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-			Class providerClass = ClassUtils.loadClass(classLoader, REST_TEMPLATE_PROVIDER_NAME);
-			HttpAdapterProvider provider = (HttpAdapterProvider) ClassUtils.newInstance(providerClass);
-			registerHttpAdapterProvider(provider);
-		}
-		this.registerHttpAdapterProvider(new OkHttpAdapterProvider());
-		this.registerHttpAdapterProvider(new HttpClientAdapterProvider());
+    public CrnkClient(ServiceUrlProvider serviceUrlProvider, ClientType clientType) {
+        this.clientType = clientType;
+        if (ClassUtils.existsClass(REST_TEMPLATE_PROVIDER_NAME)) {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            Class providerClass = ClassUtils.loadClass(classLoader, REST_TEMPLATE_PROVIDER_NAME);
+            HttpAdapterProvider provider = (HttpAdapterProvider) ClassUtils.newInstance(providerClass);
+            registerHttpAdapterProvider(provider);
+        }
+        this.registerHttpAdapterProvider(new OkHttpAdapterProvider());
+        this.registerHttpAdapterProvider(new HttpClientAdapterProvider());
 
-		moduleRegistry = new ModuleRegistry(false);
-		moduleRegistry.setUrlMapper(new DefaultQuerySpecUrlMapper());
-		moduleRegistry.getHttpRequestContextProvider().setServiceUrlProvider(serviceUrlProvider);
-		moduleRegistry.addModule(new ClientModule());
+        moduleRegistry = new ModuleRegistry(false);
+        moduleRegistry.setUrlMapper(new DefaultQuerySpecUrlMapper());
+        moduleRegistry.getHttpRequestContextProvider().setServiceUrlProvider(serviceUrlProvider);
+        moduleRegistry.addModule(new ClientModule());
 
+		moduleRegistry.setResultFactory(new SingletonResultFactory());
+        moduleRegistry.addModule(new ResourceInformationProviderModule());
 
-		moduleRegistry.addModule(new ResourceInformationProviderModule());
+        resourceRegistry = new ClientResourceRegistry(moduleRegistry);
+        queryContext.setBaseUrl(serviceUrlProvider.getUrl());
+        urlBuilder = new JsonApiUrlBuilder(moduleRegistry, queryContext);
 
-		resourceRegistry = new ClientResourceRegistry(moduleRegistry);
-		queryContext.setBaseUrl(serviceUrlProvider.getUrl());
-		urlBuilder = new JsonApiUrlBuilder(moduleRegistry, queryContext);
 
-		setProxyFactory(new BasicProxyFactory());
-	}
+        setProxyFactory(new BasicProxyFactory());
+    }
 
-	public ClientFormat getFormat() {
-		return format;
-	}
+    public int getVersion() {
+        return queryContext.getRequestVersion();
+    }
 
-	public ServiceDiscovery getServiceDiscovery() {
-		setupServiceDiscovery();
-		return serviceDiscovery;
-	}
+    /**
+     * @param version to sent along with ACCEPT header. For more information see {@link JsonApiVersion}.
+     */
+    public void setVersion(int version) {
+        this.queryContext.setRequestVersion(version);
+    }
+
+    public ClientFormat getFormat() {
+        return format;
+    }
 
-	private void setupServiceDiscovery() {
-		if (serviceDiscovery == null) {
-			// revert to reflection-based approach if no ServiceDiscovery is
-			// found
-			serviceDiscovery = serviceDiscoveryFactory.getInstance();
-			moduleRegistry.setServiceDiscovery(serviceDiscovery);
-		}
-	}
-
-	public void setServiceDiscovery(ServiceDiscovery serviceDiscovery) {
-		verifyNotInitialized();
-		PreconditionUtil.verify(this.serviceDiscovery == null, "service discovery already set");
-		this.serviceDiscovery = serviceDiscovery;
-		moduleRegistry.setServiceDiscovery(serviceDiscovery);
-	}
-
-	private void verifyNotInitialized() {
-		PreconditionUtil.verify(!initialized, "CrnkClient already initialized and can no longer be reconfigured");
-	}
-
-	public QueryContext getQueryContext() {
-		return queryContext;
-	}
-
-	private void setupPagingBehavior() {
-		if (moduleRegistry.getPagingBehaviors().isEmpty()) {
-			moduleRegistry.addAllPagingBehaviors(serviceDiscovery.getInstancesByType(PagingBehavior.class));
-		}
-
-		if (moduleRegistry.getPagingBehaviors().isEmpty()) {
-			moduleRegistry.addPagingBehavior(new OffsetLimitPagingBehavior());
-		}
-
-		for (PagingBehavior pagingBehavior : moduleRegistry.getPagingBehaviors()) {
-			if (pagingBehavior instanceof LimitBoundedPagingBehavior) {
-				if (defaultPageLimit != null) {
-					((LimitBoundedPagingBehavior) pagingBehavior).setDefaultLimit(defaultPageLimit);
-				}
-				if (maxPageLimit != null) {
-					((LimitBoundedPagingBehavior) pagingBehavior).setMaxPageLimit(maxPageLimit);
-				}
-			}
-		}
-	}
-
-	private void initJacksonModule(final boolean serializeLinksAsObjects) {
-		moduleRegistry.addModule(new JacksonModule(objectMapper, serializeLinksAsObjects));
-	}
-
-	/**
-	 * Finds and registers modules on the classpath trough the use of java.util.ServiceLoader.
-	 * Each module can register itself for lookup by registering a ClientModuleFactory.
-	 */
-	public void findModules() {
-		initObjectMapper();
-		ServiceLoader<ClientModuleFactory> loader = ServiceLoader.load(ClientModuleFactory.class);
-
-		Iterator<ClientModuleFactory> iterator = loader.iterator();
-		while (iterator.hasNext()) {
-			ClientModuleFactory factory = iterator.next();
-			Module module = factory.create();
-			addModule(module);
-		}
-
-		objectMapper.findAndRegisterModules();
-	}
-
-	public void setProxyFactory(ClientProxyFactory proxyFactory) {
-		proxyFactory.init(new ClientProxyFactoryContext() {
-
-			@Override
-			public ModuleRegistry getModuleRegistry() {
-				return moduleRegistry;
-			}
-
-			@Override
-			public <T> DefaultResourceList<T> getCollection(Class<T> resourceClass, String url) {
-				RegistryEntry entry = resourceRegistry.findEntry(resourceClass);
-				ResourceInformation resourceInformation = entry.getResourceInformation();
-				// TODO add decoration
-				final ResourceRepositoryStubImpl<T, ?> repositoryStub =
-						new ResourceRepositoryStubImpl<>(CrnkClient.this, resourceClass, resourceInformation, urlBuilder);
-				return repositoryStub.findAll(url);
-
-			}
-		});
-		this.configuredProxyFactory = proxyFactory;
-		if (documentMapper != null) {
-			documentMapper.setProxyFactory(proxyFactory);
-		}
-	}
-
-
-	public void registerHttpAdapterProvider(HttpAdapterProvider httpAdapterProvider) {
-		verifyNotInitialized();
-		httpAdapterProviders.add(httpAdapterProvider);
-	}
-
-	public List<HttpAdapterProvider> getHttpAdapterProviders() {
-		return httpAdapterProviders;
-	}
-
-	protected HttpAdapter detectHttpAdapter() {
-		for (HttpAdapterProvider httpAdapterProvider : httpAdapterProviders) {
-			if (httpAdapterProvider.isAvailable()) {
-				return httpAdapterProvider.newInstance();
-			}
-		}
-		throw new IllegalStateException(
-				"no httpAdapter can be initialized, add okhttp3 (com.squareup.okhttp3:okhttp) or apache http client (org.apache"
-						+ ".httpcomponents:httpclient) to the classpath");
-	}
-
-	protected void init() {
-		if (initialized) {
-			return;
-		}
-		initialized = true;
-
-		setupServiceDiscovery();
-		initHttpAdapter();
-
-		setupPagingBehavior();
-		initObjectMapper();
-		initModuleRegistry();
-		initExceptionMapperRegistry();
-		initResources();
-
-		Optional<Module> plainJsonModule = moduleRegistry.getModules().stream().filter(it -> it.getModuleName().equals("plain-json")).findFirst();
-		if (plainJsonModule.isPresent()) {
-			format = ClientFormat.PLAINJSON;
-		}
-	}
-
-	protected void initObjectMapper() {
-		if (objectMapper == null) {
-			objectMapper = createDefaultObjectMapper();
-			configureObjectMapper();
-		}
-	}
-
-	protected ObjectMapper createDefaultObjectMapper() {
-		ObjectMapper om = new ObjectMapper();
-		om.enable(SerializationFeature.INDENT_OUTPUT);
-		return om;
-	}
-
-	protected void configureObjectMapper() {
-		switch (clientType) {
-			case OBJECT_LINKS:
-				initJacksonModule(true);
-				documentMapper = new ClientDocumentMapper(moduleRegistry, objectMapper, key -> {
-					if (key.equals(CrnkProperties.SERIALIZE_LINKS_AS_OBJECTS)) {
-						return "true";
-					}
-					return null;
-				});
-				break;
-			default:
-				initJacksonModule(false);
-				documentMapper = new ClientDocumentMapper(moduleRegistry, objectMapper, new NullPropertiesProvider());
-		}
-		if (configuredProxyFactory != null) {
-			documentMapper.setProxyFactory(configuredProxyFactory);
-		}
-	}
-
-	protected void initHttpAdapter() {
-		if (httpAdapter == null) {
-			httpAdapter = detectHttpAdapter();
-		}
-	}
-
-	protected void initResources() {
-		ResourceLookup resourceLookup = moduleRegistry.getResourceLookup();
-		for (Class<?> resourceClass : resourceLookup.getResourceClasses()) {
-			getRepositoryForType(resourceClass);
-		}
-	}
-
-	protected void initModuleRegistry() {
-		moduleRegistry.init(objectMapper);
-	}
-
-	protected void initExceptionMapperRegistry() {
-		ExceptionMapperLookup exceptionMapperLookup = moduleRegistry.getExceptionMapperLookup();
-		exceptionMapperRegistry = new ExceptionMapperRegistryBuilder().build(exceptionMapperLookup);
-	}
-
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	protected <T, I> RegistryEntry allocateRepository(Class<T> resourceClass, RegistryEntry parentEntry) {
-		RegistryEntry entry = resourceRegistry.getEntry(resourceClass);
-		if (entry != null) {
-			return entry;
-		}
-
-		// allocate super types first
-		ResourceInformationProvider resourceInformationProvider = moduleRegistry.getResourceInformationBuilder();
-		Class<? super T> superclass = resourceClass.getSuperclass();
-		if (parentEntry == null && superclass != null && superclass != Object.class && resourceInformationProvider.accept(superclass)) {
-			parentEntry = allocateRepository(superclass, null);
-		}
-
-		entry = resourceRegistry.getEntry(resourceClass);
-		if (entry != null) {
-			return entry;
-		}
-
-		ResourceInformation resourceInformation = resourceInformationProvider.build(resourceClass);
-		DefaultRegistryEntryBuilder.contributeFields(moduleRegistry, resourceInformation);
-		ModuleUtils.adaptInformation(resourceInformation, moduleRegistry);
-
-		final ResourceRepository repositoryStub = (ResourceRepository) decorate(
-				new ResourceRepositoryStubImpl<T, I>(this, resourceClass, resourceInformation, urlBuilder)
-		);
-
-		// create interface for it!
-		ResourceRepositoryInformation repositoryInformation =
-				new ResourceRepositoryInformationImpl(resourceInformation.getResourceType(),
-						resourceInformation, new HashMap<>(), RepositoryMethodAccess.ALL, true);
-		ResourceRepositoryAdapter resourceRepositoryAdapter = new ResourceRepositoryAdapterImpl(repositoryInformation, moduleRegistry, repositoryStub);
-		Map<ResourceField, RelationshipRepositoryAdapter> relationshipRepositoryAdapters = new HashMap<>();
-		RegistryEntryImpl registryEntry = new RegistryEntryImpl(resourceInformation, resourceRepositoryAdapter,
-				relationshipRepositoryAdapters,
-				moduleRegistry);
-
-		registryEntry.setParentRegistryEntry(parentEntry);
-		resourceRegistry.addEntry(registryEntry);
-
-		allocateRepositoryRelations(registryEntry);
-
-		JsonApiResource annotation = resourceClass.getAnnotation(JsonApiResource.class);
-		if (annotation != null) {
-			for (Class subType : annotation.subTypes()) {
-				allocateRepository(subType, registryEntry);
-			}
-		}
+    public ServiceDiscovery getServiceDiscovery() {
+        setupServiceDiscovery();
+        return serviceDiscovery;
+    }
+
+    private void setupServiceDiscovery() {
+        if (serviceDiscovery == null) {
+            // revert to reflection-based approach if no ServiceDiscovery is
+            // found
+            serviceDiscovery = serviceDiscoveryFactory.getInstance();
+            moduleRegistry.setServiceDiscovery(serviceDiscovery);
+        }
+    }
+
+    public void setServiceDiscovery(ServiceDiscovery serviceDiscovery) {
+        verifyNotInitialized();
+        PreconditionUtil.verify(this.serviceDiscovery == null, "service discovery already set");
+        this.serviceDiscovery = serviceDiscovery;
+        moduleRegistry.setServiceDiscovery(serviceDiscovery);
+    }
+
+    private void verifyNotInitialized() {
+        PreconditionUtil.verify(!initialized, "CrnkClient already initialized and can no longer be reconfigured");
+    }
+
+    public QueryContext getQueryContext() {
+        return queryContext;
+    }
+
+    private void setupPagingBehavior() {
+        if (moduleRegistry.getPagingBehaviors().isEmpty()) {
+            moduleRegistry.addAllPagingBehaviors(serviceDiscovery.getInstancesByType(PagingBehavior.class));
+        }
+
+        if (moduleRegistry.getPagingBehaviors().isEmpty()) {
+            moduleRegistry.addPagingBehavior(new OffsetLimitPagingBehavior());
+        }
+
+        for (PagingBehavior pagingBehavior : moduleRegistry.getPagingBehaviors()) {
+            if (pagingBehavior instanceof LimitBoundedPagingBehavior) {
+                if (defaultPageLimit != null) {
+                    ((LimitBoundedPagingBehavior) pagingBehavior).setDefaultLimit(defaultPageLimit);
+                }
+                if (maxPageLimit != null) {
+                    ((LimitBoundedPagingBehavior) pagingBehavior).setMaxPageLimit(maxPageLimit);
+                }
+            }
+        }
+    }
+
+    private void initJacksonModule(final boolean serializeLinksAsObjects) {
+        moduleRegistry.addModule(new JacksonModule(objectMapper, serializeLinksAsObjects));
+    }
+
+    /**
+     * Finds and registers modules on the classpath trough the use of java.util.ServiceLoader.
+     * Each module can register itself for lookup by registering a ClientModuleFactory.
+     */
+    public void findModules() {
+        initObjectMapper();
+        ServiceLoader<ClientModuleFactory> loader = ServiceLoader.load(ClientModuleFactory.class);
+
+        Iterator<ClientModuleFactory> iterator = loader.iterator();
+        while (iterator.hasNext()) {
+            ClientModuleFactory factory = iterator.next();
+            Module module = factory.create();
+            addModule(module);
+        }
+
+        objectMapper.findAndRegisterModules();
+    }
+
+    public void setProxyFactory(ClientProxyFactory proxyFactory) {
+        proxyFactory.init(new ClientProxyFactoryContext() {
+
+            @Override
+            public ModuleRegistry getModuleRegistry() {
+                return moduleRegistry;
+            }
+
+            @Override
+            public <T> DefaultResourceList<T> getCollection(Class<T> resourceClass, String url) {
+                RegistryEntry entry = resourceRegistry.findEntry(resourceClass);
+                ResourceInformation resourceInformation = entry.getResourceInformation();
+                // TODO add decoration
+                final ResourceRepositoryStubImpl<T, ?> repositoryStub =
+                        new ResourceRepositoryStubImpl<>(CrnkClient.this, resourceClass, resourceInformation, urlBuilder);
+                return repositoryStub.findAll(url);
+
+            }
+        });
+        this.configuredProxyFactory = proxyFactory;
+        if (documentMapper != null) {
+            documentMapper.setProxyFactory(proxyFactory);
+        }
+    }
+
+
+    public void registerHttpAdapterProvider(HttpAdapterProvider httpAdapterProvider) {
+        verifyNotInitialized();
+        httpAdapterProviders.add(httpAdapterProvider);
+    }
+
+    public List<HttpAdapterProvider> getHttpAdapterProviders() {
+        return httpAdapterProviders;
+    }
+
+    protected HttpAdapter detectHttpAdapter() {
+        for (HttpAdapterProvider httpAdapterProvider : httpAdapterProviders) {
+            if (httpAdapterProvider.isAvailable()) {
+                return httpAdapterProvider.newInstance();
+            }
+        }
+        throw new IllegalStateException(
+                "no httpAdapter can be initialized, add okhttp3 (com.squareup.okhttp3:okhttp) or apache http client (org.apache"
+                        + ".httpcomponents:httpclient) to the classpath");
+    }
+
+    protected void init() {
+        if (initialized) {
+            return;
+        }
+        initialized = true;
+
+        setupServiceDiscovery();
+        initHttpAdapter();
+
+        setupPagingBehavior();
+        initObjectMapper();
+        configureObjectMapper();
+        initModuleRegistry();
+        initExceptionMapperRegistry();
+        initResources();
+
+		moduleRegistry.getHttpRequestContextProvider().onRequestStarted(new ClientHttpRequestContext(queryContext));
+
+        Optional<Module> plainJsonModule = moduleRegistry.getModules().stream().filter(it -> it.getModuleName().equals("plain-json")).findFirst();
+        if (plainJsonModule.isPresent()) {
+            format = ClientFormat.PLAINJSON;
+        }
+    }
+
+    protected void initObjectMapper() {
+        if (objectMapper == null) {
+            objectMapper = createDefaultObjectMapper();
+            configureObjectMapper();
+        }
+
+    }
+
+    protected ObjectMapper createDefaultObjectMapper() {
+        ObjectMapper om = new ObjectMapper();
+        om.enable(SerializationFeature.INDENT_OUTPUT);
+        return om;
+    }
+
+    protected void configureObjectMapper() {
+        initJacksonModule(clientType == ClientType.OBJECT_LINKS);
+    }
+
+    protected void initHttpAdapter() {
+        if (httpAdapter == null) {
+            httpAdapter = detectHttpAdapter();
+        }
+    }
+
+    protected void initResources() {
+        ResourceLookup resourceLookup = moduleRegistry.getResourceLookup();
+        for (Class<?> resourceClass : resourceLookup.getResourceClasses()) {
+            getRepositoryForType(resourceClass);
+        }
+    }
+
+    protected void initModuleRegistry() {
+        moduleRegistry.init(objectMapper);
+
+        switch (clientType) {
+            case OBJECT_LINKS:
+                documentMapper = new ClientDocumentMapper(moduleRegistry, objectMapper, key -> {
+                    if (key.equals(CrnkProperties.SERIALIZE_LINKS_AS_OBJECTS)) {
+                        return "true";
+                    }
+                    return null;
+                });
+                break;
+            default:
+                documentMapper = new ClientDocumentMapper(moduleRegistry, objectMapper, new NullPropertiesProvider());
+        }
+        if (configuredProxyFactory != null) {
+            documentMapper.setProxyFactory(configuredProxyFactory);
+        }
+    }
+
+    protected void initExceptionMapperRegistry() {
+        ExceptionMapperLookup exceptionMapperLookup = moduleRegistry.getExceptionMapperLookup();
+        exceptionMapperRegistry = new ExceptionMapperRegistryBuilder().build(exceptionMapperLookup);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    protected <T, I> RegistryEntry allocateRepository(Class<T> resourceClass, RegistryEntry parentEntry) {
+        RegistryEntry entry = resourceRegistry.getEntry(resourceClass);
+        if (entry != null) {
+            return entry;
+        }
+
+        // allocate super types first
+        ResourceInformationProvider resourceInformationProvider = moduleRegistry.getResourceInformationBuilder();
+        Class<? super T> superclass = resourceClass.getSuperclass();
+        if (parentEntry == null && superclass != null && superclass != Object.class && resourceInformationProvider.accept(superclass)) {
+            parentEntry = allocateRepository(superclass, null);
+        }
+
+        entry = resourceRegistry.getEntry(resourceClass);
+        if (entry != null) {
+            return entry;
+        }
+
+        ResourceInformation resourceInformation = resourceInformationProvider.build(resourceClass);
+        DefaultRegistryEntryBuilder.contributeFields(moduleRegistry, resourceInformation);
+        ModuleUtils.adaptInformation(resourceInformation, moduleRegistry);
+
+        final ResourceRepository repositoryStub = (ResourceRepository) decorate(
+                new ResourceRepositoryStubImpl<T, I>(this, resourceClass, resourceInformation, urlBuilder)
+        );
+
+        // create interface for it!
+        ResourceRepositoryInformation repositoryInformation =
+                new ResourceRepositoryInformationImpl(resourceInformation.getResourceType(),
+                        resourceInformation, new HashMap<>(), RepositoryMethodAccess.ALL, true);
+        ResourceRepositoryAdapter resourceRepositoryAdapter = new ResourceRepositoryAdapterImpl(repositoryInformation, moduleRegistry, repositoryStub);
+        Map<ResourceField, RelationshipRepositoryAdapter> relationshipRepositoryAdapters = new HashMap<>();
+        RegistryEntryImpl registryEntry = new RegistryEntryImpl(resourceInformation, resourceRepositoryAdapter,
+                relationshipRepositoryAdapters,
+                moduleRegistry);
+
+        registryEntry.setParentRegistryEntry(parentEntry);
+        resourceRegistry.addEntry(registryEntry);
+
+        allocateRepositoryRelations(registryEntry);
+
+        JsonApiResource annotation = resourceClass.getAnnotation(JsonApiResource.class);
+        if (annotation != null) {
+            for (Class subType : annotation.subTypes()) {
+                allocateRepository(subType, registryEntry);
+            }
+        }
 
 		moduleRegistry.initOpposites(true); // client only has partial knowledge o
-		if (resourceInformation.getIdField() != null) {
-			resourceInformation.initNesting();
-		}
+        if (resourceInformation.getIdField() != null) {
+            resourceInformation.initNesting();
+        }
 
-		return registryEntry;
-	}
+        return registryEntry;
+    }
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private void allocateRepositoryRelations(RegistryEntry registryEntry) {
-		ResourceInformation resourceInformation = registryEntry.getResourceInformation();
-		List<ResourceField> relationshipFields = resourceInformation.getRelationshipFields();
-		for (ResourceField relationshipField : relationshipFields) {
-			allocateRepositoryRelation(relationshipField);
-		}
-	}
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void allocateRepositoryRelations(RegistryEntry registryEntry) {
+        ResourceInformation resourceInformation = registryEntry.getResourceInformation();
+        List<ResourceField> relationshipFields = resourceInformation.getRelationshipFields();
+        for (ResourceField relationshipField : relationshipFields) {
+            allocateRepositoryRelation(relationshipField);
+        }
+    }
 
-	private RelationshipRepositoryAdapter allocateRepositoryRelation(Class sourceClass, Class targetClass) {
-		RegistryEntry sourceEntry = allocateRepository(sourceClass, null);
-		for (ResourceField field : sourceEntry.getResourceInformation().getRelationshipFields()) {
-			if (field.getElementType() == targetClass) {
-				return allocateRepositoryRelation(field);
-			}
-		}
-		throw new IllegalArgumentException("no relationship found between " + sourceClass + " " + targetClass);
-	}
-
-
-	private RelationshipRepositoryAdapter allocateRepositoryRelation(ResourceField field) {
-		// allocate relations as well
-		ClientResourceRegistry clientResourceRegistry = (ClientResourceRegistry) resourceRegistry;
-		Class<?> sourceClass = field.getResourceInformation().getImplementationClass();
-		Class<?> targetClass = field.getElementType();
-		if (!clientResourceRegistry.isInitialized(sourceClass)) {
-			allocateRepository(sourceClass, null);
-		}
-		if (!clientResourceRegistry.isInitialized(targetClass)) {
-			allocateRepository(targetClass, null);
-		}
-
-		RegistryEntryImpl sourceEntry = (RegistryEntryImpl) resourceRegistry.getEntry(sourceClass);
-		if (sourceEntry.hasRelationship(field)) {
-			return sourceEntry.getRelationshipRepository(field);
-		}
-
-		final Object relationshipRepositoryStub = decorate(
-				new RelationshipRepositoryStubImpl(this, sourceClass, targetClass, sourceEntry.getResourceInformation(), urlBuilder)
-		);
-
-		RelationshipRepositoryAdapter adapter = new RelationshipRepositoryAdapterImpl(field, moduleRegistry, relationshipRepositoryStub);
-		sourceEntry.putRelationshipRepository(field, adapter);
-		return adapter;
-	}
+    private RelationshipRepositoryAdapter allocateRepositoryRelation(Class sourceClass, Class targetClass) {
+        RegistryEntry sourceEntry = allocateRepository(sourceClass, null);
+        for (ResourceField field : sourceEntry.getResourceInformation().getRelationshipFields()) {
+            if (field.getElementType() == targetClass) {
+                return allocateRepositoryRelation(field);
+            }
+        }
+        throw new IllegalArgumentException("no relationship found between " + sourceClass + " " + targetClass);
+    }
 
 
-	@SuppressWarnings("unchecked")
-	public <R extends ResourceRepository<?, ?>> R getRepositoryForInterface(Class<R> repositoryInterfaceClass) {
-		init();
-		RepositoryInformationProvider informationBuilder = moduleRegistry.getRepositoryInformationBuilder();
-		PreconditionUtil.verify(informationBuilder.accept(repositoryInterfaceClass), "%s is not a valid repository interface", repositoryInterfaceClass);
-		ResourceRepositoryInformation repositoryInformation =
-				(ResourceRepositoryInformation) informationBuilder.build(repositoryInterfaceClass, new DefaultRepositoryInformationProviderContext(moduleRegistry));
-		Class<?> resourceClass = repositoryInformation.getResource().getResourceClass();
+    private RelationshipRepositoryAdapter allocateRepositoryRelation(ResourceField field) {
+        // allocate relations as well
+        ClientResourceRegistry clientResourceRegistry = (ClientResourceRegistry) resourceRegistry;
+        Class<?> sourceClass = field.getResourceInformation().getImplementationClass();
+        Class<?> targetClass = field.getElementType();
+        if (!clientResourceRegistry.isInitialized(sourceClass)) {
+            allocateRepository(sourceClass, null);
+        }
+        if (!clientResourceRegistry.isInitialized(targetClass)) {
+            allocateRepository(targetClass, null);
+        }
 
-		Object actionStub = actionStubFactory != null ? actionStubFactory.createStub(repositoryInterfaceClass) : null;
-		ResourceRepository<?, Serializable> repositoryStub = getRepositoryForType(resourceClass);
+        RegistryEntryImpl sourceEntry = (RegistryEntryImpl) resourceRegistry.getEntry(sourceClass);
+        if (sourceEntry.hasRelationship(field)) {
+            return sourceEntry.getRelationshipRepository(field);
+        }
 
-		ClassLoader classLoader = repositoryInterfaceClass.getClassLoader();
-		InvocationHandler invocationHandler =
-				new ClientStubInvocationHandler(repositoryInterfaceClass, repositoryStub, actionStub);
-		return (R) Proxy.newProxyInstance(classLoader, new Class[] { repositoryInterfaceClass, Wrapper.class, ResourceRepository.class },
-				invocationHandler);
-	}
+        final Object relationshipRepositoryStub = decorate(
+                new RelationshipRepositoryStubImpl(this, sourceClass, targetClass, sourceEntry.getResourceInformation(), urlBuilder)
+        );
 
-	/**
-	 * @param resourceClass repository class
-	 * @return stub for the given resourceClass
-	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public <T, I> ResourceRepository<T, I> getRepositoryForType(Class<T> resourceClass) {
-		init();
-
-		RegistryEntry entry = resourceRegistry.findEntry(resourceClass);
-		ResourceRepositoryAdapter repositoryAdapter = entry.getResourceRepository();
-		return (ResourceRepository<T, I>) repositoryAdapter.getImplementation();
-
-	}
-
-	/**
-	 * Generic access using {@link Resource} class without type mapping.
-	 */
-	public ResourceRepository<Resource, String> getRepositoryForPath(String resourceType) {
-		init();
-
-		ResourceInformation resourceInformation =
-				new ResourceInformation(
-						moduleRegistry.getTypeParser()
-						, Resource.class
-						, resourceType
-						, null
-						, null
-						, PagingSpec.class
-				);
-		return (ResourceRepository<Resource, String>) decorate(new ResourceRepositoryStubImpl<>(this, Resource.class, resourceInformation, urlBuilder));
-	}
-
-	/**
-	 * Generic access using {@link Resource} class without type mapping.
-	 */
-	public RelationshipRepository<Resource, String, Resource, String> getRepositoryForPath(String sourceResourceType,
-			String targetResourceType) {
-		init();
-
-		ResourceInformation sourceResourceInformation =
-				new ResourceInformation(moduleRegistry.getTypeParser(), Resource.class, sourceResourceType, null, null,
-						PagingSpec.class);
-		return (RelationshipRepository<Resource, String, Resource, String>) decorate(new RelationshipRepositoryStubImpl<>(this, Resource.class, Resource.class, sourceResourceInformation,
-				urlBuilder));
-	}
+        RelationshipRepositoryAdapter adapter = new RelationshipRepositoryAdapterImpl(field, moduleRegistry, relationshipRepositoryStub);
+        sourceEntry.putRelationshipRepository(field, adapter);
+        return adapter;
+    }
 
 
-	protected Object decorate(Object repository) {
-		DefaultRegistryEntryBuilder entryBuilder = new DefaultRegistryEntryBuilder(moduleRegistry);
-		return entryBuilder.decorateRepository(repository);
-	}
+    @SuppressWarnings("unchecked")
+    public <R extends ResourceRepository<?, ?>> R getRepositoryForInterface(Class<R> repositoryInterfaceClass) {
+        init();
+        RepositoryInformationProvider informationBuilder = moduleRegistry.getRepositoryInformationBuilder();
+        PreconditionUtil.verify(informationBuilder.accept(repositoryInterfaceClass), "%s is not a valid repository interface", repositoryInterfaceClass);
+        ResourceRepositoryInformation repositoryInformation =
+                (ResourceRepositoryInformation) informationBuilder.build(repositoryInterfaceClass, new DefaultRepositoryInformationProviderContext(moduleRegistry));
+        Class<?> resourceClass = repositoryInformation.getResource().getResourceClass();
+
+        Object actionStub = actionStubFactory != null ? actionStubFactory.createStub(repositoryInterfaceClass) : null;
+        ResourceRepository<?, Serializable> repositoryStub = getRepositoryForType(resourceClass);
+
+        ClassLoader classLoader = repositoryInterfaceClass.getClassLoader();
+        InvocationHandler invocationHandler =
+                new ClientStubInvocationHandler(repositoryInterfaceClass, repositoryStub, actionStub);
+        return (R) Proxy.newProxyInstance(classLoader, new Class[]{repositoryInterfaceClass, Wrapper.class, ResourceRepository.class},
+                invocationHandler);
+    }
+
+    /**
+     * @param resourceClass repository class
+     * @return stub for the given resourceClass
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public <T, I> ResourceRepository<T, I> getRepositoryForType(Class<T> resourceClass) {
+        init();
+
+        RegistryEntry entry = resourceRegistry.findEntry(resourceClass);
+        ResourceRepositoryAdapter repositoryAdapter = entry.getResourceRepository();
+        return (ResourceRepository<T, I>) repositoryAdapter.getImplementation();
+
+    }
+
+    /**
+     * Generic access using {@link Resource} class without type mapping.
+     */
+    public ResourceRepository<Resource, String> getRepositoryForPath(String resourceType) {
+        init();
+
+        ResourceInformation resourceInformation =
+                new ResourceInformation(
+                        moduleRegistry.getTypeParser()
+                        , Resource.class
+                        , resourceType
+                        , null
+                        , null
+                        , PagingSpec.class
+                );
+        return (ResourceRepository<Resource, String>) decorate(new ResourceRepositoryStubImpl<>(this, Resource.class, resourceInformation, urlBuilder));
+    }
+
+    /**
+     * Generic access using {@link Resource} class without type mapping.
+     */
+    public RelationshipRepository<Resource, String, Resource, String> getRepositoryForPath(String sourceResourceType,
+                                                                                           String targetResourceType) {
+        init();
+
+        ResourceInformation sourceResourceInformation =
+                new ResourceInformation(moduleRegistry.getTypeParser(), Resource.class, sourceResourceType, null, null,
+                        PagingSpec.class);
+        return (RelationshipRepository<Resource, String, Resource, String>) decorate(new RelationshipRepositoryStubImpl<>(this, Resource.class, Resource.class, sourceResourceInformation,
+                urlBuilder));
+    }
 
 
-	/**
-	 * @param sourceClass source class
-	 * @param targetClass target class
-	 * @return stub for the relationship between the given source and target
-	 * class
-	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public <T, I, D, J> RelationshipRepository<T, I, D, J> getRepositoryForType(
-			Class<T> sourceClass, Class<D> targetClass) {
-		init();
+    protected Object decorate(Object repository) {
+        DefaultRegistryEntryBuilder entryBuilder = new DefaultRegistryEntryBuilder(moduleRegistry);
+        return entryBuilder.decorateRepository(repository);
+    }
 
-		RelationshipRepositoryAdapter repositoryAdapter = allocateRepositoryRelation(sourceClass, targetClass);
-		return (RelationshipRepository<T, I, D, J>) repositoryAdapter.getImplementation();
-	}
 
-	/**
-	 * @param sourceClass source class
-	 * @param targetClass target class
-	 * @return stub for the relationship between the given source and target
-	 * class
-	 */
-	public <T, I, D, J> ManyRelationshipRepository<T, I, D, J> getManyRepositoryForType(
-			Class<T> sourceClass, Class<D> targetClass) {
-		init();
+    /**
+     * @param sourceClass source class
+     * @param targetClass target class
+     * @return stub for the relationship between the given source and target
+     * class
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public <T, I, D, J> RelationshipRepository<T, I, D, J> getRepositoryForType(
+            Class<T> sourceClass, Class<D> targetClass) {
+        init();
 
-		RelationshipRepositoryAdapter repositoryAdapter = allocateRepositoryRelation(sourceClass, targetClass);
-		return (ManyRelationshipRepository<T, I, D, J>) repositoryAdapter.getImplementation();
-	}
+        RelationshipRepositoryAdapter repositoryAdapter = allocateRepositoryRelation(sourceClass, targetClass);
+        return (RelationshipRepository<T, I, D, J>) repositoryAdapter.getImplementation();
+    }
 
-	/**
-	 * @param sourceClass source class
-	 * @param targetClass target class
-	 * @return stub for the relationship between the given source and target
-	 * class
-	 */
-	public <T, I, D, J> OneRelationshipRepository<T, I, D, J> getOneRepositoryForType(
-			Class<T> sourceClass, Class<D> targetClass) {
-		init();
+    /**
+     * @param sourceClass source class
+     * @param targetClass target class
+     * @return stub for the relationship between the given source and target
+     * class
+     */
+    public <T, I, D, J> ManyRelationshipRepository<T, I, D, J> getManyRepositoryForType(
+            Class<T> sourceClass, Class<D> targetClass) {
+        init();
 
-		RelationshipRepositoryAdapter repositoryAdapter = allocateRepositoryRelation(sourceClass, targetClass);
-		return (OneRelationshipRepository<T, I, D, J>) repositoryAdapter.getImplementation();
-	}
+        RelationshipRepositoryAdapter repositoryAdapter = allocateRepositoryRelation(sourceClass, targetClass);
+        return (ManyRelationshipRepository<T, I, D, J>) repositoryAdapter.getImplementation();
+    }
 
-	/**
-	 * @return objectMapper in use
-	 */
-	public ObjectMapper getObjectMapper() {
-		initObjectMapper();
-		return objectMapper;
-	}
+    /**
+     * @param sourceClass source class
+     * @param targetClass target class
+     * @return stub for the relationship between the given source and target
+     * class
+     */
+    public <T, I, D, J> OneRelationshipRepository<T, I, D, J> getOneRepositoryForType(
+            Class<T> sourceClass, Class<D> targetClass) {
+        init();
 
-	public void setObjectMapper(ObjectMapper objectMapper) {
-		PreconditionUtil.verify(this.objectMapper == null, "ObjectMapper already configured, consider calling SetObjectMapper earlier or and avoid multiple calls");
-		this.objectMapper = objectMapper;
-		this.configureObjectMapper();
-	}
+        RelationshipRepositoryAdapter repositoryAdapter = allocateRepositoryRelation(sourceClass, targetClass);
+        return (OneRelationshipRepository<T, I, D, J>) repositoryAdapter.getImplementation();
+    }
 
-	/**
-	 * @return resource registry use.
-	 */
-	public ResourceRegistry getRegistry() {
-		init();
-		return resourceRegistry;
-	}
+    /**
+     * @return objectMapper in use
+     */
+    public ObjectMapper getObjectMapper() {
+        initObjectMapper();
+        return objectMapper;
+    }
 
-	/**
-	 * Adds the given module.
-	 */
-	public void addModule(Module module) {
-		PreconditionUtil.verify(!initialized, "CrnkClient already initialized, cannot add further modules");
-		if (module instanceof HttpAdapterAware) {
-			((HttpAdapterAware) module).setHttpAdapter(getHttpAdapter());
-		}
-		this.moduleRegistry.addModule(module);
-	}
+    public void setObjectMapper(ObjectMapper objectMapper) {
+        PreconditionUtil.verify(this.objectMapper == null, "ObjectMapper already configured, consider calling SetObjectMapper earlier or and avoid multiple calls");
+        this.objectMapper = objectMapper;
+        this.configureObjectMapper();
+    }
 
-	public HttpAdapter getHttpAdapter() {
-		initHttpAdapter();
-		return httpAdapter;
-	}
+    /**
+     * @return resource registry use.
+     */
+    public ResourceRegistry getRegistry() {
+        init();
+        return resourceRegistry;
+    }
 
-	public void setHttpAdapter(HttpAdapter httpAdapter) {
-		this.httpAdapter = httpAdapter;
+    /**
+     * Adds the given module.
+     */
+    public void addModule(Module module) {
+        PreconditionUtil.verify(!initialized, "CrnkClient already initialized, cannot add further modules");
+        if (module instanceof HttpAdapterAware) {
+            ((HttpAdapterAware) module).setHttpAdapter(getHttpAdapter());
+        }
+        this.moduleRegistry.addModule(module);
+    }
 
-		List<Module> modules = moduleRegistry.getModules();
-		for (Module module : modules) {
-			if (module instanceof HttpAdapterAware) {
-				((HttpAdapterAware) module).setHttpAdapter(getHttpAdapter());
-			}
-		}
-	}
+    public HttpAdapter getHttpAdapter() {
+        initHttpAdapter();
+        return httpAdapter;
+    }
 
-	public ExceptionMapperRegistry getExceptionMapperRegistry() {
-		init();
-		return exceptionMapperRegistry;
-	}
+    public void setHttpAdapter(HttpAdapter httpAdapter) {
+        this.httpAdapter = httpAdapter;
 
-	public ActionStubFactory getActionStubFactory() {
-		return actionStubFactory;
-	}
+        List<Module> modules = moduleRegistry.getModules();
+        for (Module module : modules) {
+            if (module instanceof HttpAdapterAware) {
+                ((HttpAdapterAware) module).setHttpAdapter(getHttpAdapter());
+            }
+        }
+    }
 
-	/**
-	 * Sets the factory to use to create action stubs (like JAX-RS annotated
-	 * repository methods).
-	 *
-	 * @param actionStubFactory to use
-	 */
-	public void setActionStubFactory(ActionStubFactory actionStubFactory) {
-		this.actionStubFactory = actionStubFactory;
-		if (actionStubFactory != null) {
-			actionStubFactory.init(new ActionStubFactoryContext() {
+    public ExceptionMapperRegistry getExceptionMapperRegistry() {
+        init();
+        return exceptionMapperRegistry;
+    }
 
-				@Override
-				public ServiceUrlProvider getServiceUrlProvider() {
-					return moduleRegistry.getHttpRequestContextProvider().getServiceUrlProvider();
-				}
+    public ActionStubFactory getActionStubFactory() {
+        return actionStubFactory;
+    }
 
-				@Override
-				public HttpAdapter getHttpAdapter() {
-					return httpAdapter;
-				}
-			});
-		}
-	}
+    /**
+     * Sets the factory to use to create action stubs (like JAX-RS annotated
+     * repository methods).
+     *
+     * @param actionStubFactory to use
+     */
+    public void setActionStubFactory(ActionStubFactory actionStubFactory) {
+        this.actionStubFactory = actionStubFactory;
+        if (actionStubFactory != null) {
+            actionStubFactory.init(new ActionStubFactoryContext() {
 
-	public QuerySpecUrlMapper getUrlMapper() {
-		return moduleRegistry.getUrlMapper();
-	}
+                @Override
+                public ServiceUrlProvider getServiceUrlProvider() {
+                    return moduleRegistry.getHttpRequestContextProvider().getServiceUrlProvider();
+                }
 
-	public void setUrlMapper(QuerySpecUrlMapper urlMapper) {
-		moduleRegistry.setUrlMapper(urlMapper);
-	}
+                @Override
+                public HttpAdapter getHttpAdapter() {
+                    return httpAdapter;
+                }
+            });
+        }
+    }
 
-	public ModuleRegistry getModuleRegistry() {
-		return moduleRegistry;
-	}
+    public QuerySpecUrlMapper getUrlMapper() {
+        return moduleRegistry.getUrlMapper();
+    }
 
-	public ClientDocumentMapper getDocumentMapper() {
-		initObjectMapper();
-		return documentMapper;
-	}
+    public void setUrlMapper(QuerySpecUrlMapper urlMapper) {
+        moduleRegistry.setUrlMapper(urlMapper);
+    }
 
-	public ServiceUrlProvider getServiceUrlProvider() {
-		return moduleRegistry.getHttpRequestContextProvider().getServiceUrlProvider();
-	}
+    public ModuleRegistry getModuleRegistry() {
+        return moduleRegistry;
+    }
 
-	class ClientResourceRegistry extends ResourceRegistryImpl {
+    public ClientDocumentMapper getDocumentMapper() {
+        init();
+        return documentMapper;
+    }
 
-		public ClientResourceRegistry(ModuleRegistry moduleRegistry) {
-			super(new DefaultResourceRegistryPart(), moduleRegistry);
-		}
+    public ServiceUrlProvider getServiceUrlProvider() {
+        return moduleRegistry.getHttpRequestContextProvider().getServiceUrlProvider();
+    }
 
-		@Override
-		protected synchronized RegistryEntry findEntry(Class<?> clazz, boolean allowNull) {
-			RegistryEntry entry = getEntry(clazz);
-			if (entry == null) {
-				ResourceInformationProvider informationBuilder = moduleRegistry.getResourceInformationBuilder();
-				if (!informationBuilder.accept(clazz)) {
-					throw new InvalidResourceException(clazz.getName() + " not recognized as resource class, consider adding "
-							+ "@JsonApiResource annotation");
-				}
-				entry = allocateRepository(clazz, null);
-			}
-			return entry;
-		}
+    class ClientResourceRegistry extends ResourceRegistryImpl {
 
-		public boolean isInitialized(Class<?> clazz) {
-			return super.getEntry(clazz) != null;
-		}
-	}
+        public ClientResourceRegistry(ModuleRegistry moduleRegistry) {
+            super(new DefaultResourceRegistryPart(), moduleRegistry);
+        }
+
+        @Override
+        protected synchronized RegistryEntry findEntry(Class<?> clazz, boolean allowNull) {
+            RegistryEntry entry = getEntry(clazz);
+            if (entry == null) {
+                ResourceInformationProvider informationBuilder = moduleRegistry.getResourceInformationBuilder();
+                if (!informationBuilder.accept(clazz)) {
+                    throw new InvalidResourceException(clazz.getName() + " not recognized as resource class, consider adding "
+                            + "@JsonApiResource annotation");
+                }
+                entry = allocateRepository(clazz, null);
+            }
+            return entry;
+        }
+
+        public boolean isInitialized(Class<?> clazz) {
+            return super.getEntry(clazz) != null;
+        }
+    }
 }

--- a/crnk-client/src/main/java/io/crnk/client/internal/ClientDocumentMapper.java
+++ b/crnk-client/src/main/java/io/crnk/client/internal/ClientDocumentMapper.java
@@ -10,6 +10,7 @@ import io.crnk.client.internal.proxy.ObjectProxy;
 import io.crnk.core.engine.document.Document;
 import io.crnk.core.engine.document.Relationship;
 import io.crnk.core.engine.document.Resource;
+import io.crnk.core.engine.filter.ResourceFilterDirectory;
 import io.crnk.core.engine.information.resource.ResourceField;
 import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.dispatcher.controller.ControllerContext;
@@ -21,6 +22,7 @@ import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.engine.parser.TypeParser;
 import io.crnk.core.engine.properties.PropertiesProvider;
 import io.crnk.core.engine.query.QueryAdapter;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.engine.result.ImmediateResultFactory;
 import io.crnk.core.module.ModuleRegistry;
@@ -44,7 +46,8 @@ public class ClientDocumentMapper extends DocumentMapper {
 
 	public ClientDocumentMapper(ModuleRegistry moduleRegistry, ObjectMapper objectMapper, PropertiesProvider
 			propertiesProvider) {
-		super(moduleRegistry.getResourceRegistry(), objectMapper, propertiesProvider, null, new ImmediateResultFactory(), null, true);
+		super(moduleRegistry.getResourceRegistry(), objectMapper, propertiesProvider, moduleRegistry.getContext().getResourceFilterDirectory(),
+				new ImmediateResultFactory(), null, true);
 		this.moduleRegistry = moduleRegistry;
 		this.resourceRegistry = moduleRegistry.getResourceRegistry();
 		this.typeParser = moduleRegistry.getTypeParser();
@@ -53,7 +56,7 @@ public class ClientDocumentMapper extends DocumentMapper {
 
 	@Override
 	protected ResourceMapper newResourceMapper(final DocumentMapperUtil util, boolean client, ObjectMapper objectMapper) {
-		return new ResourceMapper(util, client, objectMapper, null) {
+		return new ResourceMapper(util, client, objectMapper, resourceFilterDirectory) {
 
 			@Override
 			protected void setRelationship(Resource resource, ResourceField field, Object entity,
@@ -123,7 +126,7 @@ public class ClientDocumentMapper extends DocumentMapper {
 		this.proxyFactory = proxyFactory;
 	}
 
-	public Object fromDocument(Document document, boolean getList) {
+	public Object fromDocument(Document document, boolean getList, QueryContext queryContext) {
 		ControllerContext controllerContext = new ControllerContext(moduleRegistry, () -> this);
 		ClientResourceUpsert upsert = new ClientResourceUpsert(proxyFactory);
 		upsert.init(controllerContext);
@@ -137,14 +140,14 @@ public class ClientDocumentMapper extends DocumentMapper {
 		List<Resource> included = document.getIncluded();
 		List<Resource> data = document.getCollectionData().get();
 
-		List<Object> dataObjects = upsert.allocateResources(data);
+		List<Object> dataObjects = upsert.allocateResources(data, queryContext);
 		if (included != null) {
-			upsert.allocateResources(included);
+			upsert.allocateResources(included, queryContext);
 		}
 
-		upsert.setRelations(data);
+		upsert.setRelations(data, queryContext);
 		if (included != null) {
-			upsert.setRelations(included);
+			upsert.setRelations(included, queryContext);
 		}
 
 		if (getList) {

--- a/crnk-client/src/main/java/io/crnk/client/internal/ClientHttpRequestContext.java
+++ b/crnk-client/src/main/java/io/crnk/client/internal/ClientHttpRequestContext.java
@@ -1,0 +1,104 @@
+package io.crnk.client.internal;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Set;
+
+import io.crnk.core.engine.http.HttpRequestContext;
+import io.crnk.core.engine.http.HttpResponse;
+import io.crnk.core.engine.query.QueryContext;
+
+public class ClientHttpRequestContext implements HttpRequestContext {
+
+	private QueryContext queryContext;
+
+	public ClientHttpRequestContext(QueryContext queryContext) {
+		this.queryContext = queryContext;
+	}
+
+	@Override
+	public boolean accepts(String contentType) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean acceptsAny() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public <T> T unwrap(Class<T> type) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object getRequestAttribute(String name) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setRequestAttribute(String name, Object value) {
+		throw new UnsupportedOperationException();
+
+	}
+
+	@Override
+	public QueryContext getQueryContext() {
+		return queryContext;
+	}
+
+	@Override
+	public boolean hasResponse() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Set<String> getRequestHeaderNames() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getRequestHeader(String name) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Map<String, Set<String>> getRequestParameters() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getPath() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getBaseUrl() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public byte[] getRequestBody() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getMethod() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public URI getRequestUri() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public HttpResponse getResponse() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setResponse(HttpResponse response) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/crnk-client/src/main/java/io/crnk/client/internal/ClientResourceUpsert.java
+++ b/crnk-client/src/main/java/io/crnk/client/internal/ClientResourceUpsert.java
@@ -19,168 +19,176 @@ import io.crnk.core.engine.document.Resource;
 import io.crnk.core.engine.document.ResourceIdentifier;
 import io.crnk.core.engine.http.HttpMethod;
 import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.information.resource.ResourceFieldType;
 import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.dispatcher.controller.ResourceUpsert;
 import io.crnk.core.engine.internal.dispatcher.path.JsonPath;
+import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.engine.internal.utils.SerializerUtil;
 import io.crnk.core.engine.query.QueryAdapter;
 import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.result.Result;
 import io.crnk.core.engine.result.ResultFactory;
+import io.crnk.core.queryspec.internal.QuerySpecAdapter;
 
 class ClientResourceUpsert extends ResourceUpsert {
 
-	private ClientProxyFactory proxyFactory;
+    private ClientProxyFactory proxyFactory;
 
-	private Map<String, Object> resourceMap = new HashMap<>();
+    private Map<String, Object> resourceMap = new HashMap<>();
 
-	public ClientResourceUpsert(ClientProxyFactory proxyFactory) {
-		this.proxyFactory = proxyFactory;
-	}
+    public ClientResourceUpsert(ClientProxyFactory proxyFactory) {
+        this.proxyFactory = proxyFactory;
+    }
 
-	public String getUID(ResourceIdentifier id) {
-		return id.getType() + "#" + id.getId();
-	}
+    public String getUID(ResourceIdentifier id) {
+        return id.getType() + "#" + id.getId();
+    }
 
-	public String getUID(RegistryEntry entry, Serializable id) {
-		ResourceInformation resourceInformation = entry.getResourceInformation();
-		String idString = resourceInformation.toIdString(id);
-		return resourceInformation.getResourceType() + "#" + idString;
-	}
+    public String getUID(RegistryEntry entry, Serializable id) {
+        ResourceInformation resourceInformation = entry.getResourceInformation();
+        String idString = resourceInformation.toIdString(id);
+        return resourceInformation.getResourceType() + "#" + idString;
+    }
 
-	public void setRelations(List<Resource> resources) {
-		for (Resource resource : resources) {
-			String uid = getUID(resource);
-			Object object = resourceMap.get(uid);
+    public void setRelations(List<Resource> resources, QueryContext queryContext) {
+        for (Resource resource : resources) {
+            String uid = getUID(resource);
+            Object object = resourceMap.get(uid);
 
-			RegistryEntry registryEntry = context.getResourceRegistry().getEntry(resource.getType());
+            RegistryEntry registryEntry = context.getResourceRegistry().getEntry(resource.getType());
 
-			// no need for any query parameters when doing POST/PATCH
-			QueryAdapter queryAdapter = null;
+            // no need for any query parameters when doing POST/PATCH
+            QueryAdapter queryAdapter = new QuerySpecAdapter(null, null, queryContext);
 
-			setRelationsAsync(object, registryEntry, resource, queryAdapter, true).get();
-		}
-	}
+            setRelationsAsync(object, registryEntry, resource, queryAdapter, true).get();
+        }
+    }
 
-	/**
-	 * Get relations from includes section or create a remote proxy
-	 */
-	@Override
-	protected Result<Object> fetchRelated(RegistryEntry entry, Serializable relationId, QueryAdapter queryAdapter) {
+    /**
+     * Get relations from includes section or create a remote proxy
+     */
+    @Override
+    protected Result<Object> fetchRelated(RegistryEntry entry, Serializable relationId, QueryAdapter queryAdapter) {
 
-		ResultFactory resultFactory = context.getResultFactory();
+        ResultFactory resultFactory = context.getResultFactory();
 
-		String uid = getUID(entry, relationId);
-		Object relatedResource = resourceMap.get(uid);
-		if (relatedResource != null) {
-			return resultFactory.just(relatedResource);
-		}
-		ResourceInformation resourceInformation = entry.getResourceInformation();
-		Class<?> resourceClass = resourceInformation.getResourceClass();
-		return resultFactory.just(proxyFactory.createResourceProxy(resourceClass, relationId));
-	}
+        String uid = getUID(entry, relationId);
+        Object relatedResource = resourceMap.get(uid);
+        if (relatedResource != null) {
+            return resultFactory.just(relatedResource);
+        }
+        ResourceInformation resourceInformation = entry.getResourceInformation();
+        Class<?> resourceClass = resourceInformation.getResourceClass();
+        return resultFactory.just(proxyFactory.createResourceProxy(resourceClass, relationId));
+    }
 
-	@Override
-	protected boolean decideSetRelationObjectField(RegistryEntry entry, Serializable relationId, ResourceField field) {
-		return !field.hasIdField() || resourceMap.containsKey(getUID(entry, relationId));
-	}
+    @Override
+    protected boolean decideSetRelationObjectField(RegistryEntry entry, Serializable relationId, ResourceField field) {
+        return !field.hasIdField() || resourceMap.containsKey(getUID(entry, relationId));
+    }
 
-	@Override
-	protected boolean decideSetRelationObjectsField(ResourceField relationshipField) {
+    @Override
+    protected boolean decideSetRelationObjectsField(ResourceField relationshipField) {
+        return true;
+    }
+
+    public List<Object> allocateResources(List<Resource> resources, QueryContext queryContext) {
+        List<Object> objects = new ArrayList<>();
+        for (Resource resource : resources) {
+
+            RegistryEntry registryEntry = getRegistryEntry(resource.getType());
+            ResourceInformation resourceInformation = registryEntry.getResourceInformation();
+
+            Object object = newEntity(resourceInformation, resource);
+            setId(resource, object, resourceInformation);
+            setType(resource, object);
+            setAttributes(resource, object, resourceInformation, queryContext);
+            setLinks(resource, object, resourceInformation);
+            setMeta(resource, object, resourceInformation);
+
+            objects.add(object);
+
+            String uid = getUID(resource);
+            resourceMap.put(uid, object);
+        }
+        return objects;
+    }
+
+    @Override
+    public boolean isAcceptable(JsonPath jsonPath, String method) {
+        // no in use on client side, consider refactoring ResourceUpsert to
+        // separate from controllers
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Result<Response> handleAsync(JsonPath jsonPath, QueryAdapter queryAdapter, Document requestDocument) {
+        // no in use on client side, consider refactoring ResourceUpsert to
+        // separate from controllers
+        throw new UnsupportedOperationException();
+
+    }
+
+    @Override
+    protected RuntimeException newBodyException(String message, IOException e) {
+        throw new ResponseBodyException(message, e);
+    }
+
+    @Override
+    protected Optional<Result> setRelationsFieldAsync(Object newResource, RegistryEntry registryEntry,
+                                                      Map.Entry<String, Relationship> property, QueryAdapter queryAdapter) {
+
+        Relationship relationship = property.getValue();
+
+        if (!relationship.getData().isPresent()) {
+            ObjectNode links = relationship.getLinks();
+            ObjectNode meta = relationship.getMeta();
+            if (links != null) {
+                // create proxy to lazy load relations
+                String fieldJsonName = property.getKey();
+                ResourceInformation resourceInformation = registryEntry.getResourceInformation();
+                QueryContext queryContext = queryAdapter.getQueryContext();
+                ResourceField field = resourceInformation.findFieldByJsonName(fieldJsonName, queryContext.getRequestVersion());
+                PreconditionUtil.verifyEquals(ResourceFieldType.RELATIONSHIP, field.getResourceFieldType(), "expected {} to be a relationship", fieldJsonName);
+                Class elementType = field.getElementType();
+                Class collectionClass = field.getType();
+
+                JsonNode relatedNode = links.get("related");
+                if (relatedNode != null) {
+                    String url = null;
+                    if (relatedNode.has(SerializerUtil.HREF)) {
+                        JsonNode hrefNode = relatedNode.get(SerializerUtil.HREF);
+                        if (hrefNode != null) {
+                            url = hrefNode.asText().trim();
+                        }
+                    } else {
+                        url = relatedNode.asText().trim();
+                    }
+                    Object proxy = proxyFactory.createCollectionProxy(elementType, collectionClass, url, links, meta);
+                    field.getAccessor().setValue(newResource, proxy);
+                }
+            }
+            return Optional.empty();
+        } else {
+            // set elements
+            return super.setRelationsFieldAsync(newResource, registryEntry, property, queryAdapter);
+        }
+    }
+
+    @Override
+    protected boolean checkAccess() {
+        return false;
+    }
+
+    @Override
+    protected HttpMethod getHttpMethod() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+	protected boolean isClient() {
 		return true;
-	}
-
-	public List<Object> allocateResources(List<Resource> resources) {
-		List<Object> objects = new ArrayList<>();
-		for (Resource resource : resources) {
-
-			RegistryEntry registryEntry = getRegistryEntry(resource.getType());
-			ResourceInformation resourceInformation = registryEntry.getResourceInformation();
-
-			Object object = newEntity(resourceInformation, resource);
-			setId(resource, object, resourceInformation);
-			setType(resource, object);
-			setAttributes(resource, object, resourceInformation, new QueryContext());
-			setLinks(resource, object, resourceInformation);
-			setMeta(resource, object, resourceInformation);
-
-			objects.add(object);
-
-			String uid = getUID(resource);
-			resourceMap.put(uid, object);
-		}
-		return objects;
-	}
-
-	@Override
-	public boolean isAcceptable(JsonPath jsonPath, String method) {
-		// no in use on client side, consider refactoring ResourceUpsert to
-		// separate from controllers
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Result<Response> handleAsync(JsonPath jsonPath, QueryAdapter queryAdapter, Document requestDocument) {
-		// no in use on client side, consider refactoring ResourceUpsert to
-		// separate from controllers
-		throw new UnsupportedOperationException();
-
-	}
-
-	@Override
-	protected RuntimeException newBodyException(String message, IOException e) {
-		throw new ResponseBodyException(message, e);
-	}
-
-	@Override
-	protected Optional<Result> setRelationsFieldAsync(Object newResource, RegistryEntry registryEntry,
-			Map.Entry<String, Relationship> property, QueryAdapter queryAdapter) {
-
-		Relationship relationship = property.getValue();
-
-		if (!relationship.getData().isPresent()) {
-			ObjectNode links = relationship.getLinks();
-			ObjectNode meta = relationship.getMeta();
-			if (links != null) {
-				// create proxy to lazy load relations
-				String fieldName = property.getKey();
-				ResourceInformation resourceInformation = registryEntry.getResourceInformation();
-				ResourceField field = resourceInformation.findRelationshipFieldByName(fieldName);
-				Class elementType = field.getElementType();
-				Class collectionClass = field.getType();
-
-				JsonNode relatedNode = links.get("related");
-				if (relatedNode != null) {
-					String url = null;
-					if (relatedNode.has(SerializerUtil.HREF)) {
-						JsonNode hrefNode = relatedNode.get(SerializerUtil.HREF);
-						if (hrefNode != null) {
-							url = hrefNode.asText().trim();
-						}
-					}
-					else {
-						url = relatedNode.asText().trim();
-					}
-					Object proxy = proxyFactory.createCollectionProxy(elementType, collectionClass, url, links, meta);
-					field.getAccessor().setValue(newResource, proxy);
-				}
-			}
-			return Optional.empty();
-		}
-		else {
-			// set elements
-			return super.setRelationsFieldAsync(newResource, registryEntry, property, queryAdapter);
-		}
-	}
-
-	@Override
-	protected boolean checkAccess() {
-		return false;
-	}
-
-	@Override
-	protected HttpMethod getHttpMethod() {
-		throw new UnsupportedOperationException();
 	}
 }

--- a/crnk-client/src/main/java/io/crnk/client/internal/ClientStubBase.java
+++ b/crnk-client/src/main/java/io/crnk/client/internal/ClientStubBase.java
@@ -9,8 +9,6 @@ import io.crnk.client.TransportException;
 import io.crnk.client.http.HttpAdapter;
 import io.crnk.client.http.HttpAdapterRequest;
 import io.crnk.client.http.HttpAdapterResponse;
-import io.crnk.core.resource.meta.JsonLinksInformation;
-import io.crnk.core.resource.meta.JsonMetaInformation;
 import io.crnk.core.engine.document.Document;
 import io.crnk.core.engine.document.Resource;
 import io.crnk.core.engine.error.ErrorResponse;
@@ -19,7 +17,11 @@ import io.crnk.core.engine.http.HttpHeaders;
 import io.crnk.core.engine.http.HttpMethod;
 import io.crnk.core.engine.internal.exception.ExceptionMapperRegistry;
 import io.crnk.core.engine.internal.utils.JsonApiUrlBuilder;
+import io.crnk.core.engine.internal.utils.PreconditionUtil;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.resource.list.DefaultResourceList;
+import io.crnk.core.resource.meta.JsonLinksInformation;
+import io.crnk.core.resource.meta.JsonMetaInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +69,13 @@ public class ClientStubBase {
             if (method == HttpMethod.POST || method == HttpMethod.PATCH) {
                 request.header("Content-Type", format.getContentType());
             }
-            request.header("Accept", format.getAcceptType());
+            String accept = format.getAcceptType();
+            int version = client.getVersion();
+            PreconditionUtil.verify(version >= 0, "version not specified");
+            if (version != Integer.MAX_VALUE) {
+                accept += "; " + HttpHeaders.VERSION_ACCEPT_PARAMETER + "=" + version;
+            }
+            request.header("Accept", accept);
 
             HttpAdapterResponse response = request.execute();
 
@@ -90,7 +98,8 @@ public class ClientStubBase {
                     Document document = objectMapper.readValue(body, format.getDocumentClass());
 
                     ClientDocumentMapper documentMapper = client.getDocumentMapper();
-                    return documentMapper.fromDocument(document, responseType == ResponseType.RESOURCES);
+                    QueryContext queryContext = client.getQueryContext();
+                    return documentMapper.fromDocument(document, responseType == ResponseType.RESOURCES, queryContext);
                 }
             }
             return null;

--- a/crnk-client/src/main/java/io/crnk/client/internal/SingletonResultFactory.java
+++ b/crnk-client/src/main/java/io/crnk/client/internal/SingletonResultFactory.java
@@ -1,0 +1,35 @@
+package io.crnk.client.internal;
+
+import io.crnk.core.engine.result.ImmediateResult;
+import io.crnk.core.engine.result.ImmediateResultFactory;
+import io.crnk.core.engine.result.Result;
+
+public class SingletonResultFactory extends ImmediateResultFactory {
+
+	private Object context;
+
+	@Override
+	public Object getThreadContext() {
+		return context;
+	}
+
+	@Override
+	public Result<Object> getContext() {
+		return new ImmediateResult(context);
+	}
+
+	@Override
+	public void setThreadContext(Object context) {
+		this.context = context;
+	}
+
+	@Override
+	public void clearContext() {
+		this.context = null;
+	}
+
+	@Override
+	public boolean hasThreadContext() {
+		return context != null;
+	}
+}

--- a/crnk-client/src/test/java/io/crnk/client/AbstractClientTest.java
+++ b/crnk-client/src/test/java/io/crnk/client/AbstractClientTest.java
@@ -82,7 +82,7 @@ public abstract class AbstractClientTest extends JerseyTestBase {
 		List<String> values = headers.get(name);
 		Assert.assertNotNull(values);
 
-		Assert.assertTrue(values.contains(value));
+		Assert.assertTrue(values.toString(), values.contains(value));
 	}
 
 	/**

--- a/crnk-client/src/test/java/io/crnk/client/QuerySpecAllowUnknownAttributeClientTest.java
+++ b/crnk-client/src/test/java/io/crnk/client/QuerySpecAllowUnknownAttributeClientTest.java
@@ -1,6 +1,7 @@
 package io.crnk.client;
 
 import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.queryspec.Direction;
 import io.crnk.core.queryspec.FilterOperator;
 import io.crnk.core.queryspec.FilterSpec;
@@ -67,7 +68,7 @@ public class QuerySpecAllowUnknownAttributeClientTest extends AbstractClientTest
         parameterMap.put("sort", Collections.singleton("-unknownAttr"));
         ResourceInformation taskInformation = client.getRegistry().getEntry(Task.class).getResourceInformation();
         QuerySpecUrlMapper urlMapper = client.getUrlMapper();
-        QuerySpec querySpec = urlMapper.deserialize(taskInformation, parameterMap);
+        QuerySpec querySpec = urlMapper.deserialize(taskInformation, parameterMap, new QueryContext());
         Assert.assertEquals(1, querySpec.getFilters().size());
         FilterSpec filterSpec = querySpec.getFilters().get(0);
         Assert.assertEquals("unknownAttr", filterSpec.getAttributePath().get(0));

--- a/crnk-client/src/test/java/io/crnk/client/QuerySpecUnknownAttributeClientTest.java
+++ b/crnk-client/src/test/java/io/crnk/client/QuerySpecUnknownAttributeClientTest.java
@@ -2,6 +2,7 @@ package io.crnk.client;
 
 import io.crnk.core.boot.CrnkBoot;
 import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.queryspec.Direction;
 import io.crnk.core.queryspec.FilterOperator;
 import io.crnk.core.queryspec.FilterSpec;
@@ -68,7 +69,7 @@ public class QuerySpecUnknownAttributeClientTest extends AbstractClientTest {
         parameterMap.put("filter[unknownAttr]", Collections.singleton("test"));
         parameterMap.put("sort", Collections.singleton("-unknownAttr"));
         ResourceInformation taskInformation = client.getRegistry().getEntry(Task.class).getResourceInformation();
-        QuerySpec querySpec = boot.getUrlMapper().deserialize(taskInformation, parameterMap);
+        QuerySpec querySpec = boot.getUrlMapper().deserialize(taskInformation, parameterMap, new QueryContext());
         Assert.assertEquals(1, querySpec.getFilters().size());
         FilterSpec filterSpec = querySpec.getFilters().get(0);
         Assert.assertEquals("unknownAttr", filterSpec.getAttributePath().get(0));

--- a/crnk-client/src/test/java/io/crnk/client/VersionedClientTest.java
+++ b/crnk-client/src/test/java/io/crnk/client/VersionedClientTest.java
@@ -1,0 +1,178 @@
+package io.crnk.client;
+
+import java.io.IOException;
+
+import io.crnk.client.http.HttpAdapter;
+import io.crnk.client.http.HttpAdapterRequest;
+import io.crnk.client.http.HttpAdapterResponse;
+import io.crnk.core.boot.CrnkBoot;
+import io.crnk.core.engine.http.HttpHeaders;
+import io.crnk.core.engine.http.HttpMethod;
+import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.version.VersionModule;
+import io.crnk.core.exception.ForbiddenException;
+import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.repository.ResourceRepository;
+import io.crnk.test.mock.models.VersionedTask;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class VersionedClientTest extends AbstractClientTest {
+
+	private ResourceRepository<VersionedTask, Long> taskRepo;
+
+	private CrnkBoot boot;
+
+	@Before
+	public void setup() {
+		super.setup();
+
+		client.addModule(new VersionModule());
+
+		taskRepo = client.getRepositoryForType(VersionedTask.class);
+	}
+
+	@Test
+	public void versionsAvailableFromInformationModel() {
+		ResourceInformation resourceInformation = boot.getResourceRegistry().getEntry(VersionedTask.class).getResourceInformation();
+		Assert.assertEquals(0, resourceInformation.getVersionRange().getMin());
+		Assert.assertEquals(5, resourceInformation.getVersionRange().getMax());
+
+		ResourceField field = resourceInformation.findFieldByUnderlyingName("completed");
+		Assert.assertEquals(1, field.getVersionRange().getMin());
+		Assert.assertEquals(3, field.getVersionRange().getMax());
+		Assert.assertSame(field, resourceInformation.findFieldByJsonName("completed", 1));
+		Assert.assertSame(field, resourceInformation.findFieldByJsonName("completed", 2));
+		Assert.assertSame(field, resourceInformation.findFieldByJsonName("completed", 3));
+
+		ResourceField newField = resourceInformation.findFieldByUnderlyingName("newCompleted");
+		Assert.assertEquals(5, newField.getVersionRange().getMin());
+		Assert.assertEquals(Integer.MAX_VALUE, newField.getVersionRange().getMax());
+		Assert.assertSame(newField, resourceInformation.findFieldByJsonName("completed", 5));
+		Assert.assertSame(newField, resourceInformation.findFieldByJsonName("completed", 6));
+		Assert.assertSame(newField, resourceInformation.findFieldByJsonName("completed", 7));
+	}
+
+	@Test
+	public void noVersionInAcceptHeaderByDefaultToGetLatest() {
+		VersionedTask task = new VersionedTask();
+		task.setId(1L);
+		task.setCompleted(true);
+		task.setName("someTask");
+		taskRepo.create(task);
+
+		assertHasHeaderValue(HttpHeaders.HTTP_HEADER_ACCEPT, HttpHeaders.JSONAPI_CONTENT_TYPE);
+	}
+
+	@Test
+	public void versionInAcceptHeaderIfConfigured() {
+		client.setVersion(3);
+
+		VersionedTask task = new VersionedTask();
+		task.setId(1L);
+		task.setCompleted(true);
+		task.setName("someTask");
+		taskRepo.create(task);
+
+		assertHasHeaderValue(HttpHeaders.HTTP_HEADER_ACCEPT, HttpHeaders.JSONAPI_CONTENT_TYPE + "; version=3");
+	}
+
+	@Test
+	public void fieldNotRequestedIfOutOfRange() {
+		client.setVersion(1);
+		VersionedTask task = new VersionedTask();
+		task.setId(1L);
+		task.setCompleted(true);
+		task.setName("someTask");
+		task = taskRepo.create(task);
+		Assert.assertTrue(task.isCompleted());
+
+		// check within range
+		client.setVersion(3);
+		task = taskRepo.findOne(task.getId(), new QuerySpec(VersionedTask.class));
+		Assert.assertTrue(task.isCompleted());
+
+		// check outside range
+		client.setVersion(4); // completed only 1 to 3
+		task = taskRepo.findOne(task.getId(), new QuerySpec(VersionedTask.class));
+		Assert.assertFalse(task.isCompleted());
+	}
+
+	@Test
+	public void fieldNotPostedOutOfRange() {
+		client.setVersion(4); // leave range
+		VersionedTask task = new VersionedTask();
+		task.setId(1L);
+		task.setCompleted(true);
+		task.setName("someTask");
+		task = taskRepo.create(task);
+		Assert.assertFalse(task.isCompleted());
+
+		client.setVersion(3);
+		task = taskRepo.findOne(task.getId(), new QuerySpec(VersionedTask.class));
+		Assert.assertFalse(task.isCompleted());
+	}
+
+	@Test
+	public void postNewVersionOfField() {
+		client.setVersion(5); // range of new version
+		VersionedTask task = new VersionedTask();
+		task.setId(1L);
+		task.setCompleted(true);
+		task.setNewCompleted(VersionedTask.CompletionStatus.IN_PROGRESS);
+		task.setName("someTask");
+		task = taskRepo.create(task);
+		Assert.assertFalse(task.isCompleted());
+		Assert.assertEquals(VersionedTask.CompletionStatus.IN_PROGRESS, task.getNewCompleted());
+
+		task = taskRepo.findOne(task.getId(), new QuerySpec(VersionedTask.class));
+		Assert.assertFalse(task.isCompleted());
+		Assert.assertEquals(VersionedTask.CompletionStatus.IN_PROGRESS, task.getNewCompleted());
+
+		// move out of new version range
+		client.setVersion(3);
+		task = taskRepo.findOne(task.getId(), new QuerySpec(VersionedTask.class));
+		Assert.assertFalse(task.isCompleted());
+		Assert.assertNull(task.getNewCompleted());
+	}
+
+	@Test
+	public void checkVersionAsParameter() throws IOException {
+		String url = client.getServiceUrlProvider().getUrl() + "/versionedTask?version=3";
+		HttpAdapter httpAdapter = client.getHttpAdapter();
+		HttpAdapterRequest request = httpAdapter.newRequest(url, HttpMethod.GET, null);
+		HttpAdapterResponse response = request.execute();
+		Assert.assertEquals(200, response.code());
+	}
+
+
+	@Test
+	public void checkVersionAsParameterOutOfRange() throws IOException {
+		String url = client.getServiceUrlProvider().getUrl() + "/versionedTask?version=6";
+		HttpAdapter httpAdapter = client.getHttpAdapter();
+		HttpAdapterRequest request = httpAdapter.newRequest(url, HttpMethod.GET, null);
+		HttpAdapterResponse response = request.execute();
+		Assert.assertEquals(403, response.code());
+	}
+
+
+	@Test(expected = ForbiddenException.class)
+	public void resourceNotAvailableOutOfRange() {
+		client.setVersion(6); // leave range of entire resource
+		VersionedTask task = new VersionedTask();
+		task.setId(1L);
+		taskRepo.create(task);
+	}
+
+	@Test
+	public void registryHoldsProperLatestVersion() {
+		Assert.assertEquals(5, boot.getResourceRegistry().getLatestVersion());
+	}
+
+	protected void setupFeature(CrnkTestFeature feature) {
+		feature.addModule(new VersionModule());
+		boot = feature.getBoot();
+	}
+}

--- a/crnk-client/src/test/java/io/crnk/client/action/JsonApiActionResponseTest.java
+++ b/crnk-client/src/test/java/io/crnk/client/action/JsonApiActionResponseTest.java
@@ -24,8 +24,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
-import javax.swing.*;
-
 public class JsonApiActionResponseTest extends AbstractClientTest {
 
     protected ScheduleRepository scheduleRepository;

--- a/crnk-client/src/test/java/io/crnk/client/internal/ClientDocumentMapperTest.java
+++ b/crnk-client/src/test/java/io/crnk/client/internal/ClientDocumentMapperTest.java
@@ -4,52 +4,56 @@ import io.crnk.core.boot.CrnkBoot;
 import io.crnk.core.engine.document.Document;
 import io.crnk.core.engine.document.ErrorDataBuilder;
 import io.crnk.core.engine.properties.NullPropertiesProvider;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.utils.Nullable;
 import io.crnk.test.mock.TestModule;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Arrays;
 
 public class ClientDocumentMapperTest {
 
 
-	private CrnkBoot boot;
+    private CrnkBoot boot;
 
-	private ClientDocumentMapper documentMapper;
+    private ClientDocumentMapper documentMapper;
 
-	@Before
-	public void setup() {
-		boot = new CrnkBoot();
-		boot.addModule(new TestModule());
-		boot.boot();
+    private QueryContext queryContext = new QueryContext();
 
-		NullPropertiesProvider properties = new NullPropertiesProvider();
-		documentMapper = new ClientDocumentMapper(boot.getModuleRegistry(), boot.getObjectMapper(), properties);
-	}
+    @Before
+    public void setup() {
+        queryContext.setRequestVersion(0);
+
+        boot = new CrnkBoot();
+        boot.addModule(new TestModule());
+        boot.boot();
+
+        NullPropertiesProvider properties = new NullPropertiesProvider();
+        documentMapper = new ClientDocumentMapper(boot.getModuleRegistry(), boot.getObjectMapper(), properties);
+    }
 
 
-	@Test
-	public void testNullData() {
-		Document doc = new Document();
-		doc.setData(Nullable.nullValue());
-		Assert.assertNull(documentMapper.fromDocument(doc, false));
-	}
+    @Test
+    public void testNullData() {
+        Document doc = new Document();
+        doc.setData(Nullable.nullValue());
+        Assert.assertNull(documentMapper.fromDocument(doc, false, queryContext));
+    }
 
-	@Test
-	public void testNoData() {
-		Document doc = new Document();
-		doc.setData(Nullable.empty());
-		Assert.assertNull(documentMapper.fromDocument(doc, false));
-	}
+    @Test
+    public void testNoData() {
+        Document doc = new Document();
+        doc.setData(Nullable.empty());
+        Assert.assertNull(documentMapper.fromDocument(doc, false, queryContext));
+    }
 
-	@Test(expected = IllegalStateException.class)
-	public void testCannotHaveErrors() {
-		Document doc = new Document();
-		doc.setErrors(Arrays.asList(new ErrorDataBuilder().build()));
-		doc.setData(Nullable.nullValue());
-		documentMapper.fromDocument(doc, false);
-	}
+    @Test(expected = IllegalStateException.class)
+    public void testCannotHaveErrors() {
+        Document doc = new Document();
+        doc.setErrors(Arrays.asList(new ErrorDataBuilder().build()));
+        doc.setData(Nullable.nullValue());
+        documentMapper.fromDocument(doc, false, queryContext);
+    }
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/http/HttpHeaders.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/http/HttpHeaders.java
@@ -22,4 +22,6 @@ public class HttpHeaders {
 	public static final String JSONAPI_CONTENT_TYPE_AND_CHARSET = JSONAPI_CONTENT_TYPE + "; charset=" +
 			DEFAULT_CHARSET;
 
+	public static final String VERSION_ACCEPT_PARAMETER = "version";
+
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/http/HttpRequestContextProvider.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/http/HttpRequestContextProvider.java
@@ -1,11 +1,16 @@
 package io.crnk.core.engine.http;
 
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.result.Result;
 import io.crnk.core.engine.result.ResultFactory;
 import io.crnk.core.engine.url.ServiceUrlProvider;
+import io.crnk.core.module.ModuleRegistry;
 import io.crnk.core.utils.Supplier;
 
 public class HttpRequestContextProvider {
+
+
+	private final ModuleRegistry moduleRegistry;
 
 	private Supplier<ResultFactory> resultFactory;
 
@@ -20,8 +25,9 @@ public class HttpRequestContextProvider {
 		}
 	};
 
-	public HttpRequestContextProvider(Supplier<ResultFactory> resultFactory) {
+	public HttpRequestContextProvider(Supplier<ResultFactory> resultFactory, ModuleRegistry moduleRegistry) {
 		this.resultFactory = resultFactory;
+		this.moduleRegistry = moduleRegistry;
 	}
 
 	/**
@@ -42,7 +48,11 @@ public class HttpRequestContextProvider {
 
 	public void onRequestStarted(HttpRequestContext request) {
 		resultFactory.get().setThreadContext(request);
+
+		QueryContext queryContext = request.getQueryContext();
+		queryContext.initializeDefaults(moduleRegistry.getResourceRegistry());
 	}
+
 
 
 	public boolean hasThreadRequestContext() {

--- a/crnk-core/src/main/java/io/crnk/core/engine/information/InformationBuilder.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/information/InformationBuilder.java
@@ -8,7 +8,7 @@ import io.crnk.core.engine.information.resource.ResourceFieldAccess;
 import io.crnk.core.engine.information.resource.ResourceFieldAccessor;
 import io.crnk.core.engine.information.resource.ResourceFieldType;
 import io.crnk.core.engine.information.resource.ResourceInformation;
-import io.crnk.core.queryspec.pagingspec.PagingBehavior;
+import io.crnk.core.engine.information.resource.VersionRange;
 import io.crnk.core.queryspec.pagingspec.PagingSpec;
 import io.crnk.core.repository.RelationshipMatcher;
 import io.crnk.core.resource.annotations.JsonIncludeStrategy;
@@ -65,6 +65,8 @@ public interface InformationBuilder {
 
         ResourceInformationBuilder pagingSpecType(Class<? extends PagingSpec> pagingSpecType);
 
+        ResourceInformationBuilder versionRange(VersionRange versionRange);
+
         ResourceInformation build();
 
     }
@@ -113,6 +115,8 @@ public interface InformationBuilder {
         FieldInformationBuilder patchStrategy(PatchStrategy patchStrategy);
 
         FieldInformationBuilder setMappedBy(boolean mappedBy);
+
+        FieldInformationBuilder versionRange(VersionRange versionRange);
     }
 
     RelationshipRepositoryInformationBuilder createRelationshipRepository(String sourceResourceType, String targeResourceType);

--- a/crnk-core/src/main/java/io/crnk/core/engine/information/resource/ResourceField.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/information/resource/ResourceField.java
@@ -96,4 +96,9 @@ public interface ResourceField {
 
     PatchStrategy getPatchStrategy();
 
+    /**
+     * @return version range this field is applicable to. See also {@link @JsonApiVersion}
+     */
+    VersionRange getVersionRange();
+
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/information/resource/ResourceFieldInformationProvider.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/information/resource/ResourceFieldInformationProvider.java
@@ -100,8 +100,12 @@ public interface ResourceFieldInformationProvider {
     Optional<PatchStrategy> getPatchStrategy(BeanAttributeInformation attributeDesc);
 
     /**
-     * Returns whether the field is the owner of a relationships.
-     * @return
+     * @return Returns whether the field is the owner of a relationships.
      */
     Optional<String> getMappedBy(BeanAttributeInformation attributeDesc);
+
+    /**
+     * @return range of version the field is applicable to. By default {@link VersionRange#UNBOUNDED} will be used.
+     */
+    Optional<VersionRange> getVersionRange(BeanAttributeInformation attributeDesc);
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/information/resource/ResourceFieldInformationProviderBase.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/information/resource/ResourceFieldInformationProviderBase.java
@@ -102,4 +102,9 @@ public class ResourceFieldInformationProviderBase implements ResourceFieldInform
     public Optional<String> getMappedBy(BeanAttributeInformation attributeDesc) {
         return Optional.empty();
     }
+
+    @Override
+    public Optional<VersionRange> getVersionRange(BeanAttributeInformation attributeDesc) {
+        return Optional.empty();
+    }
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/information/resource/VersionRange.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/information/resource/VersionRange.java
@@ -1,0 +1,38 @@
+package io.crnk.core.engine.information.resource;
+
+import io.crnk.core.engine.internal.utils.PreconditionUtil;
+
+/**
+ * Defines an integer-based version range.
+ */
+public class VersionRange {
+
+    public static final VersionRange UNBOUNDED = VersionRange.of(0, Integer.MAX_VALUE);
+
+    private int min;
+
+    private int max;
+
+    private VersionRange() {
+    }
+
+    public static VersionRange of(int min, int max) {
+        VersionRange versionRange = new VersionRange();
+        versionRange.min = min;
+        versionRange.max = max;
+        return versionRange;
+    }
+
+    public int getMin() {
+        return min;
+    }
+
+    public int getMax() {
+        return max;
+    }
+
+    public boolean contains(int version) {
+        PreconditionUtil.verify(version >= 0, "version not set");
+        return min <= version && version <= max;
+    }
+}

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/path/PathBuilder.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/dispatcher/path/PathBuilder.java
@@ -1,12 +1,5 @@
 package io.crnk.core.engine.internal.dispatcher.path;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-
 import io.crnk.core.engine.information.repository.RepositoryAction;
 import io.crnk.core.engine.information.repository.ResourceRepositoryInformation;
 import io.crnk.core.engine.information.resource.ResourceField;
@@ -16,280 +9,289 @@ import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.engine.parser.TypeParser;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.exception.BadRequestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Builder responsible for parsing URL path.
  */
 public class PathBuilder {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(PathBuilder.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PathBuilder.class);
 
-	public static final String SEPARATOR = "/";
+    public static final String SEPARATOR = "/";
 
-	public static final String RELATIONSHIP_MARK = "relationships";
+    public static final String RELATIONSHIP_MARK = "relationships";
 
-	private final ResourceRegistry resourceRegistry;
+    private final ResourceRegistry resourceRegistry;
 
-	private final TypeParser parser;
+    private final TypeParser parser;
 
-	public PathBuilder(ResourceRegistry resourceRegistry, TypeParser parser) {
-		this.resourceRegistry = resourceRegistry;
-		this.parser = parser;
-	}
+    public PathBuilder(ResourceRegistry resourceRegistry, TypeParser parser) {
+        this.resourceRegistry = resourceRegistry;
+        this.parser = parser;
+    }
 
-	private static List<Serializable> parseIds(String idsString, ResourceInformation resourceInformation) {
-		String[] strPathIds = idsString.split(JsonPath.ID_SEPARATOR_PATTERN);
+    private static List<Serializable> parseIds(String idsString, ResourceInformation resourceInformation) {
+        String[] strPathIds = idsString.split(JsonPath.ID_SEPARATOR_PATTERN);
 
-		List<Serializable> pathIds = new ArrayList<>();
-		for (String strPathId : strPathIds) {
-			pathIds.add(resourceInformation.parseIdString(strPathId));
-		}
+        List<Serializable> pathIds = new ArrayList<>();
+        for (String strPathId : strPathIds) {
+            pathIds.add(resourceInformation.parseIdString(strPathId));
+        }
 
-		return pathIds;
-	}
+        return pathIds;
+    }
 
-	private List<Serializable> parseNestedIds(String idsString, Serializable parentId, ResourceField parentField) {
-		String[] strPathIds = idsString.split(JsonPath.ID_SEPARATOR_PATTERN);
+    private List<Serializable> parseNestedIds(String idsString, Serializable parentId, ResourceField parentField) {
+        String[] strPathIds = idsString.split(JsonPath.ID_SEPARATOR_PATTERN);
 
-		ResourceInformation resourceInformation = parentField.getResourceInformation();
-		Class<?> idType = resourceInformation.getIdField().getType();
+        ResourceInformation resourceInformation = parentField.getResourceInformation();
+        Class<?> idType = resourceInformation.getIdField().getType();
 
-		ResourceFieldAccessor nestedIdAccessor = resourceInformation.getChildIdAccessor();
-		ResourceFieldAccessor parentIdAccessor = resourceInformation.getParentIdAccessor();
+        ResourceFieldAccessor nestedIdAccessor = resourceInformation.getChildIdAccessor();
+        ResourceFieldAccessor parentIdAccessor = resourceInformation.getParentIdAccessor();
 
-		List<Serializable> pathIds = new ArrayList<>();
-		for (String strPathId : strPathIds) {
-			Serializable nestedId = (Serializable) ClassUtils.newInstance(idType);
-			Object childId = parser.parse(strPathId, nestedIdAccessor.getImplementationClass());
-			parentIdAccessor.setValue(nestedId, parentId);
-			nestedIdAccessor.setValue(nestedId, childId);
-			pathIds.add(nestedId);
-		}
+        List<Serializable> pathIds = new ArrayList<>();
+        for (String strPathId : strPathIds) {
+            Serializable nestedId = (Serializable) ClassUtils.newInstance(idType);
+            Object childId = parser.parse(strPathId, nestedIdAccessor.getImplementationClass());
+            parentIdAccessor.setValue(nestedId, parentId);
+            nestedIdAccessor.setValue(nestedId, childId);
+            pathIds.add(nestedId);
+        }
 
-		return pathIds;
-	}
+        return pathIds;
+    }
 
-	private static String[] splitPath(String path) {
-		if (path.startsWith(SEPARATOR)) {
-			path = path.substring(1);
-		}
-		if (path.endsWith(SEPARATOR)) {
-			path = path;
-		}
-		return path.split(SEPARATOR);
-	}
+    private static String[] splitPath(String path) {
+        if (path.startsWith(SEPARATOR)) {
+            path = path.substring(1);
+        }
+        if (path.endsWith(SEPARATOR)) {
+            path = path;
+        }
+        return path.split(SEPARATOR);
+    }
 
-	/**
-	 * Parses path provided by the application. The path provided cannot contain neither hostname nor protocol. It
-	 * can start or end with slash e.g. <i>/tasks/1/</i> or <i>tasks/1</i>.
-	 *
-	 * @param path Path to be parsed
-	 * @return doubly-linked list which represents path given at the input
-	 */
-	public JsonPath build(String path) {
-		String[] pathElements = splitPath(path);
-		if (pathElements.length == 0 || (pathElements.length == 1 && "".equals(pathElements[0]))) {
-			LOGGER.debug("requested root path: {}", path);
-			return null;
-		}
-		return parseResourcePath(new LinkedList<>(Arrays.asList(pathElements)));
-	}
+    /**
+     * Parses path provided by the application. The path provided cannot contain neither hostname nor protocol. It
+     * can start or end with slash e.g. <i>/tasks/1/</i> or <i>tasks/1</i>.
+     *
+     * @param path Path to be parsed
+     * @return doubly-linked list which represents path given at the input
+     */
+    public JsonPath build(String path, QueryContext queryContext) {
+        String[] pathElements = splitPath(path);
+        if (pathElements.length == 0 || (pathElements.length == 1 && "".equals(pathElements[0]))) {
+            LOGGER.debug("requested root path: {}", path);
+            return null;
+        }
+        return parseResourcePath(new LinkedList<>(Arrays.asList(pathElements)), queryContext);
+    }
 
-	private JsonPath parseResourcePath(LinkedList<String> pathElements) {
-		RegistryEntry rootEntry = getRootEntry(pathElements);
-		if (rootEntry == null) {
-			return null;
-		}
-		if (pathElements.isEmpty()) {
-			LOGGER.debug("resource path to root entry found: {}", rootEntry);
-			return new ResourcePath(rootEntry, null);
-		}
-		Map<String, RepositoryAction> actions = rootEntry.getRepositoryInformation().getActions();
-		if (actions.containsKey(pathElements.peek())) {
-			String pathElement = pathElements.pop();
-			return new ActionPath(rootEntry, null, pathElement);
-		}
-		return parseIdPath(rootEntry, pathElements);
-	}
+    private JsonPath parseResourcePath(LinkedList<String> pathElements, QueryContext queryContext) {
+        RegistryEntry rootEntry = getRootEntry(pathElements);
+        if (rootEntry == null) {
+            return null;
+        }
+        if (pathElements.isEmpty()) {
+            LOGGER.debug("resource path to root entry found: {}", rootEntry);
+            return new ResourcePath(rootEntry, null);
+        }
+        Map<String, RepositoryAction> actions = rootEntry.getRepositoryInformation().getActions();
+        if (actions.containsKey(pathElements.peek())) {
+            String pathElement = pathElements.pop();
+            return new ActionPath(rootEntry, null, pathElement);
+        }
+        return parseIdPath(rootEntry, pathElements, queryContext);
+    }
 
-	private JsonPath parseIdPath(RegistryEntry entry, LinkedList<String> pathElements) {
-		String pathElement = pathElements.pop();
-		List<Serializable> ids = parseIds(pathElement, entry.getResourceInformation());
-		return parseFieldPath(entry, ids, pathElements);
-	}
+    private JsonPath parseIdPath(RegistryEntry entry, LinkedList<String> pathElements, QueryContext queryContext) {
+        String pathElement = pathElements.pop();
+        List<Serializable> ids = parseIds(pathElement, entry.getResourceInformation());
+        return parseFieldPath(entry, ids, pathElements, queryContext);
+    }
 
-	private JsonPath parseFieldPath(RegistryEntry entry, List<Serializable> ids, LinkedList<String> pathElements) {
-		if (pathElements.isEmpty()) {
-			LOGGER.debug("resource path for {} with ids {} found", entry, ids);
-			return new ResourcePath(entry, ids);
-		}
+    private JsonPath parseFieldPath(RegistryEntry entry, List<Serializable> ids, LinkedList<String> pathElements, QueryContext queryContext) {
+        if (pathElements.isEmpty()) {
+            LOGGER.debug("resource path for {} with ids {} found", entry, ids);
+            return new ResourcePath(entry, ids);
+        }
 
-		Map<String, RepositoryAction> actions = entry.getRepositoryInformation().getActions();
-		if (actions.containsKey(pathElements.peek())) {
-			String pathElement = pathElements.pop();
-			LOGGER.debug("action path {} for {} with ids {} found", pathElement, entry, ids);
-			return new ActionPath(entry, ids, pathElement);
-		}
+        Map<String, RepositoryAction> actions = entry.getRepositoryInformation().getActions();
+        if (actions.containsKey(pathElements.peek())) {
+            String pathElement = pathElements.pop();
+            LOGGER.debug("action path {} for {} with ids {} found", pathElement, entry, ids);
+            return new ActionPath(entry, ids, pathElement);
+        }
 
-		String fieldName = pathElements.pop();
+        String fieldName = pathElements.pop();
 
-		if (fieldName.equals(RELATIONSHIP_MARK)) {
-			if (pathElements.isEmpty()) {
-				throw new BadRequestException("invalid url, relationships fragment must be followed by name");
-			}
-			fieldName = pathElements.poll();
+        if (fieldName.equals(RELATIONSHIP_MARK)) {
+            if (pathElements.isEmpty()) {
+                throw new BadRequestException("invalid url, relationships fragment must be followed by name");
+            }
+            fieldName = pathElements.poll();
 
-			entry = findSelfOrSubtypeByField(entry, fieldName);
-			ResourceField field = entry.getResourceInformation().findRelationshipFieldByName(fieldName);
-			if (field == null) {
-				throw new BadRequestException("invalid url, requested field not found: " + fieldName);
-			}
+            entry = findSelfOrSubtypeByField(entry, fieldName, queryContext);
+            ResourceField field = entry.getResourceInformation().findFieldByJsonName(fieldName, queryContext.getRequestVersion());
+            if (field == null) {
+                throw new BadRequestException("invalid url, requested field not found: " + fieldName);
+            }
+            if(field.getResourceFieldType() != ResourceFieldType.RELATIONSHIP){
+                throw new BadRequestException("invalid url, requested field is not a relationship: " + fieldName);
+            }
 
-			if (!pathElements.isEmpty()) {
-				throw new BadRequestException("invalid url, cannot add further url fragments after relationship name");
-			}
-			LOGGER.debug("relationship path {} for {} with ids {} found", field, entry, ids);
-			return new RelationshipsPath(entry, ids, field);
-		}
+            if (!pathElements.isEmpty()) {
+                throw new BadRequestException("invalid url, cannot add further url fragments after relationship name");
+            }
+            LOGGER.debug("relationship path {} for {} with ids {} found", field, entry, ids);
+            return new RelationshipsPath(entry, ids, field);
+        }
 
-		entry = findSelfOrSubtypeByField(entry, fieldName);
-		ResourceField field = entry.getResourceInformation().findFieldByName(fieldName);
-		if (field == null) {
-			throw new BadRequestException("field not found: " + fieldName);
-		}
-		if (pathElements.isEmpty()) {
-			if (isNestedField(field) && !field.isCollection()) {
-				RegistryEntry nestedEntry = getNestedEntry(field);
-				ResourcePath path = new ResourcePath(nestedEntry, ids);
-				path.addParentField(field);
-				return path;
-			}
-			LOGGER.debug("field path {} for {} with ids {} found", field, entry, ids);
-			return new FieldPath(entry, ids, field);
-		}
+        entry = findSelfOrSubtypeByField(entry, fieldName, queryContext);
+        ResourceField field = entry.getResourceInformation().findFieldByJsonName(fieldName, queryContext.getRequestVersion());
+        if (field == null) {
+            throw new BadRequestException("field not found: " + fieldName);
+        }
+        if (pathElements.isEmpty()) {
+            if (isNestedField(field) && !field.isCollection()) {
+                RegistryEntry nestedEntry = getNestedEntry(field);
+                ResourcePath path = new ResourcePath(nestedEntry, ids);
+                path.addParentField(field);
+                return path;
+            }
+            LOGGER.debug("field path {} for {} with ids {} found", field, entry, ids);
+            return new FieldPath(entry, ids, field);
+        }
 
-		if (field.getResourceFieldType() != ResourceFieldType.RELATIONSHIP || field.getOppositeName() == null) {
-			LOGGER.debug("cannot process field={} is not a relationship with an opposite field", field);
-			throw new BadRequestException("invalid url, cannot add further url fragements after field");
-		}
+        if (field.getResourceFieldType() != ResourceFieldType.RELATIONSHIP || field.getOppositeName() == null) {
+            LOGGER.debug("cannot process field={} is not a relationship with an opposite field", field);
+            throw new BadRequestException("invalid url, cannot add further url fragements after field");
+        }
 
-		RegistryEntry oppositeEntry = resourceRegistry.getEntry(field.getOppositeResourceType());
-		ResourceInformation oppositeInformation = oppositeEntry.getResourceInformation();
-		ResourceField oppositeField = oppositeInformation.findFieldByName(field.getOppositeName());
-		PreconditionUtil.verify(oppositeField.getResourceFieldType() == ResourceFieldType.RELATIONSHIP,
-				"expected opposite field {} of {} to be a relationship", oppositeField, field);
-		if (!oppositeInformation.isNested()) {
-			LOGGER.debug("cannot process field={} because opposite={} is not an nested resource", field, oppositeInformation);
-			throw new BadRequestException("invalid url, cannot specify ID of related resource");
-		}
+        RegistryEntry oppositeEntry = resourceRegistry.getEntry(field.getOppositeResourceType());
+        ResourceInformation oppositeInformation = oppositeEntry.getResourceInformation();
+        ResourceField oppositeField = oppositeInformation.findFieldByJsonName(field.getOppositeName(), queryContext.getRequestVersion());
+        PreconditionUtil.verify(oppositeField.getResourceFieldType() == ResourceFieldType.RELATIONSHIP,
+                "expected opposite field {} of {} to be a relationship", oppositeField, field);
+        if (!oppositeInformation.isNested()) {
+            LOGGER.debug("cannot process field={} because opposite={} is not an nested resource", field, oppositeInformation);
+            throw new BadRequestException("invalid url, cannot specify ID of related resource");
+        }
 
-		PreconditionUtil.verify(oppositeField != null, "nested resource must specify opposite on relationship from parent to child, got null for %s", field);
+        PreconditionUtil.verify(oppositeField != null, "nested resource must specify opposite on relationship from parent to child, got null for %s", field);
 
-		List<Serializable> nestedIds;
-		if (field.isCollection()) {
-			PreconditionUtil.verify(ids.size() == 1, "cannot follow multiple ids along nested path");
-			Serializable parentId = ids.get(0);
+        List<Serializable> nestedIds;
+        if (field.isCollection()) {
+            PreconditionUtil.verify(ids.size() == 1, "cannot follow multiple ids along nested path");
+            Serializable parentId = ids.get(0);
 
-			// nested many-relationship must specify a nested id
-			String strNestedId = pathElements.poll();
-			nestedIds = parseNestedIds(strNestedId, parentId, oppositeField);
-		}
-		else {
-			nestedIds = ids;
-		}
+            // nested many-relationship must specify a nested id
+            String strNestedId = pathElements.poll();
+            nestedIds = parseNestedIds(strNestedId, parentId, oppositeField);
+        } else {
+            nestedIds = ids;
+        }
 
-		JsonPath jsonPath = parseFieldPath(oppositeEntry, nestedIds, pathElements);
-		if (jsonPath != null) {
-			jsonPath.addParentField(field);
-		}
-		return jsonPath;
-	}
+        JsonPath jsonPath = parseFieldPath(oppositeEntry, nestedIds, pathElements, queryContext);
+        if (jsonPath != null) {
+            jsonPath.addParentField(field);
+        }
+        return jsonPath;
+    }
 
-	private RegistryEntry findSelfOrSubtypeByField(RegistryEntry entry, String fieldName) {
-		if (entry.getResourceInformation().findFieldByName(fieldName) == null) {
-			// consider introducing RegistyEntry.getSubTypes in the future
-			for (RegistryEntry someEntry : resourceRegistry.getEntries()) {
-				ResourceInformation resourceInformation = someEntry.getResourceInformation();
-				ResourceField field = resourceInformation.findFieldByName(fieldName);
-				if (field != null && someEntry.isParent(entry)) {
-					RegistryEntry parentEntry = someEntry.getParentRegistryEntry();
-					while (parentEntry != null && parentEntry.getResourceInformation().findFieldByName(fieldName) != null) {
-						someEntry = parentEntry;
-					}
-					return someEntry;
-				}
-			}
-		}
-		return entry; // may not contain the field in case of errorous request
-	}
+    private RegistryEntry findSelfOrSubtypeByField(RegistryEntry entry, String jsonName, QueryContext queryContext) {
+        if (entry.getResourceInformation().findFieldByJsonName(jsonName, queryContext.getRequestVersion()) == null) {
+            // consider introducing RegistyEntry.getSubTypes in the future
+            for (RegistryEntry someEntry : resourceRegistry.getEntries()) {
+                ResourceInformation resourceInformation = someEntry.getResourceInformation();
+                ResourceField field = resourceInformation.findFieldByJsonName(jsonName, queryContext.getRequestVersion());
+                if (field != null && someEntry.isParent(entry)) {
+                    RegistryEntry parentEntry = someEntry.getParentRegistryEntry();
+                    while (parentEntry != null && parentEntry.getResourceInformation().findFieldByJsonName(jsonName, queryContext.getRequestVersion()) != null) {
+                        someEntry = parentEntry;
+                    }
+                    return someEntry;
+                }
+            }
+        }
+        return entry; // may not contain the field in case of errorous request
+    }
 
-	private boolean isNestedField(ResourceField field) {
-		if (field.getResourceFieldType() == ResourceFieldType.RELATIONSHIP) {
-			RegistryEntry oppositeType = resourceRegistry.getEntry(field.getOppositeResourceType());
-			String oppositeName = field.getOppositeName();
-			PreconditionUtil.verify(oppositeType != null, "opposite type %s not found for %s", field.getOppositeResourceType(), field.getUnderlyingName());
-			ResourceInformation oppositeResourceInformation = oppositeType.getResourceInformation();
-			if (oppositeName != null && oppositeResourceInformation.isNested()) {
-				return oppositeResourceInformation.getParentField().getUnderlyingName().equals(oppositeName);
-			}
-		}
-		return false;
-	}
+    private boolean isNestedField(ResourceField field) {
+        if (field.getResourceFieldType() == ResourceFieldType.RELATIONSHIP) {
+            RegistryEntry oppositeType = resourceRegistry.getEntry(field.getOppositeResourceType());
+            String oppositeName = field.getOppositeName();
+            PreconditionUtil.verify(oppositeType != null, "opposite type %s not found for %s", field.getOppositeResourceType(), field.getUnderlyingName());
+            ResourceInformation oppositeResourceInformation = oppositeType.getResourceInformation();
+            if (oppositeName != null && oppositeResourceInformation.isNested()) {
+                return oppositeResourceInformation.getParentField().getUnderlyingName().equals(oppositeName);
+            }
+        }
+        return false;
+    }
 
-	private RegistryEntry getNestedEntry(ResourceField field) {
-		PreconditionUtil.verify(field.getResourceFieldType() == ResourceFieldType.RELATIONSHIP, "not a relationship");
-		RegistryEntry oppositeType = resourceRegistry.getEntry(field.getOppositeResourceType());
-		ResourceInformation resourceInformation = oppositeType.getResourceInformation();
-		PreconditionUtil.verify(resourceInformation.isNested(), "not a nested relationship");
-		return oppositeType;
-	}
+    private RegistryEntry getNestedEntry(ResourceField field) {
+        PreconditionUtil.verify(field.getResourceFieldType() == ResourceFieldType.RELATIONSHIP, "not a relationship");
+        RegistryEntry oppositeType = resourceRegistry.getEntry(field.getOppositeResourceType());
+        ResourceInformation resourceInformation = oppositeType.getResourceInformation();
+        PreconditionUtil.verify(resourceInformation.isNested(), "not a nested relationship");
+        return oppositeType;
+    }
 
-	private RegistryEntry getRootEntry(LinkedList<String> pathElements) {
-		StringBuilder potentialResourcePath = new StringBuilder(pathElements.pop());
+    private RegistryEntry getRootEntry(LinkedList<String> pathElements) {
+        StringBuilder potentialResourcePath = new StringBuilder(pathElements.pop());
 
-		RegistryEntry matchedEntry;
-		while (true) {
-			matchedEntry = getEntryByPath(potentialResourcePath.toString());
+        RegistryEntry matchedEntry;
+        while (true) {
+            matchedEntry = getEntryByPath(potentialResourcePath.toString());
 
-			if (matchedEntry != null) {
-				LOGGER.debug("registry entry found for: {}", potentialResourcePath);
-			}
-			else {
-				LOGGER.debug("no registry entry found for: {}", potentialResourcePath);
-			}
+            if (matchedEntry != null) {
+                LOGGER.debug("registry entry found for: {}", potentialResourcePath);
+            } else {
+                LOGGER.debug("no registry entry found for: {}", potentialResourcePath);
+            }
 
-			if (pathElements.isEmpty() || pathElements.peek().equals(RELATIONSHIP_MARK)) {
-				return matchedEntry; // maybe found or null
-			}
+            if (pathElements.isEmpty() || pathElements.peek().equals(RELATIONSHIP_MARK)) {
+                return matchedEntry; // maybe found or null
+            }
 
-			// compute next potential path
-			String pathElement = pathElements.peek();
-			if (potentialResourcePath.length() > 0) {
-				potentialResourcePath.append("/");
-			}
-			potentialResourcePath.append(pathElement);
-			if (matchedEntry != null && getEntryByPath(potentialResourcePath.toString()) == null) {
-				// no more match, return found entry
-				return matchedEntry;
-			}
-			pathElements.poll();
-		}
-	}
+            // compute next potential path
+            String pathElement = pathElements.peek();
+            if (potentialResourcePath.length() > 0) {
+                potentialResourcePath.append("/");
+            }
+            potentialResourcePath.append(pathElement);
+            if (matchedEntry != null && getEntryByPath(potentialResourcePath.toString()) == null) {
+                // no more match, return found entry
+                return matchedEntry;
+            }
+            pathElements.poll();
+        }
+    }
 
 
-	private RegistryEntry getEntryByPath(String path) {
-		RegistryEntry entry = resourceRegistry.getEntryByPath(path);
-		if (entry != null) {
-			ResourceRepositoryInformation repositoryInformation = entry.getRepositoryInformation();
-			if (repositoryInformation == null || !repositoryInformation.isExposed()) {
-				return null;
-			}
-		}
-		return entry;
-	}
+    private RegistryEntry getEntryByPath(String path) {
+        RegistryEntry entry = resourceRegistry.getEntryByPath(path);
+        if (entry != null) {
+            ResourceRepositoryInformation repositoryInformation = entry.getRepositoryInformation();
+            if (repositoryInformation == null || !repositoryInformation.isExposed()) {
+                return null;
+            }
+        }
+        return entry;
+    }
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/DocumentMapper.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/DocumentMapper.java
@@ -27,7 +27,7 @@ public class DocumentMapper {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(DocumentMapper.class);
 
-	private final ResourceFilterDirectory resourceFilterDirectory;
+	protected final ResourceFilterDirectory resourceFilterDirectory;
 
 	private ObjectNode jsonapi;
 

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/IncludeLookupUtil.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/IncludeLookupUtil.java
@@ -95,8 +95,7 @@ public class IncludeLookupUtil {
 
             // TODO same relationship on multiple children
             for (ResourceField field : information.getRelationshipFields()) {
-                boolean existsOnSuperType =
-                        superInformation != null && superInformation.findRelationshipFieldByName(field.getJsonName()) != null;
+                boolean existsOnSuperType = superInformation != null && superInformation.findFieldByUnderlyingName(field.getUnderlyingName()) != null;
                 if (!existsOnSuperType) {
                     fields.add(field);
                 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/ResourceMapper.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/ResourceMapper.java
@@ -1,11 +1,5 @@
 package io.crnk.core.engine.internal.document.mapper;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -24,181 +18,197 @@ import io.crnk.core.resource.annotations.JsonIncludeStrategy;
 import io.crnk.core.resource.links.LinksInformation;
 import io.crnk.core.resource.links.SelfLinksInformation;
 import io.crnk.core.resource.meta.MetaInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class ResourceMapper {
 
-	private static final String SELF_FIELD_NAME = "self";
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceMapper.class);
 
-	private final String RELATED_FIELD_NAME = "related";
+    private static final String SELF_FIELD_NAME = "self";
 
-	private final ResourceFilterDirectory resourceFilterDirectory;
+    private final String RELATED_FIELD_NAME = "related";
 
-	private DocumentMapperUtil util;
+    private final ResourceFilterDirectory resourceFilterDirectory;
 
-	private boolean client;
+    private DocumentMapperUtil util;
 
-	private ObjectMapper objectMapper;
+    private boolean client;
 
-	public ResourceMapper(DocumentMapperUtil util, boolean client, ObjectMapper objectMapper,
-			ResourceFilterDirectory resourceFilterDirectory) {
-		this.util = util;
-		this.client = client;
-		this.objectMapper = objectMapper;
-		this.resourceFilterDirectory = resourceFilterDirectory;
-	}
+    private ObjectMapper objectMapper;
 
-	public Resource toData(Object entity, QueryAdapter queryAdapter, ResourceMappingConfig mappingConfig) {
-		if (entity instanceof Resource) {
-			// Resource and ResourceId
-			return (Resource) entity;
-		} else {
-			// map resource objects
-			QueryContext queryContext = queryAdapter.getQueryContext();
+    public ResourceMapper(DocumentMapperUtil util, boolean client, ObjectMapper objectMapper,
+                          ResourceFilterDirectory resourceFilterDirectory) {
+        this.util = util;
+        this.client = client;
+        this.objectMapper = objectMapper;
+        this.resourceFilterDirectory = resourceFilterDirectory;
+    }
 
-			ResourceInformation resourceInformation = util.getResourceInformation(entity);
+    public Resource toData(Object entity, QueryAdapter queryAdapter, ResourceMappingConfig mappingConfig) {
+        if (entity instanceof Resource) {
+            // Resource and ResourceId
+            Resource resource = (Resource) entity;
+            LOGGER.debug("directly returning id={}, type={}", resource.getId(), resource.getType());
+            return resource;
+        } else {
+            // map resource objects
+            QueryContext queryContext = queryAdapter.getQueryContext();
+            ResourceInformation resourceInformation = util.getResourceInformation(entity);
+            Resource resource = new Resource();
+            setId(resource, entity, resourceInformation);
+            resource.setType(resourceInformation.getResourceType());
 
-			Resource resource = new Resource();
-			setId(resource, entity, resourceInformation);
-			resource.setType(resourceInformation.getResourceType());
-			if (mappingConfig.getSerializeLinks()) {
-				util.setLinks(resource, getResourceLinks(entity, resourceInformation, queryContext), queryAdapter);
-			}
-			util.setMeta(resource, getResourceMeta(entity, resourceInformation));
-			setAttributes(resource, entity, resourceInformation, queryAdapter, mappingConfig);
-			setRelationships(resource, entity, resourceInformation, queryAdapter, mappingConfig);
-			return resource;
-		}
-	}
+            LOGGER.debug("mapping id={}, type={}", resource.getId(), resource.getType());
+            if (mappingConfig.getSerializeLinks()) {
+                util.setLinks(resource, getResourceLinks(entity, resourceInformation, queryContext), queryAdapter);
+            }
+            util.setMeta(resource, getResourceMeta(entity, resourceInformation));
+            setAttributes(resource, entity, resourceInformation, queryAdapter, mappingConfig);
+            setRelationships(resource, entity, resourceInformation, queryAdapter, mappingConfig);
+            return resource;
+        }
+    }
 
-	private void setId(Resource resource, Object entity, ResourceInformation resourceInformation) {
-		ResourceField idField = resourceInformation.getIdField();
-		Object value = idField.getAccessor().getValue(entity);
-		if (isIncluded(idField, value)) {
-			resource.setId(resourceInformation.toIdString(value));
-		}
-	}
+    private void setId(Resource resource, Object entity, ResourceInformation resourceInformation) {
+        ResourceField idField = resourceInformation.getIdField();
+        Object value = idField.getAccessor().getValue(entity);
+        if (isIncluded(idField, value)) {
+            resource.setId(resourceInformation.toIdString(value));
+        }
+    }
 
-	private MetaInformation getResourceMeta(Object entity, ResourceInformation resourceInformation) {
-		if (resourceInformation.getMetaField() != null) {
-			return (MetaInformation) resourceInformation.getMetaField().getAccessor().getValue(entity);
-		}
-		return null;
-	}
+    private MetaInformation getResourceMeta(Object entity, ResourceInformation resourceInformation) {
+        if (resourceInformation.getMetaField() != null) {
+            return (MetaInformation) resourceInformation.getMetaField().getAccessor().getValue(entity);
+        }
+        return null;
+    }
 
-	public LinksInformation getResourceLinks(Object entity, ResourceInformation resourceInformation, QueryContext queryContext) {
-		LinksInformation info;
-		if (resourceInformation.getLinksField() != null) {
-			info = (LinksInformation) resourceInformation.getLinksField().getAccessor().getValue(entity);
-		} else {
-			info = new DocumentMapperUtil.DefaultSelfRelatedLinksInformation();
-		}
-		if (info instanceof SelfLinksInformation) {
-			SelfLinksInformation self = (SelfLinksInformation) info;
-			if (self.getSelf() == null && !client) {
-				self.setSelf(util.getSelfUrl(queryContext, resourceInformation, entity));
-			}
-		}
-		return info;
-	}
+    public LinksInformation getResourceLinks(Object entity, ResourceInformation resourceInformation, QueryContext queryContext) {
+        LinksInformation info;
+        if (resourceInformation.getLinksField() != null) {
+            info = (LinksInformation) resourceInformation.getLinksField().getAccessor().getValue(entity);
+        } else {
+            info = new DocumentMapperUtil.DefaultSelfRelatedLinksInformation();
+        }
+        if (info instanceof SelfLinksInformation) {
+            SelfLinksInformation self = (SelfLinksInformation) info;
+            if (self.getSelf() == null && !client) {
+                self.setSelf(util.getSelfUrl(queryContext, resourceInformation, entity));
+            }
+        }
+        return info;
+    }
 
-	@SuppressWarnings("unchecked")
-	protected void setAttributes(Resource resource, Object entity, ResourceInformation resourceInformation,
-			QueryAdapter queryAdapter, ResourceMappingConfig mappingConfig) {
-		// fields legacy may further limit the number of fields
-		List<ResourceField> fields = DocumentMapperUtil
-				.getRequestedFields(resourceInformation, queryAdapter, resourceInformation.getAttributeFields(), false);
-		// serialize the individual attributes
-		QueryContext queryContext = queryAdapter.getQueryContext();
-		for (ResourceField field : fields) {
-			if (!isIgnored(field, queryContext) && field.getAccess().isReadable()) {
-				Object value = field.getAccessor().getValue(entity);
-				if (!mappingConfig.isIgnoreDefaults() || !isDefaultValue(value)) {
-					setAttribute(resource, field, value);
-				}
-			}
+    @SuppressWarnings("unchecked")
+    protected void setAttributes(Resource resource, Object entity, ResourceInformation resourceInformation,
+                                 QueryAdapter queryAdapter, ResourceMappingConfig mappingConfig) {
+        // fields legacy may further limit the number of fields
+        List<ResourceField> fields = DocumentMapperUtil
+                .getRequestedFields(resourceInformation, queryAdapter, resourceInformation.getAttributeFields(), false);
+        // serialize the individual attributes
+        QueryContext queryContext = queryAdapter.getQueryContext();
+        for (ResourceField field : fields) {
+            if (!isIgnored(field, queryContext) && field.getAccess().isReadable()) {
+                Object value = field.getAccessor().getValue(entity);
+                if (!mappingConfig.isIgnoreDefaults() || !isDefaultValue(value)) {
+                    LOGGER.debug("setting {}={}", field.getUnderlyingName(), value);
+                    setAttribute(resource, field, value);
+                }else{
+                    LOGGER.debug("ignored default value for {}", field.getUnderlyingName());
+                }
+            }else {
+                LOGGER.debug("ignored {} due to filter", field.getUnderlyingName());
+            }
+        }
 
-		}
+        if (resourceInformation.getAnyFieldAccessor() != null) {
+            AnyResourceFieldAccessor anyFieldAccessor = resourceInformation.getAnyFieldAccessor();
+            Map<String, Object> map = anyFieldAccessor.getValues(entity);
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                setAnyAttribute(resource, entry.getKey(), entry.getValue());
+            }
+        }
 
-		if (resourceInformation.getAnyFieldAccessor() != null) {
-			AnyResourceFieldAccessor anyFieldAccessor = resourceInformation.getAnyFieldAccessor();
-			Map<String, Object> map = anyFieldAccessor.getValues(entity);
-			for (Map.Entry<String, Object> entry : map.entrySet()) {
-				setAnyAttribute(resource, entry.getKey(), entry.getValue());
-			}
-		}
+    }
 
-	}
+    private static Set<Object> defaultValues = new HashSet<>(Arrays.asList(
+            Byte.valueOf((byte) 0),
+            Short.valueOf((short) 0),
+            Integer.valueOf(0),
+            Long.valueOf(0l),
+            Float.valueOf(0f),
+            Double.valueOf(0d)
+    ));
 
-	private static Set<Object> defaultValues = new HashSet<>(Arrays.asList(
-			Byte.valueOf((byte) 0),
-			Short.valueOf((short) 0),
-			Integer.valueOf(0),
-			Long.valueOf(0l),
-			Float.valueOf(0f),
-			Double.valueOf(0d)
-	));
+    protected boolean isDefaultValue(Object value) {
+        return value == null || defaultValues.contains(value);
+    }
 
-	protected boolean isDefaultValue(Object value) {
-		return value == null || defaultValues.contains(value);
-	}
+    protected boolean isIgnored(ResourceField field, QueryContext queryContext) { // NOSONAR signature is ok since protected
+        return resourceFilterDirectory != null
+                && resourceFilterDirectory.get(field, HttpMethod.GET, queryContext) != FilterBehavior.NONE;
+    }
 
-	protected boolean isIgnored(ResourceField field, QueryContext queryContext) { // NOSONAR signature is ok since protected
-		return resourceFilterDirectory != null
-				&& resourceFilterDirectory.get(field, HttpMethod.GET, queryContext) != FilterBehavior.NONE;
-	}
+    protected void setAttribute(Resource resource, ResourceField field, Object value) {
+        if (isIncluded(field, value)) {
+            JsonNode valueNode = objectMapper.valueToTree(value);
+            resource.getAttributes().put(field.getJsonName(), valueNode);
+        }
+    }
 
-	protected void setAttribute(Resource resource, ResourceField field, Object value) {
-		if (isIncluded(field, value)) {
-			JsonNode valueNode = objectMapper.valueToTree(value);
-			resource.getAttributes().put(field.getJsonName(), valueNode);
-		}
-	}
+    protected void setAnyAttribute(Resource resource, String field, Object value) {
+        JsonNode valueNode = objectMapper.valueToTree(value);
+        resource.getAttributes().put(field, valueNode);
+    }
 
-	protected void setAnyAttribute(Resource resource, String field, Object value) {
-		JsonNode valueNode = objectMapper.valueToTree(value);
-		resource.getAttributes().put(field, valueNode);
-	}
+    private boolean isIncluded(ResourceField field, Object value) {
+        JsonIncludeStrategy includeStrategy = field.getJsonIncludeStrategy();
+        return JsonIncludeStrategy.DEFAULT.equals(includeStrategy) || value != null && JsonIncludeStrategy.NOT_NULL.equals(includeStrategy)
+                || JsonIncludeStrategy.NON_EMPTY.equals(includeStrategy) && !isDefaultValue(value);
+    }
 
-	private boolean isIncluded(ResourceField field, Object value) {
-		JsonIncludeStrategy includeStrategy = field.getJsonIncludeStrategy();
-		return JsonIncludeStrategy.DEFAULT.equals(includeStrategy) || value != null && JsonIncludeStrategy.NOT_NULL.equals(includeStrategy)
-				|| JsonIncludeStrategy.NON_EMPTY.equals(includeStrategy) && !isDefaultValue(value);
-	}
+    protected void setRelationships(Resource resource, Object entity, ResourceInformation resourceInformation,
+                                    QueryAdapter queryAdapter, ResourceMappingConfig mappingConfig) {
+        List<ResourceField> fields = DocumentMapperUtil
+                .getRequestedFields(resourceInformation, queryAdapter, resourceInformation.getRelationshipFields(), true);
+        QueryContext queryContext = queryAdapter.getQueryContext();
+        for (ResourceField field : fields) {
+            if (!isIgnored(field, queryContext)) {
+                setRelationship(resource, field, entity, resourceInformation, queryAdapter, mappingConfig);
+            }
+        }
+    }
 
-	protected void setRelationships(Resource resource, Object entity, ResourceInformation resourceInformation,
-			QueryAdapter queryAdapter, ResourceMappingConfig mappingConfig) {
-		List<ResourceField> fields = DocumentMapperUtil
-				.getRequestedFields(resourceInformation, queryAdapter, resourceInformation.getRelationshipFields(), true);
-		QueryContext queryContext = queryAdapter.getQueryContext();
-		for (ResourceField field : fields) {
-			if (!isIgnored(field, queryContext)) {
-				setRelationship(resource, field, entity, resourceInformation, queryAdapter, mappingConfig);
-			}
-		}
-	}
+    protected void setRelationship(Resource resource, ResourceField field, Object entity, ResourceInformation
+            resourceInformation, QueryAdapter queryAdapter, ResourceMappingConfig mappingConfig) {
+        { // NOSONAR signature is ok since protected
+            SerializerUtil serializerUtil = DocumentMapperUtil.getSerializerUtil();
 
-	protected void setRelationship(Resource resource, ResourceField field, Object entity, ResourceInformation
-			resourceInformation, QueryAdapter queryAdapter, ResourceMappingConfig mappingConfig) {
-		{ // NOSONAR signature is ok since protected
-			SerializerUtil serializerUtil = DocumentMapperUtil.getSerializerUtil();
-
-			Relationship relationship = new Relationship();
-			boolean addRelationship = mappingConfig.getSerializeLinks() && (queryAdapter == null || !queryAdapter.getCompactMode());
-			if (addRelationship) {
-				ObjectNode relationshipLinks = objectMapper.createObjectNode();
-				if (mappingConfig.getSerializeSelfRelationshipLinks()) {
-					String selfUrl = util.getRelationshipLink(resource, field, false);
-					if (selfUrl != null) {
-						serializerUtil.serializeLink(objectMapper, relationshipLinks, SELF_FIELD_NAME, selfUrl);
-					}
-				}
-				String relatedUrl = util.getRelationshipLink(resource, field, true);
-				if (relatedUrl != null) {
-					serializerUtil.serializeLink(objectMapper, relationshipLinks, RELATED_FIELD_NAME, relatedUrl);
-					relationship.setLinks(relationshipLinks);
-				}
-			}
-			resource.getRelationships().put(field.getJsonName(), relationship);
-		}
-	}
+            Relationship relationship = new Relationship();
+            boolean addRelationship = mappingConfig.getSerializeLinks() && (queryAdapter == null || !queryAdapter.getCompactMode());
+            if (addRelationship) {
+                ObjectNode relationshipLinks = objectMapper.createObjectNode();
+                if (mappingConfig.getSerializeSelfRelationshipLinks()) {
+                    String selfUrl = util.getRelationshipLink(resource, field, false);
+                    if (selfUrl != null) {
+                        serializerUtil.serializeLink(objectMapper, relationshipLinks, SELF_FIELD_NAME, selfUrl);
+                    }
+                }
+                String relatedUrl = util.getRelationshipLink(resource, field, true);
+                if (relatedUrl != null) {
+                    serializerUtil.serializeLink(objectMapper, relationshipLinks, RELATED_FIELD_NAME, relatedUrl);
+                    relationship.setLinks(relationshipLinks);
+                }
+            }
+            resource.getRelationships().put(field.getJsonName(), relationship);
+        }
+    }
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/http/HttpRequestContextBaseAdapter.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/http/HttpRequestContextBaseAdapter.java
@@ -1,145 +1,175 @@
 package io.crnk.core.engine.internal.http;
 
-import java.net.URI;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
 import io.crnk.core.engine.http.HttpHeaders;
 import io.crnk.core.engine.http.HttpRequestContext;
 import io.crnk.core.engine.http.HttpRequestContextBase;
 import io.crnk.core.engine.http.HttpResponse;
 import io.crnk.core.engine.query.QueryContext;
 
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class HttpRequestContextBaseAdapter implements HttpRequestContext {
 
-	private HttpRequestContextBase base;
+    private HttpRequestContextBase base;
 
-	private boolean hasResponse;
+    private boolean hasResponse;
 
-	private Map<String, Object> requestAttributes = new ConcurrentHashMap<>();
+    private Map<String, Object> requestAttributes = new ConcurrentHashMap<>();
 
-	private QueryContext queryContext = new QueryContext();
+    private QueryContext queryContext = new QueryContext();
 
-	public HttpRequestContextBaseAdapter(HttpRequestContextBase base) {
-		this.base = base;
-		this.queryContext.setBaseUrl(base.getBaseUrl());
-		this.queryContext.setAttributes(requestAttributes);
-		this.queryContext.setRequestPath(base.getPath());
-	}
+    public HttpRequestContextBaseAdapter(HttpRequestContextBase base) {
+        this.base = base;
+        this.queryContext.setBaseUrl(base.getBaseUrl());
+        this.queryContext.setAttributes(requestAttributes);
+        this.queryContext.setRequestPath(base.getPath());
+        this.queryContext.setRequestVersion(getRequestVersion());
+    }
 
-	public boolean hasResponse() {
-		return hasResponse;
-	}
+    /**
+     * @return get requested version from accept header. Fallback to URL parameter for ease of use.
+     */
+    private int getRequestVersion() {
+        String acceptHeader = base.getRequestHeader(HttpHeaders.HTTP_HEADER_ACCEPT);
+        if (acceptHeader != null) {
+            // retrieve from accept header by looking for version=x
+            Optional<Integer> requestVersion = Arrays.stream(acceptHeader.split("\\;"))
+                    .map(it -> it.replace(" ", ""))
+                    .filter(it -> it.startsWith(HttpHeaders.VERSION_ACCEPT_PARAMETER + "="))
+                    .map(it -> it.substring(HttpHeaders.VERSION_ACCEPT_PARAMETER.length() + 1).trim())
+                    .map(it -> Integer.parseInt(it))
+                    .findFirst();
+            if (requestVersion.isPresent()) {
+                return requestVersion.get();
+            }
+        }
 
-	@Override
-	public boolean accepts(String contentType) {
-		String accept = getRequestHeader(HttpHeaders.HTTP_HEADER_ACCEPT);
-		if (accept == null) {
-			return false;
-		}
-		for (String acceptElement : accept.split("\\,")) {
-			acceptElement = acceptElement.trim();
-			if (isCompatible(acceptElement, contentType)) {
-				return true;
-			}
-		}
-		return false;
-	}
+        // parameter-based fallback
+        Set<String> versions = base.getRequestParameters().get(HttpHeaders.VERSION_ACCEPT_PARAMETER);
+        if (versions != null) {
+            return Integer.parseInt(versions.iterator().next());
+        }
 
-	@Override
-	public boolean acceptsAny() {
-		String accept = getRequestHeader(HttpHeaders.HTTP_HEADER_ACCEPT);
-		return accept == null || accepts("*") || accepts("*/*");
-	}
+        return -1;
+    }
 
-	@Override
-	public <T> T unwrap(Class<T> type) {
-		if (type.isInstance(this)) {
-			return (T) this;
-		}
-		if (type.isInstance(base)) {
-			return (T) base;
-		}
-		return null;
-	}
+    public boolean hasResponse() {
+        return hasResponse;
+    }
 
-	@Override
-	public Object getRequestAttribute(String name) {
-		return requestAttributes.get(name);
-	}
+    @Override
+    public boolean accepts(String contentType) {
+        String accept = getRequestHeader(HttpHeaders.HTTP_HEADER_ACCEPT);
+        if (accept == null) {
+            return false;
+        }
+        for (String acceptElement : accept.split("\\,")) {
+            acceptElement = acceptElement.trim();
+            if (isCompatible(acceptElement, contentType)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	@Override
-	public void setRequestAttribute(String name, Object value) {
-		requestAttributes.put(name, value);
-	}
+    @Override
+    public boolean acceptsAny() {
+        String accept = getRequestHeader(HttpHeaders.HTTP_HEADER_ACCEPT);
+        return accept == null || accepts("*") || accepts("*/*");
+    }
 
-	@Override
-	public QueryContext getQueryContext() {
-		return queryContext;
-	}
+    @Override
+    public <T> T unwrap(Class<T> type) {
+        if (type.isInstance(this)) {
+            return (T) this;
+        }
+        if (type.isInstance(base)) {
+            return (T) base;
+        }
+        return null;
+    }
 
-	protected boolean isCompatible(String accept, String contentType) {
-		String acceptLower = accept.toLowerCase();
-		if (accept.equals(contentType)) {
-			return true;
-		}
-		if (acceptLower.startsWith(contentType) && acceptLower.length() > contentType.length()) {
-			char c = acceptLower.charAt(contentType.length());
-			return c == ' ' || c == ';';
-		}
-		return false;
-	}
+    @Override
+    public Object getRequestAttribute(String name) {
+        return requestAttributes.get(name);
+    }
 
-	@Override
-	public Set<String> getRequestHeaderNames() {
-		return base.getRequestHeaderNames();
-	}
+    @Override
+    public void setRequestAttribute(String name, Object value) {
+        requestAttributes.put(name, value);
+    }
 
-	@Override
-	public String getRequestHeader(String name) {
-		return base.getRequestHeader(name);
-	}
+    @Override
+    public QueryContext getQueryContext() {
+        return queryContext;
+    }
 
-	@Override
-	public Map<String, Set<String>> getRequestParameters() {
-		return base.getRequestParameters();
-	}
+    protected boolean isCompatible(String accept, String contentType) {
+        String acceptLower = accept.toLowerCase();
+        if (accept.equals(contentType)) {
+            return true;
+        }
+        if (acceptLower.startsWith(contentType) && acceptLower.length() > contentType.length()) {
+            char c = acceptLower.charAt(contentType.length());
+            return c == ' ' || c == ';';
+        }
+        return false;
+    }
 
-	@Override
-	public String getPath() {
-		return base.getPath();
-	}
+    @Override
+    public Set<String> getRequestHeaderNames() {
+        return base.getRequestHeaderNames();
+    }
 
-	@Override
-	public String getBaseUrl() {
-		return base.getBaseUrl();
-	}
+    @Override
+    public String getRequestHeader(String name) {
+        return base.getRequestHeader(name);
+    }
 
-	@Override
-	public byte[] getRequestBody() {
-		return base.getRequestBody();
-	}
+    @Override
+    public Map<String, Set<String>> getRequestParameters() {
+        return base.getRequestParameters();
+    }
 
-	@Override
-	public String getMethod() {
-		return base.getMethod();
-	}
+    @Override
+    public String getPath() {
+        return base.getPath();
+    }
 
-	@Override
-	public URI getRequestUri() {
-		return base.getRequestUri();
-	}
+    @Override
+    public String getBaseUrl() {
+        return base.getBaseUrl();
+    }
+
+    @Override
+    public byte[] getRequestBody() {
+        return base.getRequestBody();
+    }
+
+    @Override
+    public String getMethod() {
+        return base.getMethod();
+    }
+
+    @Override
+    public URI getRequestUri() {
+        return base.getRequestUri();
+    }
 
 
-	@Override
-	public HttpResponse getResponse() {
-		return base.getResponse();
-	}
+    @Override
+    public HttpResponse getResponse() {
+        return base.getResponse();
+    }
 
-	@Override
-	public void setResponse(HttpResponse response) {
-		hasResponse = true;
-		base.setResponse(response);
-	}
+    @Override
+    public void setResponse(HttpResponse response) {
+        hasResponse = true;
+        base.setResponse(response);
+    }
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/http/JsonApiRequestProcessor.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/http/JsonApiRequestProcessor.java
@@ -28,175 +28,172 @@ import org.slf4j.LoggerFactory;
 
 public class JsonApiRequestProcessor extends JsonApiRequestProcessorBase implements HttpRequestProcessor {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(JsonApiRequestProcessor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(JsonApiRequestProcessor.class);
 
-	public JsonApiRequestProcessor(Module.ModuleContext moduleContext) {
-		super(moduleContext);
-	}
+    public JsonApiRequestProcessor(Module.ModuleContext moduleContext) {
+        super(moduleContext);
+    }
 
-	public static boolean matchesContentTypeHeader(HttpRequestContext requestContext, boolean acceptPlainJson) {
-		String method = requestContext.getMethod().toUpperCase();
-		boolean isPatch = method.equals(HttpMethod.PATCH.toString());
-		boolean isPost = method.equals(HttpMethod.POST.toString());
-		if (isPatch || isPost) {
-			String contentType = requestContext.getRequestHeader(HttpHeaders.HTTP_CONTENT_TYPE);
-			if (contentType == null || !contentType.startsWith(HttpHeaders.JSONAPI_CONTENT_TYPE)) {
-				LOGGER.debug("not a JSON-API request due to content type {}", contentType);
-				return false;
-			}
-		}
-		return true;
-	}
+    public static boolean matchesContentTypeHeader(HttpRequestContext requestContext, boolean acceptPlainJson) {
+        String method = requestContext.getMethod().toUpperCase();
+        boolean isPatch = method.equals(HttpMethod.PATCH.toString());
+        boolean isPost = method.equals(HttpMethod.POST.toString());
+        if (isPatch || isPost) {
+            String contentType = requestContext.getRequestHeader(HttpHeaders.HTTP_CONTENT_TYPE);
+            if (contentType == null || !contentType.startsWith(HttpHeaders.JSONAPI_CONTENT_TYPE)) {
+                LOGGER.debug("not a JSON-API request due to content type {}", contentType);
+                return false;
+            }
+        }
+        return true;
+    }
 
-	public static boolean matchesAcceptHeader(HttpRequestContext requestContext, boolean acceptPlainJson) {
-		// short-circuit each of the possible Accept MIME type checks, so that we don't keep comparing after we have already
-		// found a match. Intentionally kept as separate statements (instead of a big, chained ||) to ease debugging/maintenance.
-		boolean acceptsJsonApi = requestContext.accepts(HttpHeaders.JSONAPI_CONTENT_TYPE);
-		boolean acceptsAny = acceptsJsonApi || requestContext.acceptsAny();
+    public static boolean matchesAcceptHeader(HttpRequestContext requestContext, boolean acceptPlainJson) {
+        // short-circuit each of the possible Accept MIME type checks, so that we don't keep comparing after we have already
+        // found a match. Intentionally kept as separate statements (instead of a big, chained ||) to ease debugging/maintenance.
+        boolean acceptsJsonApi = requestContext.accepts(HttpHeaders.JSONAPI_CONTENT_TYPE);
+        boolean acceptsAny = acceptsJsonApi || requestContext.acceptsAny();
 
-		boolean acceptsPlainJson = acceptsAny || (acceptPlainJson && requestContext.accepts("application/json"));
-		LOGGER.debug("HTTP Accept header matches: {}", acceptPlainJson);
-		return acceptsPlainJson;
-	}
-
-
-	/**
-	 * Determines whether the supplied HTTP request is considered a JSON-API request.
-	 *
-	 * @param requestContext The HTTP request
-	 * @param acceptPlainJson Whether a plain JSON request should also be considered a JSON-API request
-	 * @return <code>true</code> if it is a JSON-API request; <code>false</code> otherwise
-	 * @since 2.4
-	 */
-	@SuppressWarnings("UnnecessaryLocalVariable")
-	public static boolean isJsonApiRequest(HttpRequestContext requestContext, boolean acceptPlainJson) {
-		return matchesContentTypeHeader(requestContext, acceptPlainJson) && matchesAcceptHeader(requestContext, acceptPlainJson);
-	}
+        boolean acceptsPlainJson = acceptsAny || (acceptPlainJson && requestContext.accepts("application/json"));
+        LOGGER.debug("HTTP Accept header matches: {}", acceptPlainJson);
+        return acceptsPlainJson;
+    }
 
 
-	@Override
-	public boolean supportsAsync() {
-		return true;
-	}
-
-	@Override
-	public boolean accepts(HttpRequestContext context) {
-		boolean acceptingPlainJson = isAcceptingPlainJson();
-		boolean acceptHeaderMatch = matchesAcceptHeader(context, acceptingPlainJson);
-		if (acceptHeaderMatch) {
-			boolean contentTypeHeaderMatch = matchesContentTypeHeader(context, acceptingPlainJson);
-			JsonPath jsonPath = helper.getJsonPath(context);
-			if (jsonPath == null) {
-				LOGGER.debug("not accepted since no matching repository defined for path={}", context.getPath());
-				return false;
-			}
-			if (!contentTypeHeaderMatch) {
-				LOGGER.warn("not accepted due to content-type header mismatch, " + HttpHeaders.JSONAPI_CONTENT_TYPE + " missing?");
-				return false;
-			}
-			LOGGER.debug("accepted to server request: path={}", jsonPath);
-			return true;
-		}
-		return false;
-	}
-
-	@Override
-	public Result<HttpResponse> processAsync(HttpRequestContext requestContext) {
-		Result<HttpResponse> response = checkMethod(requestContext);
-		if (response != null) {
-			return response;
-		}
-
-		String method = requestContext.getMethod();
-		ResultFactory resultFactory = moduleContext.getResultFactory();
-
-		JsonPath jsonPath = helper.getJsonPath(requestContext);
-		LOGGER.debug("processing JSON API request path={}, method={}", jsonPath, method);
-		Map<String, Set<String>> parameters = requestContext.getRequestParameters();
-
-		if (jsonPath instanceof ActionPath) {
-			// inital implementation, has to improve
-			String path = requestContext.getPath();
-			RequestDispatcher requestDispatcher = moduleContext.getRequestDispatcher();
-			requestDispatcher.dispatchAction(path, method, parameters);
-			return null;
-		}
-		else if (jsonPath != null) {
-			Document requestDocument;
-			try {
-				requestDocument = getRequestDocument(requestContext);
-			}
-			catch (JsonProcessingException e) {
-				return resultFactory.just(getErrorResponse(e));
-			}
-			QueryContext queryContext = requestContext.getQueryContext();
-			return processAsync(jsonPath, method, parameters, requestDocument, queryContext)
-					.map(this::toHttpResponse);
-		}
-		return resultFactory.just(buildMethodNotAllowedResponse(method));
-	}
-
-	private Result<HttpResponse> checkMethod(HttpRequestContext requestContext) {
-		String method = requestContext.getMethod();
-		boolean isPatch = method.equals(HttpMethod.PATCH.toString());
-		boolean isPost = method.equals(HttpMethod.POST.toString());
-		boolean isGet = method.equals(HttpMethod.GET.toString());
-		boolean isDelete = method.equals(HttpMethod.DELETE.toString());
-		boolean acceptsMethod = isGet || isDelete || isPatch || isPost;
-		if (!acceptsMethod) {
-			ResultFactory resultFactory = moduleContext.getResultFactory();
-			return resultFactory.just(buildMethodNotAllowedResponse(method));
-		}
-		return null;
-	}
+    /**
+     * Determines whether the supplied HTTP request is considered a JSON-API request.
+     *
+     * @param requestContext  The HTTP request
+     * @param acceptPlainJson Whether a plain JSON request should also be considered a JSON-API request
+     * @return <code>true</code> if it is a JSON-API request; <code>false</code> otherwise
+     * @since 2.4
+     */
+    @SuppressWarnings("UnnecessaryLocalVariable")
+    public static boolean isJsonApiRequest(HttpRequestContext requestContext, boolean acceptPlainJson) {
+        return matchesContentTypeHeader(requestContext, acceptPlainJson) && matchesAcceptHeader(requestContext, acceptPlainJson);
+    }
 
 
-	public Result<Response> processAsync(JsonPath jsonPath, String method, Map<String, Set<String>> parameters,
-			Document requestDocument, QueryContext queryContext) {
-		try {
-			ResultFactory resultFactory = moduleContext.getResultFactory();
-			QueryAdapter queryAdapter = helper.toQueryAdapter(parameters, jsonPath, queryContext);
+    @Override
+    public boolean supportsAsync() {
+        return true;
+    }
 
-			if (resultFactory instanceof ImmediateResultFactory) {
-				LOGGER.debug("processing synchronously");
-				// not that document filters are not compatible with async programming
-				DocumentFilterContextImpl filterContext =
-						new DocumentFilterContextImpl(jsonPath, queryAdapter, requestDocument, method);
-				try {
-					DocumentFilterChain filterChain = getFilterChain(jsonPath, method);
-					Response response = filterChain.doFilter(filterContext);
-					return resultFactory.just(response);
-				}
-				catch (Exception e) {
-					Response response = toErrorResponse(e);
-					return resultFactory.just(response);
-				}
-			}
-			else {
-				LOGGER.debug("processing asynchronously");
-				ControllerRegistry controllerRegistry = moduleContext.getModuleRegistry().getControllerRegistry();
-				Controller controller = controllerRegistry.getController(jsonPath, method);
-				Result<Response> responseResult =
-						controller.handleAsync(jsonPath, queryAdapter, requestDocument);
-				return responseResult.onErrorResume(this::toErrorResponse);
-			}
-		}
-		catch (Exception e) {
-			ResultFactory resultFactory = moduleContext.getResultFactory();
-			return resultFactory.just(toErrorResponse(e));
-		}
-	}
+    @Override
+    public boolean accepts(HttpRequestContext context) {
+        boolean acceptingPlainJson = isAcceptingPlainJson();
+        boolean acceptHeaderMatch = matchesAcceptHeader(context, acceptingPlainJson);
+        if (acceptHeaderMatch) {
+            boolean contentTypeHeaderMatch = matchesContentTypeHeader(context, acceptingPlainJson);
+            JsonPath jsonPath = helper.getJsonPath(context);
+            if (jsonPath == null) {
+                LOGGER.debug("not accepted since no matching repository defined for path={}", context.getPath());
+                return false;
+            }
+            if (!contentTypeHeaderMatch) {
+                LOGGER.warn("not accepted due to content-type header mismatch, " + HttpHeaders.JSONAPI_CONTENT_TYPE + " missing?");
+                return false;
+            }
+            LOGGER.debug("accepted to server request: path={}", jsonPath);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Result<HttpResponse> processAsync(HttpRequestContext requestContext) {
+        Result<HttpResponse> response = checkMethod(requestContext);
+        if (response != null) {
+            return response;
+        }
+
+        String method = requestContext.getMethod();
+        ResultFactory resultFactory = moduleContext.getResultFactory();
+
+        JsonPath jsonPath = helper.getJsonPath(requestContext);
+        LOGGER.debug("processing JSON API request path={}, method={}", jsonPath, method);
+        Map<String, Set<String>> parameters = requestContext.getRequestParameters();
+
+        if (jsonPath instanceof ActionPath) {
+            // inital implementation, has to improve
+            String path = requestContext.getPath();
+            RequestDispatcher requestDispatcher = moduleContext.getRequestDispatcher();
+            requestDispatcher.dispatchAction(path, method, parameters);
+            return null;
+        } else if (jsonPath != null) {
+            Document requestDocument;
+            try {
+                requestDocument = getRequestDocument(requestContext);
+            } catch (JsonProcessingException e) {
+                return resultFactory.just(getErrorResponse(e));
+            }
+            QueryContext queryContext = requestContext.getQueryContext();
+            return processAsync(jsonPath, method, parameters, requestDocument, queryContext)
+                    .map(this::toHttpResponse);
+        }
+        return resultFactory.just(buildMethodNotAllowedResponse(method));
+    }
+
+    private Result<HttpResponse> checkMethod(HttpRequestContext requestContext) {
+        String method = requestContext.getMethod();
+        boolean isPatch = method.equals(HttpMethod.PATCH.toString());
+        boolean isPost = method.equals(HttpMethod.POST.toString());
+        boolean isGet = method.equals(HttpMethod.GET.toString());
+        boolean isDelete = method.equals(HttpMethod.DELETE.toString());
+        boolean acceptsMethod = isGet || isDelete || isPatch || isPost;
+        if (!acceptsMethod) {
+            ResultFactory resultFactory = moduleContext.getResultFactory();
+            return resultFactory.just(buildMethodNotAllowedResponse(method));
+        }
+        return null;
+    }
+
+
+    public Result<Response> processAsync(JsonPath jsonPath, String method, Map<String, Set<String>> parameters,
+                                         Document requestDocument, QueryContext queryContext) {
+        try {
+            ResultFactory resultFactory = moduleContext.getResultFactory();
+            QueryAdapter queryAdapter = helper.toQueryAdapter(parameters, jsonPath, queryContext);
+
+            LOGGER.debug("using requestVersion={}", queryContext.getRequestVersion());
+
+            if (resultFactory instanceof ImmediateResultFactory) {
+                LOGGER.debug("processing synchronously");
+                // not that document filters are not compatible with async programming
+                DocumentFilterContextImpl filterContext =
+                        new DocumentFilterContextImpl(jsonPath, queryAdapter, requestDocument, method);
+                try {
+                    DocumentFilterChain filterChain = getFilterChain(jsonPath, method);
+                    Response response = filterChain.doFilter(filterContext);
+                    return resultFactory.just(response);
+                } catch (Exception e) {
+                    Response response = toErrorResponse(e);
+                    return resultFactory.just(response);
+                }
+            } else {
+                LOGGER.debug("processing asynchronously");
+                ControllerRegistry controllerRegistry = moduleContext.getModuleRegistry().getControllerRegistry();
+                Controller controller = controllerRegistry.getController(jsonPath, method);
+                Result<Response> responseResult =
+                        controller.handleAsync(jsonPath, queryAdapter, requestDocument);
+                return responseResult.onErrorResume(this::toErrorResponse);
+            }
+        } catch (Exception e) {
+            ResultFactory resultFactory = moduleContext.getResultFactory();
+            return resultFactory.just(toErrorResponse(e));
+        }
+    }
 
     private Response toErrorResponse(Throwable e) {
         return moduleContext.getExceptionMapperRegistry().toErrorResponse(e);
     }
 
-	protected DocumentFilterChain getFilterChain(JsonPath jsonPath, String method) {
-		ControllerRegistry controllerRegistry = moduleContext.getModuleRegistry().getControllerRegistry();
-		Controller controller = controllerRegistry.getController(jsonPath, method);
-		return new DocumentFilterChainImpl(moduleContext, controller);
+    protected DocumentFilterChain getFilterChain(JsonPath jsonPath, String method) {
+        ControllerRegistry controllerRegistry = moduleContext.getModuleRegistry().getControllerRegistry();
+        Controller controller = controllerRegistry.getController(jsonPath, method);
+        return new DocumentFilterChainImpl(moduleContext, controller);
 
-	}
+    }
 
 
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/http/JsonApiRequestProcessorHelper.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/http/JsonApiRequestProcessorHelper.java
@@ -1,8 +1,5 @@
 package io.crnk.core.engine.internal.http;
 
-import java.util.Map;
-import java.util.Set;
-
 import io.crnk.core.engine.http.HttpRequestContext;
 import io.crnk.core.engine.information.resource.ResourceField;
 import io.crnk.core.engine.information.resource.ResourceInformation;
@@ -18,42 +15,46 @@ import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.module.Module;
 
+import java.util.Map;
+import java.util.Set;
+
 public class JsonApiRequestProcessorHelper {
 
-	private Module.ModuleContext moduleContext;
+    private Module.ModuleContext moduleContext;
 
-	public JsonApiRequestProcessorHelper(Module.ModuleContext moduleContext) {
-		this.moduleContext = moduleContext;
-	}
+    public JsonApiRequestProcessorHelper(Module.ModuleContext moduleContext) {
+        this.moduleContext = moduleContext;
+    }
 
-	public JsonPath getJsonPath(HttpRequestContext requestContext) {
-		ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
-		TypeParser typeParser = moduleContext.getTypeParser();
-		PathBuilder pathBuilder = new PathBuilder(resourceRegistry, typeParser);
-		String path = requestContext.getPath();
-		return pathBuilder.build(path);
-	}
+    public JsonPath getJsonPath(HttpRequestContext requestContext) {
+        ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
+        TypeParser typeParser = moduleContext.getTypeParser();
 
-	public QueryAdapter toQueryAdapter(Map<String, Set<String>> parameters, JsonPath jsonPath, QueryContext queryContext) {
-		ResourceInformation resourceInformation = getRequestedResource(jsonPath);
-		QueryAdapterBuilder queryAdapterBuilder = moduleContext.getModuleRegistry().getQueryAdapterBuilder();
-		return queryAdapterBuilder.build(resourceInformation, parameters, queryContext);
-	}
+        PathBuilder pathBuilder = new PathBuilder(resourceRegistry, typeParser);
+        String path = requestContext.getPath();
+        QueryContext queryContext = requestContext.getQueryContext();
+        return pathBuilder.build(path, queryContext);
+    }
+
+    public QueryAdapter toQueryAdapter(Map<String, Set<String>> parameters, JsonPath jsonPath, QueryContext queryContext) {
+        ResourceInformation resourceInformation = getRequestedResource(jsonPath);
+        QueryAdapterBuilder queryAdapterBuilder = moduleContext.getModuleRegistry().getQueryAdapterBuilder();
+        return queryAdapterBuilder.build(resourceInformation, parameters, queryContext);
+    }
 
 
-	protected ResourceInformation getRequestedResource(JsonPath jsonPath) {
-		ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
-		RegistryEntry registryEntry = jsonPath.getRootEntry();
+    protected ResourceInformation getRequestedResource(JsonPath jsonPath) {
+        ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
+        RegistryEntry registryEntry = jsonPath.getRootEntry();
 
-		ResourceField field = (jsonPath instanceof RelationshipsPath) ? ((RelationshipsPath) jsonPath).getRelationship()
-				: jsonPath instanceof FieldPath ? ((FieldPath) jsonPath).getField() : null;
-		if (field != null) {
-			String oppositeResourceType = field.getOppositeResourceType();
-			return resourceRegistry.getEntry(oppositeResourceType).getResourceInformation();
-		}
-		else {
-			return registryEntry.getResourceInformation();
-		}
-	}
+        ResourceField field = (jsonPath instanceof RelationshipsPath) ? ((RelationshipsPath) jsonPath).getRelationship()
+                : jsonPath instanceof FieldPath ? ((FieldPath) jsonPath).getField() : null;
+        if (field != null) {
+            String oppositeResourceType = field.getOppositeResourceType();
+            return resourceRegistry.getEntry(oppositeResourceType).getResourceInformation();
+        } else {
+            return registryEntry.getResourceInformation();
+        }
+    }
 
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/information/DefaultInformationBuilder.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/information/DefaultInformationBuilder.java
@@ -11,6 +11,7 @@ import io.crnk.core.engine.information.resource.ResourceFieldAccessor;
 import io.crnk.core.engine.information.resource.ResourceFieldType;
 import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.information.resource.ResourceValidator;
+import io.crnk.core.engine.information.resource.VersionRange;
 import io.crnk.core.engine.internal.information.repository.RelationshipRepositoryInformationImpl;
 import io.crnk.core.engine.internal.information.repository.ResourceRepositoryInformationImpl;
 import io.crnk.core.engine.internal.information.resource.ResourceFieldImpl;
@@ -150,6 +151,8 @@ public class DefaultInformationBuilder implements InformationBuilder {
 
         private Class<? extends PagingSpec> pagingSpecType;
 
+        private VersionRange versionRange = VersionRange.UNBOUNDED;
+
         private ResourceFieldAccess access = new ResourceFieldAccess(true, true, true, true, true, true);
 
         @Override
@@ -161,6 +164,7 @@ public class DefaultInformationBuilder implements InformationBuilder {
             idStringMapper = information.getIdStringMapper();
             validator = information.getValidator();
             access = information.getAccess();
+            versionRange = information.getVersionRange();
             for (ResourceField fromField : information.getFields()) {
                 DefaultField field = new DefaultField();
                 field.from(fromField);
@@ -222,6 +226,12 @@ public class DefaultInformationBuilder implements InformationBuilder {
             return this;
         }
 
+        @Override
+        public ResourceInformationBuilder versionRange(VersionRange versionRange) {
+            this.versionRange = versionRange;
+            return this;
+        }
+
         public ResourceInformation build() {
 
             List<ResourceField> fieldImpls = new ArrayList<>();
@@ -233,6 +243,7 @@ public class DefaultInformationBuilder implements InformationBuilder {
                     new ResourceInformation(typeParser, implementationType, resourceType, resourcePath, superResourceType,
                             fieldImpls, pagingSpecType);
             information.setAccess(access);
+            information.setVersionRange(versionRange);
             if (validator != null) {
                 information.setValidator(validator);
             }
@@ -263,6 +274,8 @@ public class DefaultInformationBuilder implements InformationBuilder {
 
         private JsonIncludeStrategy jsonIncludeStrategy = JsonIncludeStrategy.DEFAULT;
 
+        private VersionRange versionRange = VersionRange.UNBOUNDED;
+
         private String oppositeName;
 
         private ResourceFieldAccessor accessor;
@@ -292,6 +305,7 @@ public class DefaultInformationBuilder implements InformationBuilder {
             access = field.getAccess();
             serializeType = field.getSerializeType();
             jsonIncludeStrategy = field.getJsonIncludeStrategy();
+            versionRange = field.getVersionRange();
             mappedBy = field.isMappedBy();
             if (fieldType == ResourceFieldType.RELATIONSHIP) {
                 relationshipRepositoryBehavior = field.getRelationshipRepositoryBehavior();
@@ -309,7 +323,6 @@ public class DefaultInformationBuilder implements InformationBuilder {
 
 
         public ResourceField build() {
-
             if (oppositeResourceType == null && fieldType == ResourceFieldType.RELATIONSHIP) {
                 // TODO consider separating informationBuilder from resourceType extraction
                 Class<?> elementType = ClassUtils.getRawType(ClassUtils.getElementType(genericType));
@@ -324,6 +337,7 @@ public class DefaultInformationBuilder implements InformationBuilder {
                     lookupIncludeBehavior,
                     access, idName, idType, idAccessor, relationshipRepositoryBehavior, this.patchStrategy);
             impl.setMappedBy(mappedBy);
+            impl.setVersionRange(versionRange);
             if (accessor != null) {
                 impl.setAccessor(accessor);
             }
@@ -444,6 +458,12 @@ public class DefaultInformationBuilder implements InformationBuilder {
         @Override
         public FieldInformationBuilder setMappedBy(boolean mappedBy) {
             this.mappedBy = mappedBy;
+            return this;
+        }
+
+        @Override
+        public FieldInformationBuilder versionRange(VersionRange versionRange) {
+            this.versionRange = versionRange;
             return this;
         }
 

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/DefaultResourceFieldInformationProvider.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/DefaultResourceFieldInformationProvider.java
@@ -1,14 +1,10 @@
 package io.crnk.core.engine.internal.information.resource;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.util.Optional;
-
 import io.crnk.core.engine.information.bean.BeanAttributeInformation;
 import io.crnk.core.engine.information.resource.ResourceFieldInformationProvider;
 import io.crnk.core.engine.information.resource.ResourceFieldType;
 import io.crnk.core.engine.information.resource.ResourceInformationProviderContext;
+import io.crnk.core.engine.information.resource.VersionRange;
 import io.crnk.core.engine.internal.utils.StringUtils;
 import io.crnk.core.resource.ResourceTypeHolder;
 import io.crnk.core.resource.annotations.JsonApiField;
@@ -17,11 +13,17 @@ import io.crnk.core.resource.annotations.JsonApiLinksInformation;
 import io.crnk.core.resource.annotations.JsonApiMetaInformation;
 import io.crnk.core.resource.annotations.JsonApiRelation;
 import io.crnk.core.resource.annotations.JsonApiRelationId;
+import io.crnk.core.resource.annotations.JsonApiVersion;
 import io.crnk.core.resource.annotations.JsonIncludeStrategy;
 import io.crnk.core.resource.annotations.LookupIncludeBehavior;
 import io.crnk.core.resource.annotations.PatchStrategy;
 import io.crnk.core.resource.annotations.RelationshipRepositoryBehavior;
 import io.crnk.core.resource.annotations.SerializeType;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Optional;
 
 /**
  * Process the Crnk JSON API annotations.
@@ -29,181 +31,191 @@ import io.crnk.core.resource.annotations.SerializeType;
 public class DefaultResourceFieldInformationProvider implements ResourceFieldInformationProvider {
 
 
-	@Override
-	public Optional<Boolean> useFieldType(BeanAttributeInformation attributeDesc) {
-		Field field = attributeDesc.getField();
-		if (field != null) {
-			for (Annotation annotation : field.getAnnotations()) {
-				if (annotation.annotationType() == JsonApiId.class
-						|| annotation.annotationType() == JsonApiRelation.class
-						|| annotation.annotationType() == JsonApiField.class
-						|| annotation.annotationType() == JsonApiMetaInformation.class
-						|| annotation.annotationType() == JsonApiLinksInformation.class) {
-					return Optional.of(true);
-				}
-			}
-		}
-		return Optional.empty();
-	}
+    @Override
+    public Optional<Boolean> useFieldType(BeanAttributeInformation attributeDesc) {
+        Field field = attributeDesc.getField();
+        if (field != null) {
+            for (Annotation annotation : field.getAnnotations()) {
+                if (annotation.annotationType() == JsonApiId.class
+                        || annotation.annotationType() == JsonApiRelation.class
+                        || annotation.annotationType() == JsonApiField.class
+                        || annotation.annotationType() == JsonApiMetaInformation.class
+                        || annotation.annotationType() == JsonApiLinksInformation.class) {
+                    return Optional.of(true);
+                }
+            }
+        }
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<SerializeType> getSerializeType(BeanAttributeInformation attributeDesc) {
+    @Override
+    public Optional<SerializeType> getSerializeType(BeanAttributeInformation attributeDesc) {
 
-		Optional<JsonApiRelation> jsonApiRelation = attributeDesc.getAnnotation(JsonApiRelation.class);
-		if (jsonApiRelation.isPresent()) {
-			return Optional.of(jsonApiRelation.get().serialize());
-		}
-		return Optional.empty();
-	}
+        Optional<JsonApiRelation> jsonApiRelation = attributeDesc.getAnnotation(JsonApiRelation.class);
+        if (jsonApiRelation.isPresent()) {
+            return Optional.of(jsonApiRelation.get().serialize());
+        }
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<JsonIncludeStrategy> getJsonIncludeStrategy(BeanAttributeInformation attributeDesc) {
-		return Optional.empty();
-	}
+    @Override
+    public Optional<JsonIncludeStrategy> getJsonIncludeStrategy(BeanAttributeInformation attributeDesc) {
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<RelationshipRepositoryBehavior> getRelationshipRepositoryBehavior(BeanAttributeInformation attributeDesc) {
-		Optional<JsonApiRelation> jsonApiRelation = attributeDesc.getAnnotation(JsonApiRelation.class);
-		if (jsonApiRelation.isPresent()) {
-			return Optional.of(jsonApiRelation.get().repositoryBehavior());
-		}
-		return Optional.empty();
-	}
+    @Override
+    public Optional<RelationshipRepositoryBehavior> getRelationshipRepositoryBehavior(BeanAttributeInformation attributeDesc) {
+        Optional<JsonApiRelation> jsonApiRelation = attributeDesc.getAnnotation(JsonApiRelation.class);
+        if (jsonApiRelation.isPresent()) {
+            return Optional.of(jsonApiRelation.get().repositoryBehavior());
+        }
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<PatchStrategy> getPatchStrategy(BeanAttributeInformation attributeDesc) {
-		Optional<JsonApiField> annotation = attributeDesc.getAnnotation(JsonApiField.class);
-		if (annotation.isPresent()) {
-			return Optional.of(annotation.get().patchStrategy());
-		}
-		return Optional.empty();
-	}
+    @Override
+    public Optional<PatchStrategy> getPatchStrategy(BeanAttributeInformation attributeDesc) {
+        Optional<JsonApiField> annotation = attributeDesc.getAnnotation(JsonApiField.class);
+        if (annotation.isPresent()) {
+            return Optional.of(annotation.get().patchStrategy());
+        }
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<String> getMappedBy(BeanAttributeInformation attributeDesc) {
-		Optional<JsonApiRelation> jsonApiRelation = attributeDesc.getAnnotation(JsonApiRelation.class);
-		if (jsonApiRelation.isPresent()) {
-			return Optional.of(jsonApiRelation.get().mappedBy());
-		}
-		return Optional.empty();
-	}
+    @Override
+    public Optional<String> getMappedBy(BeanAttributeInformation attributeDesc) {
+        Optional<JsonApiRelation> jsonApiRelation = attributeDesc.getAnnotation(JsonApiRelation.class);
+        if (jsonApiRelation.isPresent()) {
+            return Optional.of(jsonApiRelation.get().mappedBy());
+        }
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<LookupIncludeBehavior> getLookupIncludeBehavior(BeanAttributeInformation attributeDesc) {
-		Optional<JsonApiRelation> jsonApiRelation = attributeDesc.getAnnotation(JsonApiRelation.class);
-		if (jsonApiRelation.isPresent()) {
-			return Optional.of(jsonApiRelation.get().lookUp());
-		}
-		return Optional.empty();
-	}
+    @Override
+    public Optional<VersionRange> getVersionRange(BeanAttributeInformation attributeDesc) {
+        Optional<JsonApiVersion> annotation = attributeDesc.getAnnotation(JsonApiVersion.class);
+        if (annotation.isPresent()) {
+            JsonApiVersion jsonApiVersion = annotation.get();
+            return Optional.of(VersionRange.of(jsonApiVersion.min(), jsonApiVersion.max()));
+        }
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<String> getOppositeName(BeanAttributeInformation attributeDesc) {
-		Optional<JsonApiRelation> jsonApiRelation = attributeDesc.getAnnotation(JsonApiRelation.class);
-		if (jsonApiRelation.isPresent()) {
-			return Optional.ofNullable(StringUtils.emptyToNull(jsonApiRelation.get().opposite()));
-		}
-		return Optional.empty();
-	}
+    @Override
+    public Optional<LookupIncludeBehavior> getLookupIncludeBehavior(BeanAttributeInformation attributeDesc) {
+        Optional<JsonApiRelation> jsonApiRelation = attributeDesc.getAnnotation(JsonApiRelation.class);
+        if (jsonApiRelation.isPresent()) {
+            return Optional.of(jsonApiRelation.get().lookUp());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> getOppositeName(BeanAttributeInformation attributeDesc) {
+        Optional<JsonApiRelation> jsonApiRelation = attributeDesc.getAnnotation(JsonApiRelation.class);
+        if (jsonApiRelation.isPresent()) {
+            return Optional.ofNullable(StringUtils.emptyToNull(jsonApiRelation.get().opposite()));
+        }
+        return Optional.empty();
+    }
 
 
-	@Override
-	public void init(ResourceInformationProviderContext context) {
-		// nothing to do
-	}
+    @Override
+    public void init(ResourceInformationProviderContext context) {
+        // nothing to do
+    }
 
-	@Override
-	public Optional<Boolean> isIgnored(BeanAttributeInformation attributeDesc) {
-		if (attributeDesc.getName().equals(ResourceTypeHolder.TYPE_ATTRIBUTE) && ResourceTypeHolder.class.isAssignableFrom(attributeDesc.getBeanInformation().getImplementationClass())) {
-			return Optional.of(true);
-		}
+    @Override
+    public Optional<Boolean> isIgnored(BeanAttributeInformation attributeDesc) {
+        if (attributeDesc.getName().equals(ResourceTypeHolder.TYPE_ATTRIBUTE) && ResourceTypeHolder.class.isAssignableFrom(attributeDesc.getBeanInformation().getImplementationClass())) {
+            return Optional.of(true);
+        }
 
-		Field field = attributeDesc.getField();
-		boolean isTransient = field != null && Modifier.isTransient(field.getModifiers());
-		boolean relationshipIdField = attributeDesc.getAnnotation(JsonApiRelationId.class).isPresent();
-		boolean idField = attributeDesc.getAnnotation(JsonApiId.class).isPresent();
-		if (isTransient || relationshipIdField && !idField) {
-			return Optional.of(true);
-		}
-		return Optional.empty();
-	}
+        Field field = attributeDesc.getField();
+        boolean isTransient = field != null && Modifier.isTransient(field.getModifiers());
+        boolean relationshipIdField = attributeDesc.getAnnotation(JsonApiRelationId.class).isPresent();
+        boolean idField = attributeDesc.getAnnotation(JsonApiId.class).isPresent();
+        if (isTransient || relationshipIdField && !idField) {
+            return Optional.of(true);
+        }
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<String> getJsonName(BeanAttributeInformation attributeDesc) {
-		return Optional.empty();
-	}
+    @Override
+    public Optional<String> getJsonName(BeanAttributeInformation attributeDesc) {
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<Boolean> isPostable(BeanAttributeInformation attributeDesc) {
-		Optional<JsonApiField> annotation = attributeDesc.getAnnotation(JsonApiField.class);
-		if (annotation.isPresent()) {
-			return Optional.of(annotation.get().postable());
-		}
-		return Optional.empty();
-	}
+    @Override
+    public Optional<Boolean> isPostable(BeanAttributeInformation attributeDesc) {
+        Optional<JsonApiField> annotation = attributeDesc.getAnnotation(JsonApiField.class);
+        if (annotation.isPresent()) {
+            return Optional.of(annotation.get().postable());
+        }
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<Boolean> isDeletable(BeanAttributeInformation attributeDesc) {
-		Optional<JsonApiField> annotation = attributeDesc.getAnnotation(JsonApiField.class);
-		if (annotation.isPresent()) {
-			return Optional.of(annotation.get().deletable());
-		}
-		return Optional.empty();
-	}
+    @Override
+    public Optional<Boolean> isDeletable(BeanAttributeInformation attributeDesc) {
+        Optional<JsonApiField> annotation = attributeDesc.getAnnotation(JsonApiField.class);
+        if (annotation.isPresent()) {
+            return Optional.of(annotation.get().deletable());
+        }
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<Boolean> isPatchable(BeanAttributeInformation attributeDesc) {
-		Optional<JsonApiField> annotation = attributeDesc.getAnnotation(JsonApiField.class);
-		if (annotation.isPresent()) {
-			return Optional.of(annotation.get().patchable());
-		}
-		return Optional.empty();
-	}
+    @Override
+    public Optional<Boolean> isPatchable(BeanAttributeInformation attributeDesc) {
+        Optional<JsonApiField> annotation = attributeDesc.getAnnotation(JsonApiField.class);
+        if (annotation.isPresent()) {
+            return Optional.of(annotation.get().patchable());
+        }
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<Boolean> isReadable(final BeanAttributeInformation attributeDesc) {
-		Optional<JsonApiField> annotation = attributeDesc.getAnnotation(JsonApiField.class);
-		if (annotation.isPresent()) {
-			return Optional.of(annotation.get().readable());
-		}
-		return Optional.empty();
-	}
+    @Override
+    public Optional<Boolean> isReadable(final BeanAttributeInformation attributeDesc) {
+        Optional<JsonApiField> annotation = attributeDesc.getAnnotation(JsonApiField.class);
+        if (annotation.isPresent()) {
+            return Optional.of(annotation.get().readable());
+        }
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<Boolean> isSortable(BeanAttributeInformation attributeDesc) {
-		Optional<JsonApiField> annotation = attributeDesc.getAnnotation(JsonApiField.class);
-		if (annotation.isPresent()) {
-			return Optional.of(annotation.get().sortable());
-		}
-		return Optional.empty();
-	}
+    @Override
+    public Optional<Boolean> isSortable(BeanAttributeInformation attributeDesc) {
+        Optional<JsonApiField> annotation = attributeDesc.getAnnotation(JsonApiField.class);
+        if (annotation.isPresent()) {
+            return Optional.of(annotation.get().sortable());
+        }
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<Boolean> isFilterable(BeanAttributeInformation attributeDesc) {
-		Optional<JsonApiField> annotation = attributeDesc.getAnnotation(JsonApiField.class);
-		if (annotation.isPresent()) {
-			return Optional.of(annotation.get().filterable());
-		}
-		return Optional.empty();
-	}
+    @Override
+    public Optional<Boolean> isFilterable(BeanAttributeInformation attributeDesc) {
+        Optional<JsonApiField> annotation = attributeDesc.getAnnotation(JsonApiField.class);
+        if (annotation.isPresent()) {
+            return Optional.of(annotation.get().filterable());
+        }
+        return Optional.empty();
+    }
 
-	@Override
-	public Optional<ResourceFieldType> getFieldType(BeanAttributeInformation attributeDesc) {
-		if (attributeDesc.getAnnotation(JsonApiId.class).isPresent()) {
-			return Optional.of(ResourceFieldType.ID);
-		}
+    @Override
+    public Optional<ResourceFieldType> getFieldType(BeanAttributeInformation attributeDesc) {
+        if (attributeDesc.getAnnotation(JsonApiId.class).isPresent()) {
+            return Optional.of(ResourceFieldType.ID);
+        }
 
-		if (attributeDesc.getAnnotation(JsonApiRelation.class).isPresent()) {
-			return Optional.of(ResourceFieldType.RELATIONSHIP);
-		}
+        if (attributeDesc.getAnnotation(JsonApiRelation.class).isPresent()) {
+            return Optional.of(ResourceFieldType.RELATIONSHIP);
+        }
 
-		if (attributeDesc.getAnnotation(JsonApiMetaInformation.class).isPresent()) {
-			return Optional.of(ResourceFieldType.META_INFORMATION);
-		}
+        if (attributeDesc.getAnnotation(JsonApiMetaInformation.class).isPresent()) {
+            return Optional.of(ResourceFieldType.META_INFORMATION);
+        }
 
-		if (attributeDesc.getAnnotation(JsonApiLinksInformation.class).isPresent()) {
-			return Optional.of(ResourceFieldType.LINKS_INFORMATION);
-		}
-		return Optional.empty();
-	}
+        if (attributeDesc.getAnnotation(JsonApiLinksInformation.class).isPresent()) {
+            return Optional.of(ResourceFieldType.LINKS_INFORMATION);
+        }
+        return Optional.empty();
+    }
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/DefaultResourceInformationProvider.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/DefaultResourceInformationProvider.java
@@ -1,12 +1,11 @@
 package io.crnk.core.engine.internal.information.resource;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.crnk.core.engine.information.resource.ResourceField;
 import io.crnk.core.engine.information.resource.ResourceFieldAccess;
 import io.crnk.core.engine.information.resource.ResourceFieldInformationProvider;
 import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.information.resource.VersionRange;
 import io.crnk.core.engine.internal.utils.ClassUtils;
-import io.crnk.core.engine.internal.utils.FieldOrderedComparator;
 import io.crnk.core.engine.internal.utils.StringUtils;
 import io.crnk.core.engine.properties.PropertiesProvider;
 import io.crnk.core.exception.RepositoryAnnotationNotFoundException;
@@ -14,13 +13,13 @@ import io.crnk.core.exception.ResourceIdNotFoundException;
 import io.crnk.core.queryspec.pagingspec.PagingBehavior;
 import io.crnk.core.queryspec.pagingspec.PagingSpec;
 import io.crnk.core.resource.annotations.JsonApiResource;
+import io.crnk.core.resource.annotations.JsonApiVersion;
 import io.crnk.core.utils.Prioritizable;
 
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * A builder which creates ResourceInformation instances of a specific class. It
@@ -88,10 +87,19 @@ public class DefaultResourceInformationProvider extends ResourceInformationProvi
                 resourceClass, resourceType, resourcePath, superResourceType, instanceBuilder, resourceFields,
                 pagingSpec);
         information.setAccess(resourceAccess);
+        information.setVersionRange(getVersionRange(resourceClass));
         if (!allowNonResourceBaseClass && information.getIdField() == null) {
             throw new ResourceIdNotFoundException(resourceClass.getCanonicalName());
         }
         return information;
+    }
+
+    private VersionRange getVersionRange(Class<?> resourceClass) {
+        JsonApiVersion annotation = resourceClass.getAnnotation(JsonApiVersion.class);
+        if (annotation != null) {
+            return VersionRange.of(annotation.min(), annotation.max());
+        }
+        return VersionRange.UNBOUNDED;
     }
 
 

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/ResourceFieldImpl.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/ResourceFieldImpl.java
@@ -7,6 +7,7 @@ import io.crnk.core.engine.information.resource.ResourceFieldAccess;
 import io.crnk.core.engine.information.resource.ResourceFieldAccessor;
 import io.crnk.core.engine.information.resource.ResourceFieldType;
 import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.information.resource.VersionRange;
 import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.resource.annotations.JsonIncludeStrategy;
@@ -57,6 +58,8 @@ public class ResourceFieldImpl implements ResourceField {
     private PatchStrategy patchStrategy;
 
     private boolean mappedBy;
+
+    private VersionRange versionRange = VersionRange.UNBOUNDED;
 
     public ResourceFieldImpl(String jsonName, String underlyingName, ResourceFieldType resourceFieldType, Class<?> type,
                              Type genericType, String oppositeResourceType) {
@@ -124,10 +127,6 @@ public class ResourceFieldImpl implements ResourceField {
     }
 
     /**
-     * See also
-     * {@link io.crnk.core.resource.annotations.JsonApiLookupIncludeAutomatically}
-     * }
-     *
      * @return if lookup should be performed
      */
     public LookupIncludeBehavior getLookupIncludeBehavior() {
@@ -185,12 +184,12 @@ public class ResourceFieldImpl implements ResourceField {
             return false;
         }
         ResourceFieldImpl that = (ResourceFieldImpl) o;
-        return Objects.equals(jsonName, that.jsonName) && resourceInformation == that.resourceInformation;
+        return Objects.equals(underlyingName, that.underlyingName) && resourceInformation == that.resourceInformation;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(jsonName, resourceInformation);
+        return Objects.hash(underlyingName, resourceInformation);
     }
 
     /**
@@ -357,5 +356,14 @@ public class ResourceFieldImpl implements ResourceField {
     @Override
     public PatchStrategy getPatchStrategy() {
         return patchStrategy;
+    }
+
+    @Override
+    public VersionRange getVersionRange() {
+        return versionRange;
+    }
+
+    public void setVersionRange(VersionRange versionRange) {
+        this.versionRange = versionRange;
     }
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/ResourceInformationProviderBase.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/information/resource/ResourceInformationProviderBase.java
@@ -11,6 +11,7 @@ import io.crnk.core.engine.information.resource.ResourceFieldInformationProvider
 import io.crnk.core.engine.information.resource.ResourceFieldType;
 import io.crnk.core.engine.information.resource.ResourceInformationProvider;
 import io.crnk.core.engine.information.resource.ResourceInformationProviderContext;
+import io.crnk.core.engine.information.resource.VersionRange;
 import io.crnk.core.engine.internal.document.mapper.IncludeLookupUtil;
 import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.core.engine.internal.utils.FieldOrderedComparator;
@@ -150,6 +151,7 @@ public abstract class ResourceInformationProviderBase implements ResourceInforma
         fieldBuilder.jsonIncludeStrategy(getJsonIncludeStrategy(attributeDesc));
         fieldBuilder.serializeType(getSerializeType(attributeDesc, fieldType));
         fieldBuilder.relationshipRepositoryBehavior(getRelationshipRepositoryBehavior(attributeDesc));
+        fieldBuilder.versionRange(getVersionRange(attributeDesc));
 
         Type genericType;
         if (useFieldType(attributeDesc)) {
@@ -202,6 +204,16 @@ public abstract class ResourceInformationProviderBase implements ResourceInforma
 
             fieldBuilder.lookupIncludeBehavior(getLookupIncludeBehavior(attributeDesc, idAttribute != null));
         }
+    }
+
+    protected VersionRange getVersionRange(BeanAttributeInformation attributeDesc) {
+        for (ResourceFieldInformationProvider fieldInformationProvider : resourceFieldInformationProviders) {
+            Optional<VersionRange> versionRange = fieldInformationProvider.getVersionRange(attributeDesc);
+            if (versionRange.isPresent()) {
+                return versionRange.get();
+            }
+        }
+        return VersionRange.UNBOUNDED;
     }
 
     protected RelationshipRepositoryBehavior getRelationshipRepositoryBehavior(BeanAttributeInformation attributeDesc) {

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/registry/ResourceRegistryImpl.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/registry/ResourceRegistryImpl.java
@@ -104,6 +104,11 @@ public class ResourceRegistryImpl extends ResourceRegistryPartBase implements Re
         return moduleRegistry.getHttpRequestContextProvider().getServiceUrlProvider();
     }
 
+    @Override
+    public int getLatestVersion() {
+        return rootPart.getLatestVersion();
+    }
+
 
     public Optional<Class<?>> getResourceClass(Object resource) {
         return getResourceClass(resource.getClass());

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/utils/JsonApiUrlBuilder.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/utils/JsonApiUrlBuilder.java
@@ -68,7 +68,7 @@ public class JsonApiUrlBuilder {
 
         QuerySpec querySpec = (QuerySpec) query;
         QuerySpecUrlMapper urlMapper = moduleRegistry.getUrlMapper();
-        urlBuilder.addQueryParameters(urlMapper.serialize(querySpec));
+        urlBuilder.addQueryParameters(urlMapper.serialize(querySpec, queryContext));
 
         return urlBuilder.toString();
     }

--- a/crnk-core/src/main/java/io/crnk/core/engine/query/QueryContext.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/query/QueryContext.java
@@ -4,43 +4,80 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.crnk.core.engine.registry.ResourceRegistry;
+import io.crnk.core.resource.annotations.JsonApiVersion;
+
+/**
+ * Holds context information about the current request.
+ */
 public class QueryContext {
 
-    private String baseUrl;
+	private String baseUrl;
 
-    private Map<String, Object> attributes = new ConcurrentHashMap<>();
+	private Map<String, Object> attributes = new ConcurrentHashMap<>();
 
-    private String requestPath;
+	private String requestPath;
 
-    public String getBaseUrl() {
-        return Objects.requireNonNull(baseUrl);
-    }
+	private int requestVersion = -1;
 
-    public void setBaseUrl(String baseUrl) {
-        this.baseUrl = baseUrl;
-    }
+	/**
+	 * @return version used to serve this request. See {@link JsonApiVersion}.
+	 */
+	public int getRequestVersion() {
+		return requestVersion;
+	}
 
-    public Object getAttribute(String key) {
-        return attributes.get(key);
-    }
+	public QueryContext setRequestVersion(int requestVersion) {
+		this.requestVersion = requestVersion;
+		return this;
+	}
 
-    public void setAttribute(String key, Object value) {
-        attributes.put(key, value);
-    }
+	/**
+	 * @return base URL requested by the client. Does not include repository paths and URL parameters.
+	 */
+	public String getBaseUrl() {
+		return Objects.requireNonNull(baseUrl);
+	}
 
-    public Map<String, Object> getAttributes() {
-        return attributes;
-    }
+	public void setBaseUrl(String baseUrl) {
+		this.baseUrl = baseUrl;
+	}
 
-    public void setAttributes(Map<String, Object> attributes) {
-        this.attributes = attributes;
-    }
+	/**
+	 * @return attribute with given key associated to the current request. Can be used, for example, to hold
+	 * the current user principal.
+	 */
+	public Object getAttribute(String key) {
+		return attributes.get(key);
+	}
 
-    public String getRequestPath() {
-        return requestPath;
-    }
+	public void setAttribute(String key, Object value) {
+		attributes.put(key, value);
+	}
 
-    public void setRequestPath(String requestPath) {
-        this.requestPath = requestPath;
-    }
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	public void setAttributes(Map<String, Object> attributes) {
+		this.attributes = attributes;
+	}
+
+	/**
+	 * @return path to the requested repository based from {@link #getBaseUrl()}.
+	 */
+	public String getRequestPath() {
+		return requestPath;
+	}
+
+	public void setRequestPath(String requestPath) {
+		this.requestPath = requestPath;
+	}
+
+	public void initializeDefaults(ResourceRegistry resourceRegistry) {
+		// serve latest version if no other is specified
+		if (getRequestVersion() == -1) {
+			setRequestVersion(resourceRegistry.getLatestVersion());
+		}
+	}
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/registry/DefaultResourceRegistryPart.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/registry/DefaultResourceRegistryPart.java
@@ -1,5 +1,12 @@
 package io.crnk.core.engine.registry;
 
+import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.internal.utils.PreconditionUtil;
+import io.crnk.core.exception.RepositoryNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.HashMap;
@@ -7,114 +14,126 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import io.crnk.core.engine.information.resource.ResourceInformation;
-import io.crnk.core.engine.internal.utils.PreconditionUtil;
-import io.crnk.core.exception.RepositoryNotFoundException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 /**
  * Implements ResourceRegistryPart by maintaining a simple set of RegistryEntry in memory.
  */
 public class DefaultResourceRegistryPart extends ResourceRegistryPartBase {
 
-	private final Logger logger = LoggerFactory.getLogger(DefaultResourceRegistryPart.class);
+    private final Logger logger = LoggerFactory.getLogger(DefaultResourceRegistryPart.class);
 
-	private final Map<String, RegistryEntry> resourcesByType;
+    private final Map<String, RegistryEntry> resourcesByType;
 
-	private final Map<String, RegistryEntry> resourcesByPath;
+    private final Map<String, RegistryEntry> resourcesByPath;
 
-	private final Map<Type, RegistryEntry> resourcesByImplementationType;
+    private final Map<Type, RegistryEntry> resourcesByImplementationType;
 
-	public DefaultResourceRegistryPart() {
-		this.resourcesByType = new HashMap<>();
-		this.resourcesByPath = new HashMap<>();
-		this.resourcesByImplementationType = new HashMap<>();
-	}
+    private int latestVersion;
 
-	@Override
-	public RegistryEntry addEntry(RegistryEntry entry) {
-		ResourceInformation resourceInformation = entry.getResourceInformation();
-		Type implementationType = resourceInformation.getImplementationType();
-		String resourceType = resourceInformation.getResourceType();
-		String resourcePath = resourceInformation.getResourcePath();
-		PreconditionUtil.verify(resourceType != null, "no resourceType set for entry %s", entry);
-		PreconditionUtil
-				.verify(!resourcesByType.containsKey(resourceType), "resourceType '%s' already exists, cannot add entry %s",
-						resourceType, entry);
-		if (entry.hasResourceRepository()) {
-			PreconditionUtil
-					.verify(!resourcesByPath.containsKey(resourcePath), "resourceType '%s' already exists, cannot add entry %s",
-							resourcePath, entry);
-			resourcesByPath.put(resourcePath != null ? resourcePath : resourceType, entry);
-		}
-		resourcesByImplementationType.put(implementationType, entry);
-		resourcesByType.put(resourceType, entry);
-		logger.debug("Added resource '{}' to ResourceRegistry", resourceType);
-		notifyChange();
-		return entry;
-	}
+    public DefaultResourceRegistryPart() {
+        this.resourcesByType = new HashMap<>();
+        this.resourcesByPath = new HashMap<>();
+        this.resourcesByImplementationType = new HashMap<>();
+    }
 
-	@Override
-	public boolean hasEntry(Class<?> implementationClass) {
-		return getEntry(implementationClass) != null;
-	}
+    @Override
+    public RegistryEntry addEntry(RegistryEntry entry) {
+        ResourceInformation resourceInformation = entry.getResourceInformation();
+        Type implementationType = resourceInformation.getImplementationType();
+        String resourceType = resourceInformation.getResourceType();
+        String resourcePath = resourceInformation.getResourcePath();
+        PreconditionUtil.verify(resourceType != null, "no resourceType set for entry %s", entry);
+        PreconditionUtil
+                .verify(!resourcesByType.containsKey(resourceType), "resourceType '%s' already exists, cannot add entry %s",
+                        resourceType, entry);
+        if (entry.hasResourceRepository()) {
+            PreconditionUtil
+                    .verify(!resourcesByPath.containsKey(resourcePath), "resourceType '%s' already exists, cannot add entry %s",
+                            resourcePath, entry);
+            resourcesByPath.put(resourcePath != null ? resourcePath : resourceType, entry);
+        }
+        resourcesByImplementationType.put(implementationType, entry);
+        resourcesByType.put(resourceType, entry);
 
-	@Override
-	public boolean hasEntry(Type implementationType) {
-		return getEntry(implementationType) != null;
-	}
+        latestVersion = Math.max(latestVersion, ignoreUnbounded(resourceInformation.getVersionRange().getMax()));
+        for (ResourceField field : resourceInformation.getFields()) {
+            latestVersion = Math.max(latestVersion, ignoreUnbounded(field.getVersionRange().getMax()));
+        }
 
-	@Override
-	public boolean hasEntry(String resourceType) {
-		return resourcesByType.get(resourceType) != null;
-	}
+        logger.debug("Added resource '{}' to ResourceRegistry", resourceType);
+        notifyChange();
+        return entry;
+    }
 
-	@Override
-	public RegistryEntry getEntry(Class<?> implementationClass) {
-		return resourcesByImplementationType.get(implementationClass);
-	}
-
-	@Override
-	public RegistryEntry getEntry(Type implementationType) {
-		return resourcesByImplementationType.get(implementationType);
-	}
-
-	/**
-	 * Get a list of all registered resources by Crnk.
-	 *
-	 * @return resources
-	 */
-	public Set<RegistryEntry> getEntries() {
-		return Collections.unmodifiableSet(new HashSet<>(resourcesByType.values()));
-	}
+    private int ignoreUnbounded(int version) {
+        return version != Integer.MAX_VALUE ? version : 0;
+    }
 
 
-	/**
-	 * Searches the registry for a resource identified by a JSON API resource
-	 * type. If a resource cannot be found, <i>null</i> is returned.
-	 *
-	 * @param resourceType resource type
-	 * @return registry entry or <i>null</i>
-	 */
-	public RegistryEntry getEntry(String resourceType) {
-		RegistryEntry entry = resourcesByType.get(resourceType);
-		if (entry == null) {
-			throw new RepositoryNotFoundException(resourceType);
-		}
-		return entry;
-	}
+    @Override
+    public boolean hasEntry(Class<?> implementationClass) {
+        return getEntry(implementationClass) != null;
+    }
 
-	/**
-	 * Searches the registry for a resource identified by a JSON API resource
-	 * path. If a resource cannot be found, <i>null</i> is returned.
-	 *
-	 * @param resourcePath resource path
-	 * @return registry entry or <i>null</i>
-	 */
-	public RegistryEntry getEntryByPath(String resourcePath) {
-		return resourcesByPath.get(resourcePath);
-	}
+    @Override
+    public boolean hasEntry(Type implementationType) {
+        return getEntry(implementationType) != null;
+    }
+
+    @Override
+    public boolean hasEntry(String resourceType) {
+        return resourcesByType.get(resourceType) != null;
+    }
+
+    @Override
+    public RegistryEntry getEntry(Class<?> implementationClass) {
+        return resourcesByImplementationType.get(implementationClass);
+    }
+
+    @Override
+    public RegistryEntry getEntry(Type implementationType) {
+        return resourcesByImplementationType.get(implementationType);
+    }
+
+    /**
+     * Get a list of all registered resources by Crnk.
+     *
+     * @return resources
+     */
+    public Set<RegistryEntry> getEntries() {
+        return Collections.unmodifiableSet(new HashSet<>(resourcesByType.values()));
+    }
+
+
+    /**
+     * Searches the registry for a resource identified by a JSON API resource
+     * type. If a resource cannot be found, <i>null</i> is returned.
+     *
+     * @param resourceType resource type
+     * @return registry entry or <i>null</i>
+     */
+    public RegistryEntry getEntry(String resourceType) {
+        RegistryEntry entry = resourcesByType.get(resourceType);
+        if (entry == null) {
+            throw new RepositoryNotFoundException(resourceType);
+        }
+        return entry;
+    }
+
+    /**
+     * Searches the registry for a resource identified by a JSON API resource
+     * path. If a resource cannot be found, <i>null</i> is returned.
+     *
+     * @param resourcePath resource path
+     * @return registry entry or <i>null</i>
+     */
+    public RegistryEntry getEntryByPath(String resourcePath) {
+        return resourcesByPath.get(resourcePath);
+    }
+
+    @Override
+    public int getLatestVersion() {
+        return latestVersion;
+    }
 
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/registry/HierarchicalResourceRegistryPart.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/registry/HierarchicalResourceRegistryPart.java
@@ -12,124 +12,133 @@ import java.util.Map;
  */
 public class HierarchicalResourceRegistryPart extends ResourceRegistryPartBase {
 
-	private static final String PATH_SEPARATOR = "/";
+    private static final String PATH_SEPARATOR = "/";
 
-	private Map<String, ResourceRegistryPart> partMap = new HashMap<>();
+    private Map<String, ResourceRegistryPart> partMap = new HashMap<>();
 
-	private List<ResourceRegistryPart> partList = new ArrayList<>();
+    private List<ResourceRegistryPart> partList = new ArrayList<>();
 
-	private ResourceRegistryPartListener childListener = new ResourceRegistryPartListener() {
-		@Override
-		public void onChanged(ResourceRegistryPartEvent event) {
-			notifyChange();
-		}
-	};
+    private ResourceRegistryPartListener childListener = new ResourceRegistryPartListener() {
+        @Override
+        public void onChanged(ResourceRegistryPartEvent event) {
+            notifyChange();
+        }
+    };
 
-	public void putPart(String prefix, ResourceRegistryPart part) {
-		if (partMap.containsKey(prefix)) {
-			throw new IllegalStateException("part with prefx " + prefix + " already exists");
-		}
-		partMap.put(prefix, part);
-		partList.add(part);
-		part.addListener(childListener);
-	}
+    public void putPart(String prefix, ResourceRegistryPart part) {
+        if (partMap.containsKey(prefix)) {
+            throw new IllegalStateException("part with prefx " + prefix + " already exists");
+        }
+        partMap.put(prefix, part);
+        partList.add(part);
+        part.addListener(childListener);
+    }
 
 
-	@Override
-	public RegistryEntry addEntry(RegistryEntry entry) {
-		String resourceType = entry.getResourceInformation().getResourceType();
-		ResourceRegistryPart part = getPart(resourceType);
-		if (part == null) {
-			throw new IllegalStateException("cannot add " + resourceType + ", no part available in hierarchy");
-		}
-		return part.addEntry(entry);
-	}
+    @Override
+    public RegistryEntry addEntry(RegistryEntry entry) {
+        String resourceType = entry.getResourceInformation().getResourceType();
+        ResourceRegistryPart part = getPart(resourceType);
+        if (part == null) {
+            throw new IllegalStateException("cannot add " + resourceType + ", no part available in hierarchy");
+        }
+        return part.addEntry(entry);
+    }
 
-	@Override
-	public boolean hasEntry(Class<?> implementationClass) {
-		for (ResourceRegistryPart part : partList) {
-			if (part.hasEntry(implementationClass)) {
-				return true;
-			}
-		}
-		return false;
-	}
+    @Override
+    public boolean hasEntry(Class<?> implementationClass) {
+        for (ResourceRegistryPart part : partList) {
+            if (part.hasEntry(implementationClass)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	@Override
-	public boolean hasEntry(Type implementationType) {
-		for (ResourceRegistryPart part : partList) {
-			if (part.hasEntry(implementationType)) {
-				return true;
-			}
-		}
-		return false;
-	}
+    @Override
+    public boolean hasEntry(Type implementationType) {
+        for (ResourceRegistryPart part : partList) {
+            if (part.hasEntry(implementationType)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	@Override
-	public boolean hasEntry(String resourceType) {
-		for (ResourceRegistryPart part : partList) {
-			if (part.hasEntry(resourceType)) {
-				return true;
-			}
-		}
-		return false;
-	}
+    @Override
+    public boolean hasEntry(String resourceType) {
+        for (ResourceRegistryPart part : partList) {
+            if (part.hasEntry(resourceType)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	@Override
-	public RegistryEntry getEntry(String resourceType) {
-		ResourceRegistryPart part = getPart(resourceType);
-		if (part == null) {
-			return null;
-		}
-		return part.getEntry(resourceType);
-	}
+    @Override
+    public RegistryEntry getEntry(String resourceType) {
+        ResourceRegistryPart part = getPart(resourceType);
+        if (part == null) {
+            return null;
+        }
+        return part.getEntry(resourceType);
+    }
 
-	@Override
-	public RegistryEntry getEntryByPath(String resourcePath) {
-		ResourceRegistryPart part = getPart(resourcePath);
-		if (part == null) {
-			return null;
-		}
-		return part.getEntryByPath(resourcePath);
-	}
+    @Override
+    public RegistryEntry getEntryByPath(String resourcePath) {
+        ResourceRegistryPart part = getPart(resourcePath);
+        if (part == null) {
+            return null;
+        }
+        return part.getEntryByPath(resourcePath);
+    }
 
-	private ResourceRegistryPart getPart(String resourceType) {
-		int sep = resourceType.indexOf(PATH_SEPARATOR);
-		String prefix;
-		if (sep == -1) {
-			prefix = "";
-		} else {
-			prefix = resourceType.substring(0, sep);
-		}
-		return partMap.get(prefix);
-	}
+    @Override
+    public int getLatestVersion() {
+        int latestVersion = 0;
+        for (ResourceRegistryPart part : partList) {
+            latestVersion = Math.max(latestVersion, part.getLatestVersion());
+        }
+        return latestVersion;
+    }
 
-	@Override
-	public Collection<RegistryEntry> getEntries() {
-		List<RegistryEntry> list = new ArrayList<>();
-		for (ResourceRegistryPart part : partList) {
-			list.addAll(part.getEntries());
-		}
-		return list;
-	}
+    private ResourceRegistryPart getPart(String resourceType) {
+        int sep = resourceType.indexOf(PATH_SEPARATOR);
+        String prefix;
+        if (sep == -1) {
+            prefix = "";
+        } else {
+            prefix = resourceType.substring(0, sep);
+        }
+        return partMap.get(prefix);
+    }
 
-	@Override
-	public RegistryEntry getEntry(Class<?> implementationClass) {
-		for (ResourceRegistryPart part : partList) {
-			if (part.hasEntry(implementationClass)) {
-				return part.getEntry(implementationClass);
-			}
-		}
-		return null;
-	}
+    @Override
+    public Collection<RegistryEntry> getEntries() {
+        List<RegistryEntry> list = new ArrayList<>();
+        for (ResourceRegistryPart part : partList) {
+            list.addAll(part.getEntries());
+        }
+        return list;
+    }
 
-	@Override
-	public RegistryEntry getEntry(Type implementationType) {
-		for (ResourceRegistryPart part : partList) {
-			if (part.hasEntry(implementationType)) {
-				return part.getEntry(implementationType);
-			}
-		}
-		return null;
-	}
+    @Override
+    public RegistryEntry getEntry(Class<?> implementationClass) {
+        for (ResourceRegistryPart part : partList) {
+            if (part.hasEntry(implementationClass)) {
+                return part.getEntry(implementationClass);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public RegistryEntry getEntry(Type implementationType) {
+        for (ResourceRegistryPart part : partList) {
+            if (part.hasEntry(implementationType)) {
+                return part.getEntry(implementationType);
+            }
+        }
+        return null;
+    }
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/registry/ResourceRegistry.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/registry/ResourceRegistry.java
@@ -3,6 +3,7 @@ package io.crnk.core.engine.registry;
 import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.url.ServiceUrlProvider;
+import io.crnk.core.resource.annotations.JsonApiVersion;
 
 /**
  * ${@link ResourceRegistryPart} implementation if a number of convenience methods used and exposed
@@ -10,91 +11,98 @@ import io.crnk.core.engine.url.ServiceUrlProvider;
  */
 public interface ResourceRegistry extends ResourceRegistryPart {
 
-	RegistryEntry findEntry(Class<?> resourceClass);
+    RegistryEntry findEntry(Class<?> resourceClass);
 
-	/**
-	 * @return entry matching the given resource, accoutring for the {@link Class}, {@link io.crnk.core.resource.annotations.JsonApiId},
-	 * {@link io.crnk.core.engine.document.Resource}.
-	 */
-	RegistryEntry findEntry(Object resource);
+    /**
+     * @return entry matching the given resource, accoutring for the {@link Class}, {@link io.crnk.core.resource.annotations.JsonApiId},
+     * {@link io.crnk.core.engine.document.Resource}.
+     */
+    RegistryEntry findEntry(Object resource);
 
-	/**
-	 * @return url for the given resourceInformation. Depending on the ServiceUrlProvider setup, a request must be active
-	 * to invoke this method (to obtain domain/host information).
-	 */
-	String getResourceUrl(ResourceInformation resourceInformation);
+    /**
+     * @return url for the given resourceInformation. Depending on the ServiceUrlProvider setup, a request must be active
+     * to invoke this method (to obtain domain/host information).
+     */
+    String getResourceUrl(ResourceInformation resourceInformation);
 
-	/**
-	 * Retrieves the url of the resource
-	 *
-	 * @param resource Resource
-	 * @return Url of provided resource in case it's a registered resource
-	 */
-	String getResourceUrl(Object resource);
+    /**
+     * Retrieves the url of the resource
+     *
+     * @param resource Resource
+     * @return Url of provided resource in case it's a registered resource
+     */
+    String getResourceUrl(Object resource);
 
-	/**
-	 * Retrieves the url of the type
-	 *
-	 * @param clazz Type
-	 * @return Url of provided resource in case it's a registered resource
-	 */
-	String getResourceUrl(Class<?> clazz);
+    /**
+     * Retrieves the url of the type
+     *
+     * @param clazz Type
+     * @return Url of provided resource in case it's a registered resource
+     */
+    String getResourceUrl(Class<?> clazz);
 
-	/**
-	 * Retrieves the url of the type and identifier
-	 *
-	 * @param clazz Type
-	 * @param id Identifier
-	 * @return Url of provided resource in case it's a registered resource
-	 */
-	String getResourceUrl(Class<?> clazz, String id);
+    /**
+     * Retrieves the url of the type and identifier
+     *
+     * @param clazz Type
+     * @param id    Identifier
+     * @return Url of provided resource in case it's a registered resource
+     */
+    String getResourceUrl(Class<?> clazz, String id);
 
 
-	/**
-	 * Retrieves the path of the type and identifier
-	 *
-	 * @param id Identifier
-	 * @return complete path of provided resource in case it's a registered resource
-	 */
-	String getResourcePath(ResourceInformation resourceInformation, Object id);
+    /**
+     * Retrieves the path of the type and identifier
+     *
+     * @param id Identifier
+     * @return complete path of provided resource in case it's a registered resource
+     */
+    String getResourcePath(ResourceInformation resourceInformation, Object id);
 
-	/**
-	 * @return url for the given resourceInformation. Depending on the ServiceUrlProvider setup, a request must be active
-	 * to invoke this method (to obtain domain/host information).
-	 */
-	String getResourceUrl(QueryContext queryContext, ResourceInformation resourceInformation);
+    /**
+     * @return url for the given resourceInformation. Depending on the ServiceUrlProvider setup, a request must be active
+     * to invoke this method (to obtain domain/host information).
+     */
+    String getResourceUrl(QueryContext queryContext, ResourceInformation resourceInformation);
 
-	String getResourceUrl(QueryContext queryContext, ResourceInformation resourceInformation, Object id);
+    String getResourceUrl(QueryContext queryContext, ResourceInformation resourceInformation, Object id);
 
-	/**
-	 * Retrieves the url of the resource
-	 *
-	 * @param resource Resource
-	 * @return Url of provided resource in case it's a registered resource
-	 */
-	String getResourceUrl(QueryContext queryContext, Object resource);
+    /**
+     * Retrieves the url of the resource
+     *
+     * @param resource Resource
+     * @return Url of provided resource in case it's a registered resource
+     */
+    String getResourceUrl(QueryContext queryContext, Object resource);
 
-	/**
-	 * Retrieves the url of the type
-	 *
-	 * @param clazz Type
-	 * @return Url of provided resource in case it's a registered resource
-	 */
-	String getResourceUrl(QueryContext queryContext, Class<?> clazz);
+    /**
+     * Retrieves the url of the type
+     *
+     * @param clazz Type
+     * @return Url of provided resource in case it's a registered resource
+     */
+    String getResourceUrl(QueryContext queryContext, Class<?> clazz);
 
-	/**
-	 * Retrieves the url of the type and identifier
-	 *
-	 * @param clazz Type
-	 * @param id Identifier
-	 * @return Url of provided resource in case it's a registered resource
-	 */
-	String getResourceUrl(QueryContext queryContext, Class<?> clazz, String id);
+    /**
+     * Retrieves the url of the type and identifier
+     *
+     * @param clazz Type
+     * @param id    Identifier
+     * @return Url of provided resource in case it's a registered resource
+     */
+    String getResourceUrl(QueryContext queryContext, Class<?> clazz, String id);
 
-	/**
-	 * @return ResourceInformation of the the top most super type of the provided resource.
-	 */
-	ResourceInformation getBaseResourceInformation(String resourceType);
+    /**
+     * @return ResourceInformation of the the top most super type of the provided resource.
+     */
+    ResourceInformation getBaseResourceInformation(String resourceType);
 
-	ServiceUrlProvider getServiceUrlProvider();
+    ServiceUrlProvider getServiceUrlProvider();
+
+    /**
+     * @return latest version within repository or 0 if no versioning in place. For more information
+     * see {@link JsonApiVersion}
+     */
+    int getLatestVersion();
+
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/registry/ResourceRegistryPart.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/registry/ResourceRegistryPart.java
@@ -6,26 +6,27 @@ import java.util.Collection;
 
 public interface ResourceRegistryPart {
 
-	RegistryEntry addEntry(RegistryEntry entry);
+    RegistryEntry addEntry(RegistryEntry entry);
 
-	boolean hasEntry(Class<?> clazz);
+    boolean hasEntry(Class<?> clazz);
 
-	boolean hasEntry(Type type);
+    boolean hasEntry(Type type);
 
-	boolean hasEntry(String resourceType);
+    boolean hasEntry(String resourceType);
 
-	RegistryEntry getEntry(String resourceType);
+    RegistryEntry getEntry(String resourceType);
 
-	Collection<RegistryEntry> getEntries();
+    Collection<RegistryEntry> getEntries();
 
-	RegistryEntry getEntry(Class<?> clazz);
+    RegistryEntry getEntry(Class<?> clazz);
 
-	RegistryEntry getEntry(Type type);
+    RegistryEntry getEntry(Type type);
 
-	RegistryEntry getEntryByPath(String resourcePath);
+    RegistryEntry getEntryByPath(String resourcePath);
 
-	void addListener(ResourceRegistryPartListener listener);
+    void addListener(ResourceRegistryPartListener listener);
 
-	void removeListener(ResourceRegistryPartListener listener);
+    void removeListener(ResourceRegistryPartListener listener);
 
+    int getLatestVersion();
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/version/VersionModule.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/version/VersionModule.java
@@ -1,0 +1,53 @@
+package io.crnk.core.engine.version;
+
+import io.crnk.core.engine.filter.FilterBehavior;
+import io.crnk.core.engine.filter.ResourceFilter;
+import io.crnk.core.engine.filter.ResourceFilterContext;
+import io.crnk.core.engine.http.HttpMethod;
+import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.information.resource.VersionRange;
+import io.crnk.core.engine.query.QueryContext;
+import io.crnk.core.module.Module;
+import io.crnk.core.resource.annotations.JsonApiVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Enables support for {@link JsonApiVersion}.
+ */
+public class VersionModule implements Module {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VersionModule.class);
+
+    @Override
+    public String getModuleName() {
+        return "crnk.version";
+    }
+
+    @Override
+    public void setupModule(ModuleContext context) {
+        context.addResourceFilter(new VersionResourceFilter());
+    }
+
+    class VersionResourceFilter implements ResourceFilter {
+
+        @Override
+        public FilterBehavior filterResource(ResourceFilterContext filterContext, ResourceInformation resourceInformation, HttpMethod method) {
+            QueryContext queryContext = filterContext.getQueryContext();
+            VersionRange versionRange = resourceInformation.getVersionRange();
+            FilterBehavior filterBehavior = versionRange.contains(queryContext.getRequestVersion()) ? FilterBehavior.NONE : FilterBehavior.FORBIDDEN;
+            LOGGER.debug("{} for {}", filterBehavior, resourceInformation);
+            return filterBehavior;
+        }
+
+        @Override
+        public FilterBehavior filterField(ResourceFilterContext filterContext, ResourceField field, HttpMethod method) {
+            QueryContext queryContext = filterContext.getQueryContext();
+            VersionRange versionRange = field.getVersionRange();
+            FilterBehavior filterBehavior = versionRange.contains(queryContext.getRequestVersion()) ? FilterBehavior.NONE : FilterBehavior.FORBIDDEN;
+            LOGGER.debug("{} for {}", filterBehavior, field);
+            return filterBehavior;
+        }
+    }
+}

--- a/crnk-core/src/main/java/io/crnk/core/module/ModuleRegistry.java
+++ b/crnk-core/src/main/java/io/crnk/core/module/ModuleRegistry.java
@@ -154,7 +154,7 @@ public class ModuleRegistry {
 
     private RequestDispatcher requestDispatcher;
 
-    private HttpRequestContextProvider httpRequestContextProvider = new HttpRequestContextProvider(() -> getResultFactory());
+	private HttpRequestContextProvider httpRequestContextProvider = new HttpRequestContextProvider(() -> getResultFactory(), this);
 
     private PropertiesProvider propertiesProvider = new NullPropertiesProvider();
 
@@ -215,6 +215,7 @@ public class ModuleRegistry {
      * @param module module
      */
     public void addModule(Module module) {
+		checkState(InitializedState.NOT_INITIALIZED, InitializedState.NOT_INITIALIZED);
         LOGGER.debug("adding module {}", module);
         module.setupModule(new ModuleContextImpl(module));
         modules.add(module);
@@ -448,7 +449,7 @@ public class ModuleRegistry {
             Optional<? extends Module> optModule = getModule(extension.getTargetModule());
             if (optModule.isPresent()) {
                 reverseExtensionMap.add(optModule.get(), extension);
-            } else if (!extension.isOptional()) {
+			} else if (!extension.isOptional()) {
                 throw new IllegalStateException(extension.getTargetModule() + " not installed but required by " + extension);
             }
         }
@@ -545,7 +546,7 @@ public class ModuleRegistry {
                     String oppositeOppositeName = oppositeField.getOppositeName();
                     if (oppositeOppositeName != null) {
                         PreconditionUtil.verifyEquals(field.getUnderlyingName(), oppositeOppositeName, "opposite references do not match for %s and %s", field, oppositeField);
-                    } else {
+					} else {
                         ((ResourceFieldImpl) oppositeField).setOppositeName(field.getUnderlyingName());
                     }
                 }
@@ -586,7 +587,7 @@ public class ModuleRegistry {
             RegistryEntry parentEntry;
             if (resourceInformationProvider.accept(superclass)) {
                 parentEntry = applyResourceRegistration(superclass, additionalEntryMap);
-            } else {
+			} else {
                 throw new IllegalStateException("super type " + superclass + " of " + resourceClass
                         + " is not a resource. Is it annotated with @JsonApiResource?");
             }

--- a/crnk-core/src/main/java/io/crnk/core/module/internal/ResourceFilterDirectoryImpl.java
+++ b/crnk-core/src/main/java/io/crnk/core/module/internal/ResourceFilterDirectoryImpl.java
@@ -66,6 +66,7 @@ public class ResourceFilterDirectoryImpl implements ResourceFilterDirectory {
 
     @Override
     public FilterBehavior get(ResourceField field, HttpMethod method, QueryContext queryContext) {
+    	PreconditionUtil.verify(field != null, "field cannot be null");
         Map<Object, FilterBehavior> map = getCache(method, queryContext);
 
         FilterBehavior behavior = map.get(field);

--- a/crnk-core/src/main/java/io/crnk/core/queryspec/internal/DefaultQueryPathResolver.java
+++ b/crnk-core/src/main/java/io/crnk/core/queryspec/internal/DefaultQueryPathResolver.java
@@ -12,6 +12,7 @@ import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.core.engine.internal.utils.MultivaluedMap;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.engine.internal.utils.StringUtils;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.exception.BadRequestException;
@@ -29,163 +30,163 @@ import java.util.Map;
 // TODO eventually ResourceInformation should alo provide information abaout nested non-resource types to make use of reflection here unncessary
 public class DefaultQueryPathResolver implements QueryPathResolver {
 
-	private QuerySpecUrlContext ctx;
+    private QuerySpecUrlContext ctx;
 
-	private boolean allowUnknownAttributes = false;
+    private boolean allowUnknownAttributes = false;
 
-	private boolean mapJsonNames = true;
+    private boolean mapJsonNames = true;
 
-	@Override
-	public void init(QuerySpecUrlContext ctx) {
-		this.ctx = ctx;
-	}
+    @Override
+    public void init(QuerySpecUrlContext ctx) {
+        this.ctx = ctx;
+    }
 
-	@Override
-	public QueryPathSpec resolve(ResourceInformation resourceInformation, List<String> attributePath, NamingType sourceNamingType, String sourceParameter) {
-		if (attributePath == null) {
-			// no attribute specified, query string expected, use String
-			return new QueryPathSpec(String.class, null, null);
-		}
+    @Override
+    public QueryPathSpec resolve(ResourceInformation resourceInformation, List<String> attributePath, NamingType sourceNamingType, String sourceParameter, QueryContext queryContext) {
+        if (attributePath == null) {
+            // no attribute specified, query string expected, use String
+            return new QueryPathSpec(String.class, null, null);
+        }
 
-		ResourceRegistry resourceRegistry = ctx.getResourceRegistry();
-		Type valueType = resourceInformation.getResourceClass();
-		AnyResourceFieldAccessor anyFieldAccessor = resourceInformation.getAnyFieldAccessor();
+        ResourceRegistry resourceRegistry = ctx.getResourceRegistry();
+        Type valueType = resourceInformation.getResourceClass();
+        AnyResourceFieldAccessor anyFieldAccessor = resourceInformation.getAnyFieldAccessor();
 
-		SubTypeMap subTypeMap = null;
+        SubTypeMap subTypeMap = null;
 
-		List<String> targetPath = new ArrayList<>();
-		List<ResourceField> fields = new ArrayList<>();
+        List<String> targetPath = new ArrayList<>();
+        List<ResourceField> fields = new ArrayList<>();
 
-		for (String sourceAttributePath : attributePath) {
-			if (resourceInformation != null) {
-				ResourceField field = sourceNamingType == NamingType.JSON ? resourceInformation.findFieldByName(sourceAttributePath) : resourceInformation.findFieldByUnderlyingName(sourceAttributePath);
-				if (field == null) {
-					// search subtypes for field if not available on main resource
-					if (subTypeMap == null) {
-						subTypeMap = new SubTypeMap(resourceRegistry);
-					}
-					List<ResourceInformation> subTypes = subTypeMap.findSubTypes(resourceInformation.getResourceType());
-					for (ResourceInformation subType : subTypes) {
-						field = sourceNamingType == NamingType.JSON ? subType.findFieldByName(sourceAttributePath) : subType.findFieldByUnderlyingName(sourceAttributePath);
-						if (field != null) {
-							break;
-						}
-					}
-				}
+        for (String sourceAttributePath : attributePath) {
+            if (resourceInformation != null) {
+                ResourceField field = sourceNamingType == NamingType.JSON ? resourceInformation.findFieldByJsonName(sourceAttributePath, queryContext.getRequestVersion()) : resourceInformation.findFieldByUnderlyingName(sourceAttributePath);
+                if (field == null) {
+                    // search subtypes for field if not available on main resource
+                    if (subTypeMap == null) {
+                        subTypeMap = new SubTypeMap(resourceRegistry);
+                    }
+                    List<ResourceInformation> subTypes = subTypeMap.findSubTypes(resourceInformation.getResourceType());
+                    for (ResourceInformation subType : subTypes) {
+                        field = sourceNamingType == NamingType.JSON ? subType.findFieldByJsonName(sourceAttributePath, queryContext.getRequestVersion()) : subType.findFieldByUnderlyingName(sourceAttributePath);
+                        if (field != null) {
+                            break;
+                        }
+                    }
+                }
 
-				fields.add(field);
+                fields.add(field);
 
-				if (field != null) {
-					if (field.getResourceFieldType() == ResourceFieldType.RELATIONSHIP) {
-						RegistryEntry entry = resourceRegistry.getEntry(field.getOppositeResourceType());
-						PreconditionUtil.verify(entry != null, "resourceType=%s not found for field=%s", field.getOppositeResourceType(), field.getUnderlyingName());
-						resourceInformation = entry.getResourceInformation();
-						valueType = resourceInformation.getResourceClass();
-					} else {
-						resourceInformation = null;
-						valueType = field.getElementType();
-					}
-					targetPath.add(sourceNamingType == NamingType.JSON ? field.getUnderlyingName() : field.getJsonName());
-					continue;
-				}
-			} else {
-				resourceInformation = null;
-				fields.add(null);
-				if (valueType == Object.class) {
-					targetPath.add(sourceAttributePath);
-					continue;
-				} else if (Map.class.isAssignableFrom(ClassUtils.getRawType(valueType))) {
-					if (valueType instanceof ParameterizedType) {
-						valueType = ((ParameterizedType) valueType).getActualTypeArguments()[1];
-					} else {
-						valueType = Object.class;
-					}
-					targetPath.add(sourceAttributePath);
-					continue;
-				} else {
-					BeanInformation beanInformation = BeanInformation.get(ClassUtils.getRawType(valueType));
-					BeanAttributeInformation attribute = sourceNamingType == NamingType.JSON ? beanInformation.getAttributeByJsonName(sourceAttributePath) : beanInformation.getAttribute(sourceAttributePath);
-					if (attribute != null) {
-						valueType = attribute.getImplementationType();
-						targetPath.add(sourceNamingType == NamingType.JSON ? attribute.getName() : attribute.getJsonName());
-						continue;
-					}
-				}
-			}
+                if (field != null) {
+                    if (field.getResourceFieldType() == ResourceFieldType.RELATIONSHIP) {
+                        RegistryEntry entry = resourceRegistry.getEntry(field.getOppositeResourceType());
+                        PreconditionUtil.verify(entry != null, "resourceType=%s not found for field=%s", field.getOppositeResourceType(), field.getUnderlyingName());
+                        resourceInformation = entry.getResourceInformation();
+                        valueType = resourceInformation.getResourceClass();
+                    } else {
+                        resourceInformation = null;
+                        valueType = field.getElementType();
+                    }
+                    targetPath.add(sourceNamingType == NamingType.JSON ? field.getUnderlyingName() : field.getJsonName());
+                    continue;
+                }
+            } else {
+                resourceInformation = null;
+                fields.add(null);
+                if (valueType == Object.class) {
+                    targetPath.add(sourceAttributePath);
+                    continue;
+                } else if (Map.class.isAssignableFrom(ClassUtils.getRawType(valueType))) {
+                    if (valueType instanceof ParameterizedType) {
+                        valueType = ((ParameterizedType) valueType).getActualTypeArguments()[1];
+                    } else {
+                        valueType = Object.class;
+                    }
+                    targetPath.add(sourceAttributePath);
+                    continue;
+                } else {
+                    BeanInformation beanInformation = BeanInformation.get(ClassUtils.getRawType(valueType));
+                    BeanAttributeInformation attribute = sourceNamingType == NamingType.JSON ? beanInformation.getAttributeByJsonName(sourceAttributePath) : beanInformation.getAttribute(sourceAttributePath);
+                    if (attribute != null) {
+                        valueType = attribute.getImplementationType();
+                        targetPath.add(sourceNamingType == NamingType.JSON ? attribute.getName() : attribute.getJsonName());
+                        continue;
+                    }
+                }
+            }
 
-			if (allowUnknownAttributes || anyFieldAccessor != null) {
-				targetPath.add(sourceAttributePath);
-				valueType = Object.class;
-			} else {
-				ErrorData errorData = ErrorData.builder()
-						.setCode("UNKNOWN_PARAMETER")
-						.setTitle("unknown parameter")
-						.setDetail("Failed to resolve path to field '" + StringUtils.join(".", attributePath) + "' from " + resourceInformation.getResourceClass())
-						.setSourceParameter(sourceParameter)
-						.setStatus(String.valueOf(HttpStatus.BAD_REQUEST_400)).build();
-				throw new BadRequestException(HttpStatus.BAD_REQUEST_400, errorData);
-			}
-		}
+            if (allowUnknownAttributes || anyFieldAccessor != null) {
+                targetPath.add(sourceAttributePath);
+                valueType = Object.class;
+            } else {
+                ErrorData errorData = ErrorData.builder()
+                        .setCode("UNKNOWN_PARAMETER")
+                        .setTitle("unknown parameter")
+                        .setDetail("Failed to resolve path to field '" + StringUtils.join(".", attributePath) + "' from " + resourceInformation.getResourceClass())
+                        .setSourceParameter(sourceParameter)
+                        .setStatus(String.valueOf(HttpStatus.BAD_REQUEST_400)).build();
+                throw new BadRequestException(HttpStatus.BAD_REQUEST_400, errorData);
+            }
+        }
 
-		List<String> path = mapJsonNames ? targetPath : attributePath;
-		return new QueryPathSpec(valueType, path, fields);
-	}
+        List<String> path = mapJsonNames ? targetPath : attributePath;
+        return new QueryPathSpec(valueType, path, fields);
+    }
 
-	@Override
-	public boolean getAllowUnknownAttributes() {
-		return allowUnknownAttributes;
-	}
+    @Override
+    public boolean getAllowUnknownAttributes() {
+        return allowUnknownAttributes;
+    }
 
-	@Override
-	public void setAllowUnknownAttributes(boolean allowUnknownAttributes) {
-		this.allowUnknownAttributes = allowUnknownAttributes;
-	}
+    @Override
+    public void setAllowUnknownAttributes(boolean allowUnknownAttributes) {
+        this.allowUnknownAttributes = allowUnknownAttributes;
+    }
 
-	@Override
-	public boolean getMapJsonNames() {
-		return mapJsonNames;
-	}
+    @Override
+    public boolean getMapJsonNames() {
+        return mapJsonNames;
+    }
 
-	@Override
-	public void setMapJsonNames(boolean mapJsonNames) {
-		this.mapJsonNames = mapJsonNames;
-	}
+    @Override
+    public void setMapJsonNames(boolean mapJsonNames) {
+        this.mapJsonNames = mapJsonNames;
+    }
 
-	class SubTypeMap {
-		private MultivaluedMap<String, ResourceInformation> mapping = new MultivaluedMap();
+    class SubTypeMap {
+        private MultivaluedMap<String, ResourceInformation> mapping = new MultivaluedMap();
 
-		public SubTypeMap(ResourceRegistry resourceRegistry) {
+        public SubTypeMap(ResourceRegistry resourceRegistry) {
 
-			Collection<RegistryEntry> entries = resourceRegistry.getEntries();
-			for (RegistryEntry entry : entries) {
-				ResourceInformation resourceInformation = entry.getResourceInformation();
-				String superResourceType = resourceInformation.getSuperResourceType();
-				if (superResourceType != null) {
-					mapping.add(superResourceType, resourceInformation);
-				}
-			}
-		}
+            Collection<RegistryEntry> entries = resourceRegistry.getEntries();
+            for (RegistryEntry entry : entries) {
+                ResourceInformation resourceInformation = entry.getResourceInformation();
+                String superResourceType = resourceInformation.getSuperResourceType();
+                if (superResourceType != null) {
+                    mapping.add(superResourceType, resourceInformation);
+                }
+            }
+        }
 
-		public List<ResourceInformation> findSubTypes(String resourceType) {
-			List<ResourceInformation> results = new ArrayList<>();
-			findSubTypes(results, resourceType);
-			return results;
-		}
+        public List<ResourceInformation> findSubTypes(String resourceType) {
+            List<ResourceInformation> results = new ArrayList<>();
+            findSubTypes(results, resourceType);
+            return results;
+        }
 
-		private void findSubTypes(List<ResourceInformation> results, String resourceType) {
-			if (mapping.containsKey(resourceType)) {
-				List<ResourceInformation> children = mapping.getList(resourceType);
-				// add direct descendants first
-				for (ResourceInformation child : children) {
-					results.add(child);
-				}
-				// only after add transitive children
-				for (ResourceInformation child : children) {
-					findSubTypes(results, child.getResourceType());
-				}
-			}
-		}
-	}
+        private void findSubTypes(List<ResourceInformation> results, String resourceType) {
+            if (mapping.containsKey(resourceType)) {
+                List<ResourceInformation> children = mapping.getList(resourceType);
+                // add direct descendants first
+                for (ResourceInformation child : children) {
+                    results.add(child);
+                }
+                // only after add transitive children
+                for (ResourceInformation child : children) {
+                    findSubTypes(results, child.getResourceType());
+                }
+            }
+        }
+    }
 
 
 }

--- a/crnk-core/src/main/java/io/crnk/core/queryspec/internal/QuerySpecAdapterBuilder.java
+++ b/crnk-core/src/main/java/io/crnk/core/queryspec/internal/QuerySpecAdapterBuilder.java
@@ -28,7 +28,7 @@ public class QuerySpecAdapterBuilder implements QueryAdapterBuilder {
 	@Override
 	public QueryAdapter build(ResourceInformation resourceInformation, Map<String, Set<String>> parameters,
 							  QueryContext queryContext) {
-		QuerySpecAdapter adapter = new QuerySpecAdapter(querySpecUrlMapper.deserialize(resourceInformation, parameters),
+		QuerySpecAdapter adapter = new QuerySpecAdapter(querySpecUrlMapper.deserialize(resourceInformation, parameters, queryContext),
 				moduleRegistry.getResourceRegistry(), queryContext);
 		HttpRequestContext requestContext = moduleRegistry.getHttpRequestContextProvider().getRequestContext();
 		if (requestContext != null) {

--- a/crnk-core/src/main/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapper.java
+++ b/crnk-core/src/main/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapper.java
@@ -1,17 +1,5 @@
 package io.crnk.core.queryspec.mapper;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,6 +9,7 @@ import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.engine.internal.utils.StringUtils;
 import io.crnk.core.engine.parser.ParserException;
 import io.crnk.core.engine.parser.TypeParser;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.exception.ParametersDeserializationException;
@@ -39,692 +28,682 @@ import io.crnk.core.queryspec.pagingspec.PagingSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 public class DefaultQuerySpecUrlMapper
-		implements QuerySpecUrlMapper, UnkonwnMappingAware {
+        implements QuerySpecUrlMapper, UnkonwnMappingAware {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(DefaultQuerySpecUrlMapper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultQuerySpecUrlMapper.class);
 
-	private static final String NULL_VALUE_STRING = "null";
+    private static final String NULL_VALUE_STRING = "null";
 
-	private FilterOperator defaultOperator = FilterOperator.EQ;
+    private FilterOperator defaultOperator = FilterOperator.EQ;
 
-	private Map<String, FilterOperator> supportedOperators = new HashMap<>();
+    private Map<String, FilterOperator> supportedOperators = new HashMap<>();
 
-	private boolean enforceDotPathSeparator = true;
+    private boolean enforceDotPathSeparator = true;
 
-	private boolean ignoreParseExceptions;
+    private boolean ignoreParseExceptions;
 
-	private boolean allowUnknownParameters = false;
+    private boolean allowUnknownParameters = false;
 
-	protected QuerySpecUrlContext context;
+    protected QuerySpecUrlContext context;
 
-	protected QueryPathResolver pathResolver = new DefaultQueryPathResolver();
+    protected QueryPathResolver pathResolver = new DefaultQueryPathResolver();
 
-	private boolean allowCommaSeparatedValue = true;
+    private boolean allowCommaSeparatedValue = true;
 
-	private JsonFilterSpecMapper jsonParser;
+    private JsonFilterSpecMapper jsonParser;
 
-	private ObjectMapper compactMapper = new ObjectMapper();
+    private ObjectMapper compactMapper = new ObjectMapper();
 
 
-	public DefaultQuerySpecUrlMapper() {
-		addSupportedOperator(FilterOperator.LIKE);
-		addSupportedOperator(FilterOperator.EQ);
-		addSupportedOperator(FilterOperator.NEQ);
-		addSupportedOperator(FilterOperator.NOT);
-		addSupportedOperator(FilterOperator.AND);
-		addSupportedOperator(FilterOperator.OR);
-		addSupportedOperator(FilterOperator.GT);
-		addSupportedOperator(FilterOperator.GE);
-		addSupportedOperator(FilterOperator.LT);
-		addSupportedOperator(FilterOperator.LE);
-		addSupportedOperator(FilterOperator.SELECT);
-		addSupportedOperator(FilterOperator.GROUP);
-	}
-
-	@Override
-	public void init(QuerySpecUrlContext ctx) {
-		this.context = ctx;
-		pathResolver.init(context);
-
-		jsonParser = new JsonFilterSpecMapper(ctx, supportedOperators, defaultOperator, pathResolver);
-	}
-
-	/**
-	 * @return true if attribute paths must be separated with ".". Ealier
-	 * Crnk versions did made use of brackets
-	 * "[attribute1][attribute2]".
-	 */
-	public boolean getEnforceDotPathSeparator() {
-		return enforceDotPathSeparator;
-	}
-
-	public void setEnforceDotPathSeparator(boolean enforceDotPathSeparator) {
-		this.enforceDotPathSeparator = enforceDotPathSeparator;
-	}
-
-	/**
-	 * @return whether to allow to pass unknown paths in sort, filter, include and field parameters. Disabled by default.
-	 */
-	public boolean getAllowUnknownAttributes() {
-		return pathResolver.getAllowUnknownAttributes();
-	}
-
-	public void setAllowUnknownAttributes(boolean allowUnknownAttributes) {
-		pathResolver.setAllowUnknownAttributes(allowUnknownAttributes);
-	}
-
-	/**
-	 * @return true if filter parameters can be separated by comma, resulting in a collection of values typically filtered as OR.
-	 */
-	public boolean getAllowCommaSeparatedValue() {
-		return allowCommaSeparatedValue;
-	}
-
-	public void setAllowCommaSeparatedValue(boolean allowCommaSeparatedValue) {
-		this.allowCommaSeparatedValue = allowCommaSeparatedValue;
-	}
-
-	/**
-	 * @return whether to map json to java names in {@link QuerySpec} for sort, filter, include and field parameters. True by
-	 * default.
-	 */
-	public boolean getMapJsonNames() {
-		return pathResolver.getMapJsonNames();
-	}
-
-	public void setMapJsonNames(boolean mapJsonNames) {
-		pathResolver.setMapJsonNames(mapJsonNames);
-	}
-
-	public FilterOperator getDefaultOperator() {
-		return defaultOperator;
-	}
-
-	public void setDefaultOperator(FilterOperator defaultOperator) {
-		this.defaultOperator = defaultOperator;
-	}
-
-	public Collection<FilterOperator> getSupportedOperators() {
-		return supportedOperators.values();
-	}
-
-	public void addSupportedOperator(FilterOperator supportedOperator) {
-		this.supportedOperators.put(supportedOperator.getName(), supportedOperator);
-	}
-
-
-	protected QuerySpec createQuerySpec(ResourceInformation resourceInformation) {
-		return new QuerySpec(resourceInformation);
-	}
-
-	@Override
-	public QuerySpec deserialize(ResourceInformation resourceInformation, Map<String, Set<String>> parameterMap) {
-		QuerySpec rootQuerySpec = createQuerySpec(resourceInformation);
-
-		List<QueryParameter> parameters = parseParameters(parameterMap, resourceInformation);
-		Map<String, Set<String>> pageParameters = new HashMap<>();
-		for (QueryParameter parameter : parameters) {
-			QuerySpec querySpec = rootQuerySpec;
-			if (parameter.getResourceInformation() != null) {
-				querySpec = rootQuerySpec.getQuerySpec(parameter.getResourceInformation());
-				if (querySpec == null) {
-					querySpec = rootQuerySpec.getOrCreateQuerySpec(parameter.getResourceInformation());
-				}
-			}
-			switch (parameter.getType()) {
-				case SORT:
-					deserializeSort(querySpec, parameter);
-					break;
-				case FILTER:
-					deserializeFilter(querySpec, parameter);
-					break;
-				case INCLUDE:
-					deserializeIncludes(querySpec, parameter);
-					break;
-				case FIELDS:
-					deserializeFields(querySpec, parameter);
-					break;
-				case PAGE:
-					pageParameters.put(parameter.getPagingType(), parameter.getValues());
-					break;
-				default:
-					deserializeUnknown(querySpec, parameter);
-			}
-		}
-
-		RegistryEntry entry = context.getResourceRegistry().getEntry(resourceInformation.getResourceType());
-		PagingBehavior<PagingSpec> pagingBehavior = entry.getPagingBehavior();
-
-		if (pagingBehavior == null && !pageParameters.isEmpty()) {
-			throw new IllegalStateException("Instance of PagingBehavior must be provided");
-		}
-
-		if (pagingBehavior != null) {
-			PagingSpec pagingSpec = pagingBehavior.deserialize(pageParameters);
-			rootQuerySpec.setPaging(pagingSpec);
-		}
-
-		return rootQuerySpec;
-	}
-
-	private static void put(Map<String, Set<String>> map, String key, String value) {
-		map.put(key, new HashSet<>(Arrays.asList(value)));
-	}
-
-	private String toJsonPath(ResourceInformation resourceInformation, List<String> attributePath) {
-		QueryPathSpec pathSpec =
-				pathResolver.resolve(resourceInformation, attributePath, QueryPathResolver.NamingType.JAVA, null);
-		return StringUtils.join(".", pathSpec.getAttributePath());
-	}
-
-	protected String addResourceType(QueryParameterType type, String key, ResourceInformation resourceInformation, boolean isRoot) {
-		String resourceType = resourceInformation.getResourceType();
-		if (isRoot) {
-			return type.toString().toLowerCase() + (key != null ? key : "");
-		}
-		return type.toString().toLowerCase() + "[" + resourceType + "]" + (key != null ? key : "");
-	}
-
-	protected String serializeValue(Object value) {
-		if (value == null) {
-			return NULL_VALUE_STRING;
-		}
-		TypeParser typeParser = context.getTypeParser();
-		String strValue = typeParser.toString(value);
-		PreconditionUtil.verify(strValue != null, "should not map to null: %s", value);
-		return strValue;
-	}
-
-	@Override
-	public Map<String, Set<String>> serialize(QuerySpec querySpec) {
-		Map<String, Set<String>> map = new HashMap<>();
-		serialize(querySpec, map, querySpec);
-		return map;
-	}
-
-	protected void serialize(QuerySpec querySpec, Map<String, Set<String>> map, QuerySpec rootQuerySpec) {
-		ResourceRegistry resourceRegistry = context.getResourceRegistry();
-		if (querySpec != null) {
-			String resourceType = querySpec.getResourceType();
-			ResourceInformation resourceInformation;
-			if (resourceType == null) {
-				RegistryEntry entry = resourceRegistry.getEntry(querySpec.getResourceClass());
-				if (entry == null) {
-					throw new RepositoryNotFoundException(querySpec.getResourceClass());
-				}
-				resourceInformation = entry.getResourceInformation();
-			}
-			else {
-				if (resourceRegistry.hasEntry(querySpec.getResourceType())) {
-					RegistryEntry entry = resourceRegistry.getEntry(querySpec.getResourceType());
-					resourceInformation = entry.getResourceInformation();
-				}
-				else {
-					// model may not be available on client side in case of dynamic client with Resource.class
-					resourceInformation = null;
-				}
-			}
-
-			boolean isRoot = querySpec == rootQuerySpec;
-
-			serializeFilters(querySpec, resourceInformation, map, isRoot);
-			serializeSorting(querySpec, resourceInformation, map, isRoot);
-			serializeIncludedFields(querySpec, resourceInformation, map, isRoot);
-			serializeIncludedRelations(querySpec, resourceInformation, map, isRoot);
-
-			RegistryEntry rootEntry = resourceRegistry.getEntry(rootQuerySpec.getResourceClass());
-			if (rootEntry != null && rootEntry.getResourceInformation() != null
-					&& rootEntry.getResourceInformation().getPagingSpecType() != null) {
-				PagingBehavior pagingBehavior = rootEntry.getPagingBehavior();
-				/**
-				 * Until we have order-based determination of pagination, we can not really rely on crnk finding proper one
-				 * since it will return first suitable pagination behavior even if there is an exact one.
-				 * As a result, we must always check whether resource's paging equals to the one query-spec holds.
-				 * If yes, use it as it is, otherwise try to convert it.
-				 */
-				PagingSpec pagingSpec = pagingBehavior.createDefaultPagingSpec().getClass().isInstance(querySpec.getPaging())
-						? querySpec.getPaging()
-						: querySpec.getPaging(rootEntry.getResourceInformation().getPagingSpecType());
-				map.putAll(pagingBehavior.serialize(pagingSpec, resourceType));
-			}
-
-			for (QuerySpec relatedSpec : querySpec.getNestedSpecs()) {
-				serialize(relatedSpec, map, querySpec);
-			}
-		}
-	}
-
-	protected void serializeFilters(QuerySpec querySpec, ResourceInformation resourceInformation, Map<String, Set<String>> map, boolean isRoot) {
-		if (jsonParser.isNested(querySpec.getFilters())) {
-			JsonNode jsonNode = jsonParser.serialize(querySpec.getFilters());
-			String json;
-			try {
-				// we keep it rather compact without white spaces (or any line separator) to avoid complex, encoded urls
-				json = compactMapper.writeValueAsString(jsonNode);
-			}
-			catch (JsonProcessingException e) {
-				throw new IllegalStateException(e);
-			}
-
-			String key = addResourceType(QueryParameterType.FILTER, null, resourceInformation, isRoot);
-			put(map, key, json);
-		}
-		else {
-
-			for (FilterSpec filterSpec : querySpec.getFilters()) {
-				if (filterSpec.hasExpressions()) {
-					throw new UnsupportedOperationException("filter expressions like and and or not yet supported");
-				}
-
-				String key;
-				if (filterSpec.getAttributePath() != null) {
-					String attrKey = "[" + toJsonPath(resourceInformation, filterSpec.getAttributePath()) + "]";
-					if (!defaultOperator.equals(filterSpec.getOperator())) {
-						attrKey += "[" + filterSpec.getOperator().getName() + "]";
-					}
-
-					key = addResourceType(QueryParameterType.FILTER, attrKey, resourceInformation, isRoot);
-				}
-				else {
-					// TODO support nested query spec
-					key = QueryParameterType.FILTER.toString().toLowerCase();
-				}
-
-				if (filterSpec.getValue() instanceof Collection) {
-					Collection<?> col = filterSpec.getValue();
-					Set<String> values = new HashSet<>();
-					for (Object elem : col) {
-						values.add(serializeValue(elem));
-					}
-					if (allowCommaSeparatedValue) {
-						String strValue = values.stream().sorted().collect(Collectors.joining(","));
-						HashSet singletonSet = new HashSet();
-						singletonSet.add(strValue);
-						map.put(key, singletonSet);
-					}
-					else {
-						map.put(key, values);
-					}
-				}
-				else {
-					String value = serializeValue(filterSpec.getValue());
-					put(map, key, value);
-				}
-			}
-		}
-	}
-
-	public void serializeSorting(QuerySpec querySpec, ResourceInformation resourceInformation, Map<String, Set<String>> map, boolean isRoot) {
-		if (!querySpec.getSort().isEmpty()) {
-			String key = addResourceType(QueryParameterType.SORT, null, resourceInformation, isRoot);
-
-			StringBuilder builder = new StringBuilder();
-			for (SortSpec filterSpec : querySpec.getSort()) {
-				if (builder.length() > 0) {
-					builder.append(",");
-				}
-				if (filterSpec.getDirection() == Direction.DESC) {
-					builder.append("-");
-				}
-				builder.append(toJsonPath(resourceInformation, filterSpec.getAttributePath()));
-			}
-			put(map, key, builder.toString());
-		}
-	}
-
-	protected void serializeIncludedFields(QuerySpec querySpec, ResourceInformation resourceInformation,
-			Map<String, Set<String>> map, boolean isRoot) {
-		if (!querySpec.getIncludedFields().isEmpty()) {
-			String key = addResourceType(QueryParameterType.FIELDS, null, resourceInformation, isRoot);
-
-			StringBuilder builder = new StringBuilder();
-			for (IncludeFieldSpec includedField : querySpec.getIncludedFields()) {
-				if (builder.length() > 0) {
-					builder.append(",");
-				}
-				builder.append(toJsonPath(resourceInformation, includedField.getAttributePath()));
-			}
-			put(map, key, builder.toString());
-		}
-	}
-
-	protected void serializeIncludedRelations(QuerySpec querySpec, ResourceInformation resourceInformation,
-			Map<String, Set<String>> map, boolean isRoot) {
-		if (!querySpec.getIncludedRelations().isEmpty()) {
-			String key = addResourceType(QueryParameterType.INCLUDE, null, resourceInformation, isRoot);
-
-			StringBuilder builder = new StringBuilder();
-			for (IncludeRelationSpec includedField : querySpec.getIncludedRelations()) {
-				if (builder.length() > 0) {
-					builder.append(",");
-				}
-				builder.append(toJsonPath(resourceInformation, includedField.getAttributePath()));
-			}
-			put(map, key, builder.toString());
-		}
-	}
-
-
-	protected void deserializeIncludes(QuerySpec querySpec, QueryParameter parameter) {
-		for (String values : parameter.getValues()) {
-			for (String value : splitValues(values)) {
-				List<String> attributePath = splitAttributePath(value, parameter);
-
-				ResourceInformation resourceInformation = parameter.getResourceInformation();
-				QueryPathSpec resolvedPath = pathResolver
-						.resolve(resourceInformation, attributePath, QueryPathResolver.NamingType.JSON, parameter.getName());
-				querySpec.includeRelation(resolvedPath.getAttributePath());
-			}
-		}
-	}
-
-	private String[] splitValues(String values) {
-		return values.split(",");
-	}
-
-	protected void deserializeFields(QuerySpec querySpec, QueryParameter parameter) {
-		ResourceInformation resourceInformation = parameter.getResourceInformation();
-		for (String values : parameter.getValues()) {
-			for (String value : splitValues(values)) {
-				List<String> attributePath = splitAttributePath(value, parameter);
-				QueryPathSpec resolvedPath = pathResolver
-						.resolve(resourceInformation, attributePath, QueryPathResolver.NamingType.JSON, parameter.getName());
-				querySpec.includeField(resolvedPath.getAttributePath());
-			}
-		}
-	}
-
-	protected void deserializeFilter(QuerySpec querySpec, QueryParameter parameter) {
-		ResourceInformation resourceInformation = parameter.getResourceInformation();
-
-		FilterOperator operator = parameter.getOperator();
-
-		QueryPathSpec resolvedPath = pathResolver.resolve(resourceInformation, parameter.getAttributePath(),
-				QueryPathResolver.NamingType.JSON, parameter.getName());
-		resolvedPath.verifyFilterable();
-		Class filterType = ClassUtils.getRawType(operator.getFilterType(parameter, resolvedPath.getValueType()));
-
-		Optional<JsonNode> optional = getJsonQuery(resolvedPath, parameter);
-		if (optional.isPresent()) {
-			// structured json filter parameter
-			List<FilterSpec> filterSpecs = jsonParser.deserialize(optional.get(), parameter.getResourceInformation());
-			filterSpecs.forEach(querySpec::addFilter);
-		}
-		else {
-			// regular basic filter parameter
-			Set<Object> typedValues = new HashSet<>();
-			for (String stringValue : parameter.getValues()) {
-				if (operator != FilterOperator.GROUP) {
-					typedValues.add(toObjectValue(stringValue, parameter, filterType));
-				}
-				else {
-					typedValues.add(stringValue);
-				}
-			}
-			Object value = typedValues.size() == 1 ? typedValues.iterator().next() : typedValues;
-			FilterSpec filterSpec = new FilterSpec(resolvedPath.getAttributePath(), operator, value);
-			querySpec.addFilter(filterSpec);
-		}
-	}
-
-
-	private Optional<JsonNode> getJsonQuery(QueryPathSpec resolvedPath, QueryParameter parameter) {
-		if (resolvedPath.getAttributePath() == null && parameter.getValues().size() == 1) {
-			String value = parameter.getValues().iterator().next();
-			if (jsonParser.isJson(value)) {
-				ObjectMapper objectMapper = context.getObjectMapper();
-				try {
-					return Optional.of(objectMapper.readTree(value));
-				}
-				catch (IOException e) {
-					throw new ParametersDeserializationException("failed to parse " + value, e);
-				}
-			}
-		}
-		return Optional.empty();
-	}
-
-	private Object toObjectValue(String stringValue, QueryParameter parameter, Class filterType) {
-		try {
-			if (NULL_VALUE_STRING.equals(stringValue)) {
-				return null;
-			}
-			else if (filterType != Object.class) {
-				TypeParser typeParser = context.getTypeParser();
-				return typeParser.parse(stringValue, filterType);
-			}
-			else {
-				return stringValue;
-			}
-		}
-		catch (ParserException e) {
-			if (ignoreParseExceptions) {
-				LOGGER.debug("failed to parse {}", parameter);
-				return stringValue;
-			}
-			else {
-				throw new ParametersDeserializationException(parameter.toString(), e);
-			}
-		}
-	}
-
-
-	private void deserializeSort(QuerySpec querySpec, QueryParameter parameter) {
-		ResourceInformation resourceInformation = parameter.getResourceInformation();
-		for (String values : parameter.getValues()) {
-			for (String value : splitValues(values)) {
-				boolean desc = value.startsWith("-");
-				if (desc) {
-					value = value.substring(1);
-				}
-				List<String> attributePath = splitAttributePath(value, parameter);
-
-				QueryPathSpec resolvedPath = pathResolver
-						.resolve(resourceInformation, attributePath, QueryPathResolver.NamingType.JSON, parameter.getName());
-				resolvedPath.verifySortable();
-
-				Direction dir = desc ? Direction.DESC : Direction.ASC;
-				querySpec.addSort(new SortSpec(resolvedPath.getAttributePath(), dir));
-			}
-		}
-	}
-
-	protected void deserializeUnknown(QuerySpec querySpec, QueryParameter parameter) {
-		if (!allowUnknownParameters) {
-			throw new ParametersDeserializationException(parameter.getName());
-		}
-	}
-
-	protected List<QueryParameter> parseParameters(Map<String, Set<String>> params,
-			ResourceInformation rootResourceInformation) {
-		List<QueryParameter> list = new ArrayList<>();
-		Set<Map.Entry<String, Set<String>>> entrySet = params.entrySet();
-		for (Map.Entry<String, Set<String>> entry : entrySet) {
-			list.add(parseParameter(entry.getKey(), entry.getValue(), rootResourceInformation));
-		}
-		return list;
-	}
-
-	protected QueryParameter parseParameter(String parameterName, Set<String> values,
-			ResourceInformation rootResourceInformation) {
-		int typeSep = parameterName.indexOf('[');
-		String strParamType = typeSep != -1 ? parameterName.substring(0, typeSep) : parameterName;
-
-		QueryParameterType paramType;
-		try {
-			paramType = QueryParameterType.valueOf(strParamType.toUpperCase());
-		}
-		catch (IllegalArgumentException e) {
-			paramType = QueryParameterType.UNKNOWN;
-		}
-
-		boolean jsonFilter = false;
-		if (allowCommaSeparatedValue && paramType == QueryParameterType.FILTER && values.size() == 1) {
-			String value = values.iterator().next();
-			jsonFilter = jsonParser.isJson(value);
-			if (!jsonFilter) {
-				String[] valueArray = value.split("\\,");
-				values = new HashSet<>(Arrays.asList(valueArray));
-			}
-		}
-
-		List<String> elements = parseParameterNameArguments(parameterName, typeSep);
-
-		QueryParameter param = new QueryParameter(context.getTypeParser());
-		param.setName(parameterName);
-		param.setType(paramType);
-		param.setValues(values);
-
-
-		if (paramType == QueryParameterType.FILTER && elements.size() >= 1) {
-			parseFilterParameterName(param, elements, rootResourceInformation, !jsonFilter);
-		}
-		else if (paramType == QueryParameterType.PAGE && elements.size() == 1) {
-			param.setResourceInformation(rootResourceInformation);
-			param.setPagingType(elements.get(0));
-		}
-		else if (paramType == QueryParameterType.PAGE && elements.size() == 2) {
-			param.setResourceInformation(getResourceInformation(elements.get(0), parameterName));
-			param.setPagingType(elements.get(1));
-		}
-		else if (paramType == QueryParameterType.UNKNOWN) {
-			param.setResourceInformation(null);
-		}
-		else if (elements.size() == 1) {
-			param.setResourceInformation(getResourceInformation(elements.get(0), parameterName));
-		}
-		else {
-			param.setResourceInformation(rootResourceInformation);
-		}
-		if (param.getOperator() == null) {
-			param.setOperator(defaultOperator);
-		}
-		return param;
-	}
-
-	protected List<String> parseParameterNameArguments(String parameterName, int typeSep) {
-		List<String> elements = new ArrayList<>();
-		if (typeSep != -1) {
-			String parameterNameSuffix = parameterName.substring(typeSep);
-			if (!parameterNameSuffix.startsWith("[") || !parameterNameSuffix.endsWith("]")) {
-				throw new ParametersDeserializationException("expected not [ resp. ] in legacy " +
-						parameterName);
-			}
-			elements.addAll(Arrays.asList(parameterNameSuffix.substring(1, parameterNameSuffix.length() - 1).split("\\]\\[")));
-		}
-		return elements;
-	}
-
-	protected void parseFilterParameterName(QueryParameter param, List<String> elements,
-			ResourceInformation rootResourceInformation, boolean canHaveAttributes) {
-		// check whether last element is an operator
-		parseFilterOperator(param, elements);
-
-		if (elements.isEmpty()) {
-			throw new ParametersDeserializationException("failed to parse " + param.getName() + ", expected "
-					+ "([resourceType])[attr1.attr2]([operator])");
-		}
-		if (enforceDotPathSeparator && elements.size() > 2) {
-			throw new ParametersDeserializationException(
-					"failed to parse " + param.getName() + ", expected ([resourceType])[attr1.attr2]([operator])");
-		}
-		if (enforceDotPathSeparator && elements.size() == 2) {
-			param.setResourceInformation(getResourceInformation(elements.get(0), param.getName()));
-			param.setAttributePath(Arrays.asList(elements.get(1).split("\\.")));
-		}
-		else if (enforceDotPathSeparator && elements.size() == 1 && !canHaveAttributes) {
-			param.setResourceInformation(getResourceInformation(elements.get(0), param.getName()));
-		}
-		else if (enforceDotPathSeparator && elements.size() == 1) {
-			param.setResourceInformation(rootResourceInformation);
-			param.setAttributePath(Arrays.asList(elements.get(0).split("\\.")));
-		}
-		else {
-			legacyParseFilterParameterName(param, elements, rootResourceInformation);
-		}
-	}
-
-	protected void legacyParseFilterParameterName(QueryParameter param, List<String> elements,
-			ResourceInformation rootResourceInformation) {
-		// check whether first element is a type or attribute, this
-		// can cause problems if names clash, so use
-		// enforceDotPathSeparator!
-		if (isResourceType(elements.get(0))) {
-			param.setResourceInformation(getResourceInformation(elements.get(0), param.getName()));
-			elements.remove(0);
-		}
-		else {
-			param.setResourceInformation(rootResourceInformation);
-		}
-		ArrayList<String> attributePath = new ArrayList<>();
-		for (String element : elements) {
-			attributePath.addAll(Arrays.asList(element.split("\\.")));
-		}
-		param.setAttributePath(attributePath);
-	}
-
-	protected void parseFilterOperator(QueryParameter param, List<String> elements) {
-		String lastElement = elements.get(elements.size() - 1);
-		FilterOperator operator = findOperator(lastElement);
-		if (operator != null) {
-			elements.remove(elements.size() - 1);
-		}
-		else {
-			operator = defaultOperator;
-		}
-		param.setOperator(operator);
-	}
-
-	protected boolean isResourceType(String resourceType) {
-		ResourceRegistry resourceRegistry = context.getResourceRegistry();
-		return resourceRegistry.hasEntry(resourceType);
-	}
-
-	protected FilterOperator findOperator(String lastElement) {
-		for (FilterOperator op : supportedOperators.values()) {
-			if (op.getName().equalsIgnoreCase(lastElement)) {
-				return op;
-			}
-		}
-		return null;
-	}
-
-	protected ResourceInformation getResourceInformation(String resourceType, String parameterName) {
-		ResourceRegistry resourceRegistry = context.getResourceRegistry();
-		RegistryEntry registryEntry = resourceRegistry.getEntry(resourceType);
-		if (registryEntry == null) {
-			throw new ParametersDeserializationException("failed to parse parameter " + parameterName + ", resourceType=" +
-					resourceType + " not found");
-		}
-		return registryEntry.getResourceInformation();
-	}
-
-	protected List<String> splitAttributePath(String pathString, QueryParameter param) {
-		return Arrays.asList(pathString.split("\\."));
-	}
-
-	public boolean isIgnoreParseExceptions() {
-		return ignoreParseExceptions;
-	}
-
-	public void setIgnoreParseExceptions(boolean ignoreParseExceptions) {
-		this.ignoreParseExceptions = ignoreParseExceptions;
-	}
-
-	public boolean isAllowUnknownParameters() {
-		return allowUnknownParameters;
-	}
-
-	public void setAllowUnknownParameters(final boolean allowUnknownParameters) {
-		this.allowUnknownParameters = allowUnknownParameters;
-	}
-
-	public boolean getAllowUnknownParameters() {
-		return allowUnknownParameters;
-	}
-
-	public QueryPathResolver getPathResolver() {
-		return pathResolver;
-	}
+    public DefaultQuerySpecUrlMapper() {
+        addSupportedOperator(FilterOperator.LIKE);
+        addSupportedOperator(FilterOperator.EQ);
+        addSupportedOperator(FilterOperator.NEQ);
+        addSupportedOperator(FilterOperator.NOT);
+        addSupportedOperator(FilterOperator.AND);
+        addSupportedOperator(FilterOperator.OR);
+        addSupportedOperator(FilterOperator.GT);
+        addSupportedOperator(FilterOperator.GE);
+        addSupportedOperator(FilterOperator.LT);
+        addSupportedOperator(FilterOperator.LE);
+        addSupportedOperator(FilterOperator.SELECT);
+        addSupportedOperator(FilterOperator.GROUP);
+    }
+
+    @Override
+    public void init(QuerySpecUrlContext ctx) {
+        this.context = ctx;
+        pathResolver.init(context);
+
+        jsonParser = new JsonFilterSpecMapper(ctx, supportedOperators, defaultOperator, pathResolver);
+    }
+
+    /**
+     * @return true if attribute paths must be separated with ".". Ealier
+     * Crnk versions did made use of brackets
+     * "[attribute1][attribute2]".
+     */
+    public boolean getEnforceDotPathSeparator() {
+        return enforceDotPathSeparator;
+    }
+
+    public void setEnforceDotPathSeparator(boolean enforceDotPathSeparator) {
+        this.enforceDotPathSeparator = enforceDotPathSeparator;
+    }
+
+    /**
+     * @return whether to allow to pass unknown paths in sort, filter, include and field parameters. Disabled by default.
+     */
+    public boolean getAllowUnknownAttributes() {
+        return pathResolver.getAllowUnknownAttributes();
+    }
+
+    public void setAllowUnknownAttributes(boolean allowUnknownAttributes) {
+        pathResolver.setAllowUnknownAttributes(allowUnknownAttributes);
+    }
+
+    /**
+     * @return true if filter parameters can be separated by comma, resulting in a collection of values typically filtered as OR.
+     */
+    public boolean getAllowCommaSeparatedValue() {
+        return allowCommaSeparatedValue;
+    }
+
+    public void setAllowCommaSeparatedValue(boolean allowCommaSeparatedValue) {
+        this.allowCommaSeparatedValue = allowCommaSeparatedValue;
+    }
+
+    /**
+     * @return whether to map json to java names in {@link QuerySpec} for sort, filter, include and field parameters. True by
+     * default.
+     */
+    public boolean getMapJsonNames() {
+        return pathResolver.getMapJsonNames();
+    }
+
+    public void setMapJsonNames(boolean mapJsonNames) {
+        pathResolver.setMapJsonNames(mapJsonNames);
+    }
+
+    public FilterOperator getDefaultOperator() {
+        return defaultOperator;
+    }
+
+    public void setDefaultOperator(FilterOperator defaultOperator) {
+        this.defaultOperator = defaultOperator;
+    }
+
+    public Collection<FilterOperator> getSupportedOperators() {
+        return supportedOperators.values();
+    }
+
+    public void addSupportedOperator(FilterOperator supportedOperator) {
+        this.supportedOperators.put(supportedOperator.getName(), supportedOperator);
+    }
+
+
+    protected QuerySpec createQuerySpec(ResourceInformation resourceInformation) {
+        return new QuerySpec(resourceInformation);
+    }
+
+    @Override
+    public QuerySpec deserialize(ResourceInformation resourceInformation, Map<String, Set<String>> parameterMap, QueryContext queryContext) {
+        QuerySpec rootQuerySpec = createQuerySpec(resourceInformation);
+
+        List<QueryParameter> parameters = parseParameters(parameterMap, resourceInformation);
+        Map<String, Set<String>> pageParameters = new HashMap<>();
+        for (QueryParameter parameter : parameters) {
+            QuerySpec querySpec = rootQuerySpec;
+            if (parameter.getResourceInformation() != null) {
+                querySpec = rootQuerySpec.getQuerySpec(parameter.getResourceInformation());
+                if (querySpec == null) {
+                    querySpec = rootQuerySpec.getOrCreateQuerySpec(parameter.getResourceInformation());
+                }
+            }
+            switch (parameter.getType()) {
+                case SORT:
+                    deserializeSort(querySpec, parameter, queryContext);
+                    break;
+                case FILTER:
+                    deserializeFilter(querySpec, parameter, queryContext);
+                    break;
+                case INCLUDE:
+                    deserializeIncludes(querySpec, parameter, queryContext);
+                    break;
+                case FIELDS:
+                    deserializeFields(querySpec, parameter, queryContext);
+                    break;
+                case VERSION:
+                    // handled earlier
+                    break;
+                case PAGE:
+                    pageParameters.put(parameter.getPagingType(), parameter.getValues());
+                    break;
+                default:
+                    deserializeUnknown(querySpec, parameter);
+            }
+        }
+
+        RegistryEntry entry = context.getResourceRegistry().getEntry(resourceInformation.getResourceType());
+        PagingBehavior<PagingSpec> pagingBehavior = entry.getPagingBehavior();
+
+        if (pagingBehavior == null && !pageParameters.isEmpty()) {
+            throw new IllegalStateException("Instance of PagingBehavior must be provided");
+        }
+
+        if (pagingBehavior != null) {
+            PagingSpec pagingSpec = pagingBehavior.deserialize(pageParameters);
+            rootQuerySpec.setPaging(pagingSpec);
+        }
+
+        return rootQuerySpec;
+    }
+
+    private static void put(Map<String, Set<String>> map, String key, String value) {
+        map.put(key, new HashSet<>(Arrays.asList(value)));
+    }
+
+    private String toJsonPath(ResourceInformation resourceInformation, List<String> attributePath, QueryContext queryContext) {
+        QueryPathSpec pathSpec =
+                pathResolver.resolve(resourceInformation, attributePath, QueryPathResolver.NamingType.JAVA, null, queryContext);
+        return StringUtils.join(".", pathSpec.getAttributePath());
+    }
+
+    protected String addResourceType(QueryParameterType type, String key, ResourceInformation resourceInformation, boolean isRoot) {
+        String resourceType = resourceInformation.getResourceType();
+        if (isRoot) {
+            return type.toString().toLowerCase() + (key != null ? key : "");
+        }
+        return type.toString().toLowerCase() + "[" + resourceType + "]" + (key != null ? key : "");
+    }
+
+    protected String serializeValue(Object value) {
+        if (value == null) {
+            return NULL_VALUE_STRING;
+        }
+        TypeParser typeParser = context.getTypeParser();
+        String strValue = typeParser.toString(value);
+        PreconditionUtil.verify(strValue != null, "should not map to null: %s", value);
+        return strValue;
+    }
+
+    @Override
+    public Map<String, Set<String>> serialize(QuerySpec querySpec, QueryContext queryContext) {
+        Map<String, Set<String>> map = new HashMap<>();
+        serialize(querySpec, map, querySpec, queryContext);
+        return map;
+    }
+
+    protected void serialize(QuerySpec querySpec, Map<String, Set<String>> map, QuerySpec rootQuerySpec, QueryContext queryContext) {
+        ResourceRegistry resourceRegistry = context.getResourceRegistry();
+        if (querySpec != null) {
+            String resourceType = querySpec.getResourceType();
+            ResourceInformation resourceInformation;
+            if (resourceType == null) {
+                RegistryEntry entry = resourceRegistry.getEntry(querySpec.getResourceClass());
+                if (entry == null) {
+                    throw new RepositoryNotFoundException(querySpec.getResourceClass());
+                }
+                resourceInformation = entry.getResourceInformation();
+            } else {
+                if (resourceRegistry.hasEntry(querySpec.getResourceType())) {
+                    RegistryEntry entry = resourceRegistry.getEntry(querySpec.getResourceType());
+                    resourceInformation = entry.getResourceInformation();
+                } else {
+                    // model may not be available on client side in case of dynamic client with Resource.class
+                    resourceInformation = null;
+                }
+            }
+
+            boolean isRoot = querySpec == rootQuerySpec;
+
+            serializeFilters(querySpec, resourceInformation, map, isRoot, queryContext);
+            serializeSorting(querySpec, resourceInformation, map, isRoot, queryContext);
+            serializeIncludedFields(querySpec, resourceInformation, map, isRoot, queryContext);
+            serializeIncludedRelations(querySpec, resourceInformation, map, isRoot, queryContext);
+
+            RegistryEntry rootEntry = resourceRegistry.getEntry(rootQuerySpec.getResourceClass());
+            if (rootEntry != null && rootEntry.getResourceInformation() != null
+                    && rootEntry.getResourceInformation().getPagingSpecType() != null) {
+                PagingBehavior pagingBehavior = rootEntry.getPagingBehavior();
+                /**
+                 * Until we have order-based determination of pagination, we can not really rely on crnk finding proper one
+                 * since it will return first suitable pagination behavior even if there is an exact one.
+                 * As a result, we must always check whether resource's paging equals to the one query-spec holds.
+                 * If yes, use it as it is, otherwise try to convert it.
+                 */
+                PagingSpec pagingSpec = pagingBehavior.createDefaultPagingSpec().getClass().isInstance(querySpec.getPaging())
+                        ? querySpec.getPaging()
+                        : querySpec.getPaging(rootEntry.getResourceInformation().getPagingSpecType());
+                map.putAll(pagingBehavior.serialize(pagingSpec, resourceType));
+            }
+
+            for (QuerySpec relatedSpec : querySpec.getNestedSpecs()) {
+                serialize(relatedSpec, map, querySpec, queryContext);
+            }
+        }
+    }
+
+    protected void serializeFilters(QuerySpec querySpec, ResourceInformation resourceInformation, Map<String, Set<String>> map, boolean isRoot, QueryContext queryContext) {
+        if (jsonParser.isNested(querySpec.getFilters())) {
+            JsonNode jsonNode = jsonParser.serialize(querySpec.getFilters());
+            String json;
+            try {
+                // we keep it rather compact without white spaces (or any line separator) to avoid complex, encoded urls
+                json = compactMapper.writeValueAsString(jsonNode);
+            } catch (JsonProcessingException e) {
+                throw new IllegalStateException(e);
+            }
+
+            String key = addResourceType(QueryParameterType.FILTER, null, resourceInformation, isRoot);
+            put(map, key, json);
+        } else {
+
+            for (FilterSpec filterSpec : querySpec.getFilters()) {
+                if (filterSpec.hasExpressions()) {
+                    throw new UnsupportedOperationException("filter expressions like and and or not yet supported");
+                }
+
+                String key;
+                if (filterSpec.getAttributePath() != null) {
+                    String attrKey = "[" + toJsonPath(resourceInformation, filterSpec.getAttributePath(), queryContext) + "]";
+                    if (!defaultOperator.equals(filterSpec.getOperator())) {
+                        attrKey += "[" + filterSpec.getOperator().getName() + "]";
+                    }
+
+                    key = addResourceType(QueryParameterType.FILTER, attrKey, resourceInformation, isRoot);
+                } else {
+                    // TODO support nested query spec
+                    key = QueryParameterType.FILTER.toString().toLowerCase();
+                }
+
+                if (filterSpec.getValue() instanceof Collection) {
+                    Collection<?> col = filterSpec.getValue();
+                    Set<String> values = new HashSet<>();
+                    for (Object elem : col) {
+                        values.add(serializeValue(elem));
+                    }
+                    if (allowCommaSeparatedValue) {
+                        String strValue = values.stream().sorted().collect(Collectors.joining(","));
+                        HashSet singletonSet = new HashSet();
+                        singletonSet.add(strValue);
+                        map.put(key, singletonSet);
+                    } else {
+                        map.put(key, values);
+                    }
+                } else {
+                    String value = serializeValue(filterSpec.getValue());
+                    put(map, key, value);
+                }
+            }
+        }
+    }
+
+    public void serializeSorting(QuerySpec querySpec, ResourceInformation resourceInformation, Map<String, Set<String>> map, boolean isRoot, QueryContext queryContext) {
+        if (!querySpec.getSort().isEmpty()) {
+            String key = addResourceType(QueryParameterType.SORT, null, resourceInformation, isRoot);
+
+            StringBuilder builder = new StringBuilder();
+            for (SortSpec filterSpec : querySpec.getSort()) {
+                if (builder.length() > 0) {
+                    builder.append(",");
+                }
+                if (filterSpec.getDirection() == Direction.DESC) {
+                    builder.append("-");
+                }
+                builder.append(toJsonPath(resourceInformation, filterSpec.getAttributePath(), queryContext));
+            }
+            put(map, key, builder.toString());
+        }
+    }
+
+    protected void serializeIncludedFields(QuerySpec querySpec, ResourceInformation resourceInformation,
+                                           Map<String, Set<String>> map, boolean isRoot, QueryContext queryContext) {
+        if (!querySpec.getIncludedFields().isEmpty()) {
+            String key = addResourceType(QueryParameterType.FIELDS, null, resourceInformation, isRoot);
+
+            StringBuilder builder = new StringBuilder();
+            for (IncludeFieldSpec includedField : querySpec.getIncludedFields()) {
+                if (builder.length() > 0) {
+                    builder.append(",");
+                }
+                builder.append(toJsonPath(resourceInformation, includedField.getAttributePath(), queryContext));
+            }
+            put(map, key, builder.toString());
+        }
+    }
+
+    protected void serializeIncludedRelations(QuerySpec querySpec, ResourceInformation resourceInformation,
+                                              Map<String, Set<String>> map, boolean isRoot, QueryContext queryContext) {
+        if (!querySpec.getIncludedRelations().isEmpty()) {
+            String key = addResourceType(QueryParameterType.INCLUDE, null, resourceInformation, isRoot);
+
+            StringBuilder builder = new StringBuilder();
+            for (IncludeRelationSpec includedField : querySpec.getIncludedRelations()) {
+                if (builder.length() > 0) {
+                    builder.append(",");
+                }
+                builder.append(toJsonPath(resourceInformation, includedField.getAttributePath(), queryContext));
+            }
+            put(map, key, builder.toString());
+        }
+    }
+
+
+    protected void deserializeIncludes(QuerySpec querySpec, QueryParameter parameter, QueryContext queryContext) {
+        for (String values : parameter.getValues()) {
+            for (String value : splitValues(values)) {
+                List<String> attributePath = splitAttributePath(value, parameter);
+
+                ResourceInformation resourceInformation = parameter.getResourceInformation();
+                QueryPathSpec resolvedPath = pathResolver
+                        .resolve(resourceInformation, attributePath, QueryPathResolver.NamingType.JSON, parameter.getName(), queryContext);
+                querySpec.includeRelation(resolvedPath.getAttributePath());
+            }
+        }
+    }
+
+    private String[] splitValues(String values) {
+        return values.split(",");
+    }
+
+    protected void deserializeFields(QuerySpec querySpec, QueryParameter parameter, QueryContext queryContext) {
+        ResourceInformation resourceInformation = parameter.getResourceInformation();
+        for (String values : parameter.getValues()) {
+            for (String value : splitValues(values)) {
+                List<String> attributePath = splitAttributePath(value, parameter);
+                QueryPathSpec resolvedPath = pathResolver
+                        .resolve(resourceInformation, attributePath, QueryPathResolver.NamingType.JSON, parameter.getName(), queryContext);
+                querySpec.includeField(resolvedPath.getAttributePath());
+            }
+        }
+    }
+
+    protected void deserializeFilter(QuerySpec querySpec, QueryParameter parameter, QueryContext queryContext) {
+        ResourceInformation resourceInformation = parameter.getResourceInformation();
+
+        FilterOperator operator = parameter.getOperator();
+
+        QueryPathSpec resolvedPath = pathResolver.resolve(resourceInformation, parameter.getAttributePath(),
+                QueryPathResolver.NamingType.JSON, parameter.getName(), queryContext);
+        resolvedPath.verifyFilterable();
+        Class filterType = ClassUtils.getRawType(operator.getFilterType(parameter, resolvedPath.getValueType()));
+
+        Optional<JsonNode> optional = getJsonQuery(resolvedPath, parameter);
+        if (optional.isPresent()) {
+            // structured json filter parameter
+            List<FilterSpec> filterSpecs = jsonParser.deserialize(optional.get(), parameter.getResourceInformation(), queryContext);
+            filterSpecs.forEach(querySpec::addFilter);
+        } else {
+            // regular basic filter parameter
+            Set<Object> typedValues = new HashSet<>();
+            for (String stringValue : parameter.getValues()) {
+                if (operator != FilterOperator.GROUP) {
+                    typedValues.add(toObjectValue(stringValue, parameter, filterType));
+                } else {
+                    typedValues.add(stringValue);
+                }
+            }
+            Object value = typedValues.size() == 1 ? typedValues.iterator().next() : typedValues;
+            FilterSpec filterSpec = new FilterSpec(resolvedPath.getAttributePath(), operator, value);
+            querySpec.addFilter(filterSpec);
+        }
+    }
+
+
+    private Optional<JsonNode> getJsonQuery(QueryPathSpec resolvedPath, QueryParameter parameter) {
+        if (resolvedPath.getAttributePath() == null && parameter.getValues().size() == 1) {
+            String value = parameter.getValues().iterator().next();
+            if (jsonParser.isJson(value)) {
+                ObjectMapper objectMapper = context.getObjectMapper();
+                try {
+                    return Optional.of(objectMapper.readTree(value));
+                } catch (IOException e) {
+                    throw new ParametersDeserializationException("failed to parse " + value, e);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Object toObjectValue(String stringValue, QueryParameter parameter, Class filterType) {
+        try {
+            if (NULL_VALUE_STRING.equals(stringValue)) {
+                return null;
+            } else if (filterType != Object.class) {
+                TypeParser typeParser = context.getTypeParser();
+                return typeParser.parse(stringValue, filterType);
+            } else {
+                return stringValue;
+            }
+        } catch (ParserException e) {
+            if (ignoreParseExceptions) {
+                LOGGER.debug("failed to parse {}", parameter);
+                return stringValue;
+            } else {
+                throw new ParametersDeserializationException(parameter.toString(), e);
+            }
+        }
+    }
+
+
+    private void deserializeSort(QuerySpec querySpec, QueryParameter parameter, QueryContext queryContext) {
+        ResourceInformation resourceInformation = parameter.getResourceInformation();
+        for (String values : parameter.getValues()) {
+            for (String value : splitValues(values)) {
+                boolean desc = value.startsWith("-");
+                if (desc) {
+                    value = value.substring(1);
+                }
+                List<String> attributePath = splitAttributePath(value, parameter);
+
+                QueryPathSpec resolvedPath = pathResolver
+                        .resolve(resourceInformation, attributePath, QueryPathResolver.NamingType.JSON, parameter.getName(), queryContext);
+                resolvedPath.verifySortable();
+
+                Direction dir = desc ? Direction.DESC : Direction.ASC;
+                querySpec.addSort(new SortSpec(resolvedPath.getAttributePath(), dir));
+            }
+        }
+    }
+
+    protected void deserializeUnknown(QuerySpec querySpec, QueryParameter parameter) {
+        if (!allowUnknownParameters) {
+            throw new ParametersDeserializationException(parameter.getName());
+        }
+    }
+
+    protected List<QueryParameter> parseParameters(Map<String, Set<String>> params,
+                                                   ResourceInformation rootResourceInformation) {
+        List<QueryParameter> list = new ArrayList<>();
+        Set<Map.Entry<String, Set<String>>> entrySet = params.entrySet();
+        for (Map.Entry<String, Set<String>> entry : entrySet) {
+            list.add(parseParameter(entry.getKey(), entry.getValue(), rootResourceInformation));
+        }
+        return list;
+    }
+
+    protected QueryParameter parseParameter(String parameterName, Set<String> values,
+                                            ResourceInformation rootResourceInformation) {
+        int typeSep = parameterName.indexOf('[');
+        String strParamType = typeSep != -1 ? parameterName.substring(0, typeSep) : parameterName;
+
+        QueryParameterType paramType;
+        try {
+            paramType = QueryParameterType.valueOf(strParamType.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            paramType = QueryParameterType.UNKNOWN;
+        }
+
+        boolean jsonFilter = false;
+        if (allowCommaSeparatedValue && paramType == QueryParameterType.FILTER && values.size() == 1) {
+            String value = values.iterator().next();
+            jsonFilter = jsonParser.isJson(value);
+            if (!jsonFilter) {
+                String[] valueArray = value.split("\\,");
+                values = new HashSet<>(Arrays.asList(valueArray));
+            }
+        }
+
+        List<String> elements = parseParameterNameArguments(parameterName, typeSep);
+
+        QueryParameter param = new QueryParameter(context.getTypeParser());
+        param.setName(parameterName);
+        param.setType(paramType);
+        param.setValues(values);
+
+
+        if (paramType == QueryParameterType.FILTER && elements.size() >= 1) {
+            parseFilterParameterName(param, elements, rootResourceInformation, !jsonFilter);
+        } else if (paramType == QueryParameterType.PAGE && elements.size() == 1) {
+            param.setResourceInformation(rootResourceInformation);
+            param.setPagingType(elements.get(0));
+        } else if (paramType == QueryParameterType.PAGE && elements.size() == 2) {
+            param.setResourceInformation(getResourceInformation(elements.get(0), parameterName));
+            param.setPagingType(elements.get(1));
+        } else if (paramType == QueryParameterType.UNKNOWN) {
+            param.setResourceInformation(null);
+        } else if (elements.size() == 1) {
+            param.setResourceInformation(getResourceInformation(elements.get(0), parameterName));
+        } else {
+            param.setResourceInformation(rootResourceInformation);
+        }
+        if (param.getOperator() == null) {
+            param.setOperator(defaultOperator);
+        }
+        return param;
+    }
+
+    protected List<String> parseParameterNameArguments(String parameterName, int typeSep) {
+        List<String> elements = new ArrayList<>();
+        if (typeSep != -1) {
+            String parameterNameSuffix = parameterName.substring(typeSep);
+            if (!parameterNameSuffix.startsWith("[") || !parameterNameSuffix.endsWith("]")) {
+                throw new ParametersDeserializationException("expected not [ resp. ] in legacy " +
+                        parameterName);
+            }
+            elements.addAll(Arrays.asList(parameterNameSuffix.substring(1, parameterNameSuffix.length() - 1).split("\\]\\[")));
+        }
+        return elements;
+    }
+
+    protected void parseFilterParameterName(QueryParameter param, List<String> elements,
+                                            ResourceInformation rootResourceInformation, boolean canHaveAttributes) {
+        // check whether last element is an operator
+        parseFilterOperator(param, elements);
+
+        if (elements.isEmpty()) {
+            throw new ParametersDeserializationException("failed to parse " + param.getName() + ", expected "
+                    + "([resourceType])[attr1.attr2]([operator])");
+        }
+        if (enforceDotPathSeparator && elements.size() > 2) {
+            throw new ParametersDeserializationException(
+                    "failed to parse " + param.getName() + ", expected ([resourceType])[attr1.attr2]([operator])");
+        }
+        if (enforceDotPathSeparator && elements.size() == 2) {
+            param.setResourceInformation(getResourceInformation(elements.get(0), param.getName()));
+            param.setAttributePath(Arrays.asList(elements.get(1).split("\\.")));
+        } else if (enforceDotPathSeparator && elements.size() == 1 && !canHaveAttributes) {
+            param.setResourceInformation(getResourceInformation(elements.get(0), param.getName()));
+        } else if (enforceDotPathSeparator && elements.size() == 1) {
+            param.setResourceInformation(rootResourceInformation);
+            param.setAttributePath(Arrays.asList(elements.get(0).split("\\.")));
+        } else {
+            legacyParseFilterParameterName(param, elements, rootResourceInformation);
+        }
+    }
+
+    protected void legacyParseFilterParameterName(QueryParameter param, List<String> elements,
+                                                  ResourceInformation rootResourceInformation) {
+        // check whether first element is a type or attribute, this
+        // can cause problems if names clash, so use
+        // enforceDotPathSeparator!
+        if (isResourceType(elements.get(0))) {
+            param.setResourceInformation(getResourceInformation(elements.get(0), param.getName()));
+            elements.remove(0);
+        } else {
+            param.setResourceInformation(rootResourceInformation);
+        }
+        ArrayList<String> attributePath = new ArrayList<>();
+        for (String element : elements) {
+            attributePath.addAll(Arrays.asList(element.split("\\.")));
+        }
+        param.setAttributePath(attributePath);
+    }
+
+    protected void parseFilterOperator(QueryParameter param, List<String> elements) {
+        String lastElement = elements.get(elements.size() - 1);
+        FilterOperator operator = findOperator(lastElement);
+        if (operator != null) {
+            elements.remove(elements.size() - 1);
+        } else {
+            operator = defaultOperator;
+        }
+        param.setOperator(operator);
+    }
+
+    protected boolean isResourceType(String resourceType) {
+        ResourceRegistry resourceRegistry = context.getResourceRegistry();
+        return resourceRegistry.hasEntry(resourceType);
+    }
+
+    protected FilterOperator findOperator(String lastElement) {
+        for (FilterOperator op : supportedOperators.values()) {
+            if (op.getName().equalsIgnoreCase(lastElement)) {
+                return op;
+            }
+        }
+        return null;
+    }
+
+    protected ResourceInformation getResourceInformation(String resourceType, String parameterName) {
+        ResourceRegistry resourceRegistry = context.getResourceRegistry();
+        RegistryEntry registryEntry = resourceRegistry.getEntry(resourceType);
+        if (registryEntry == null) {
+            throw new ParametersDeserializationException("failed to parse parameter " + parameterName + ", resourceType=" +
+                    resourceType + " not found");
+        }
+        return registryEntry.getResourceInformation();
+    }
+
+    protected List<String> splitAttributePath(String pathString, QueryParameter param) {
+        return Arrays.asList(pathString.split("\\."));
+    }
+
+    public boolean isIgnoreParseExceptions() {
+        return ignoreParseExceptions;
+    }
+
+    public void setIgnoreParseExceptions(boolean ignoreParseExceptions) {
+        this.ignoreParseExceptions = ignoreParseExceptions;
+    }
+
+    public boolean isAllowUnknownParameters() {
+        return allowUnknownParameters;
+    }
+
+    public void setAllowUnknownParameters(final boolean allowUnknownParameters) {
+        this.allowUnknownParameters = allowUnknownParameters;
+    }
+
+    public boolean getAllowUnknownParameters() {
+        return allowUnknownParameters;
+    }
+
+    public QueryPathResolver getPathResolver() {
+        return pathResolver;
+    }
 }

--- a/crnk-core/src/main/java/io/crnk/core/queryspec/mapper/QueryParameterType.java
+++ b/crnk-core/src/main/java/io/crnk/core/queryspec/mapper/QueryParameterType.java
@@ -17,6 +17,11 @@ public enum QueryParameterType {
 	PAGE,
 
 	/**
+	 * Used as fallback to content negotiation with HTTP ACCEPT header
+	 */
+	VERSION,
+
+	/**
 	 * List of specified fields to include in models
 	 */
 	FIELDS,

--- a/crnk-core/src/main/java/io/crnk/core/queryspec/mapper/QueryPathResolver.java
+++ b/crnk-core/src/main/java/io/crnk/core/queryspec/mapper/QueryPathResolver.java
@@ -1,40 +1,41 @@
 package io.crnk.core.queryspec.mapper;
 
 import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.queryspec.QuerySpec;
 
 import java.util.List;
 
 public interface QueryPathResolver {
 
-	enum NamingType {
-		JAVA,
-		JSON
-	}
+    enum NamingType {
+        JAVA,
+        JSON
+    }
 
-	void init(QuerySpecUrlContext context);
+    void init(QuerySpecUrlContext context);
 
-	/**
-	 * Translates a parameter path to/from JSON for QuerySpec-related operations.
-	 *
-	 * @param resourceInformation
-	 * @param attributePath
-	 * @param sourceParameter
-	 * @return
-	 */
-	QueryPathSpec resolve(ResourceInformation resourceInformation, List<String> attributePath, NamingType sourceNamingType, String sourceParameter);
+    /**
+     * Translates a parameter path to/from JSON for QuerySpec-related operations.
+     *
+     * @param resourceInformation
+     * @param attributePath
+     * @param sourceParameter
+     * @return
+     */
+    QueryPathSpec resolve(ResourceInformation resourceInformation, List<String> attributePath, NamingType sourceNamingType, String sourceParameter, QueryContext queryContext);
 
-	/**
-	 * @return whether to allow to pass unknown paths in sort, filter, include and field parameters. Disabled by default.
-	 */
-	boolean getAllowUnknownAttributes();
+    /**
+     * @return whether to allow to pass unknown paths in sort, filter, include and field parameters. Disabled by default.
+     */
+    boolean getAllowUnknownAttributes();
 
-	void setAllowUnknownAttributes(boolean allowUnknownAttributes);
+    void setAllowUnknownAttributes(boolean allowUnknownAttributes);
 
-	/**
-	 * @return whether to map json to java names in {@link QuerySpec} for sort, filter, include and field parameters. True by default.
-	 */
-	boolean getMapJsonNames();
+    /**
+     * @return whether to map json to java names in {@link QuerySpec} for sort, filter, include and field parameters. True by default.
+     */
+    boolean getMapJsonNames();
 
-	void setMapJsonNames(boolean mapJsonNames);
+    void setMapJsonNames(boolean mapJsonNames);
 }

--- a/crnk-core/src/main/java/io/crnk/core/queryspec/mapper/QuerySpecUrlMapper.java
+++ b/crnk-core/src/main/java/io/crnk/core/queryspec/mapper/QuerySpecUrlMapper.java
@@ -1,6 +1,7 @@
 package io.crnk.core.queryspec.mapper;
 
 import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.queryspec.QuerySpec;
 
 import java.util.Map;
@@ -11,10 +12,10 @@ import java.util.Set;
  */
 public interface QuerySpecUrlMapper {
 
-	void init(QuerySpecUrlContext ctx);
+    void init(QuerySpecUrlContext ctx);
 
-	Map<String, Set<String>> serialize(QuerySpec querySpec);
+    Map<String, Set<String>> serialize(QuerySpec querySpec, QueryContext queryContext);
 
-	QuerySpec deserialize(ResourceInformation resourceInformation, Map<String, Set<String>> queryParams);
+    QuerySpec deserialize(ResourceInformation resourceInformation, Map<String, Set<String>> queryParams, QueryContext queryContext);
 
 }

--- a/crnk-core/src/main/java/io/crnk/core/resource/annotations/JsonApiVersion.java
+++ b/crnk-core/src/main/java/io/crnk/core/resource/annotations/JsonApiVersion.java
@@ -1,0 +1,25 @@
+package io.crnk.core.resource.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Defines the version range the given type or field is applicable. Only types and fields with ranges that
+ * fall into the request version are returned. A version is represented as an integer number.
+ * <p>
+ * Currently considered experimental.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD})
+public @interface JsonApiVersion {
+
+    int min() default 0;
+
+    int max() default Integer.MAX_VALUE;
+
+}

--- a/crnk-core/src/test/java/io/crnk/core/CoreTestContainer.java
+++ b/crnk-core/src/test/java/io/crnk/core/CoreTestContainer.java
@@ -44,6 +44,7 @@ public class CoreTestContainer {
         requestContextBase = Mockito.mock(HttpRequestContextBase.class);
         requestContext = new HttpRequestContextBaseAdapter(requestContextBase);
         queryContext = requestContext.getQueryContext();
+        queryContext.setRequestVersion(0);
         queryContext.setBaseUrl(boot.getServiceUrlProvider().getUrl());
 
         boot.boot();

--- a/crnk-core/src/test/java/io/crnk/core/engine/http/HttpRequestContextProviderTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/http/HttpRequestContextProviderTest.java
@@ -1,7 +1,10 @@
 package io.crnk.core.engine.http;
 
 
+import io.crnk.core.engine.query.QueryContext;
+import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.engine.result.ImmediateResultFactory;
+import io.crnk.core.module.ModuleRegistry;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -10,11 +13,18 @@ public class HttpRequestContextProviderTest {
 
 	@Test
 	public void test() {
+		ModuleRegistry moduleRegistry = Mockito.mock(ModuleRegistry.class);
+		ResourceRegistry resourceRegistry = Mockito.mock(ResourceRegistry.class);
+		Mockito.when(resourceRegistry.getLatestVersion()).thenReturn(2);
+		Mockito.when(moduleRegistry.getResourceRegistry()).thenReturn(resourceRegistry);
+
 		ImmediateResultFactory resultFactory = new ImmediateResultFactory();
-		HttpRequestContextProvider provider = new HttpRequestContextProvider(() -> resultFactory);
+		HttpRequestContextProvider provider = new HttpRequestContextProvider(() -> resultFactory, moduleRegistry);
 
 		HttpRequestContext context = Mockito.mock(HttpRequestContext.class);
 		Mockito.when(context.getBaseUrl()).thenReturn("http://test");
+		QueryContext queryContext = new QueryContext();
+		Mockito.when(context.getQueryContext()).thenReturn(queryContext);
 
 		Assert.assertFalse(provider.hasThreadRequestContext());
 
@@ -24,5 +34,6 @@ public class HttpRequestContextProviderTest {
 		Assert.assertEquals("http://test", provider.getServiceUrlProvider().getUrl());
 		provider.onRequestFinished();
 		Assert.assertFalse(provider.hasThreadRequestContext());
+		Assert.assertEquals(2, queryContext.getRequestVersion()); // set to latest from registry
 	}
 }

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/BaseControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/BaseControllerTest.java
@@ -6,15 +6,12 @@ import io.crnk.core.engine.filter.FilterBehavior;
 import io.crnk.core.engine.filter.ResourceFilterDirectory;
 import io.crnk.core.engine.http.HttpMethod;
 import io.crnk.core.engine.information.resource.ResourceField;
-import io.crnk.core.engine.information.resource.ResourceFieldAccess;
 import io.crnk.core.engine.internal.dispatcher.path.JsonPath;
 import io.crnk.core.engine.properties.NullPropertiesProvider;
 import io.crnk.core.engine.query.QueryAdapter;
 import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.result.Result;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Test;
 import org.mockito.Mockito;
 
 public class BaseControllerTest {

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/CollectionGetControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/CollectionGetControllerTest.java
@@ -33,7 +33,7 @@ public class CollectionGetControllerTest extends ControllerTestBase {
     @Test
     public void onGivenRequestCollectionGetShouldAcceptIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("/tasks/");
+        JsonPath jsonPath = pathBuilder.build("/tasks/", queryContext);
         CollectionGetController sut = new CollectionGetController();
         sut.init(controllerContext);
 
@@ -47,7 +47,7 @@ public class CollectionGetControllerTest extends ControllerTestBase {
     @Test
     public void onGivenRequestCollectionGetShouldDenyIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("/tasks/2");
+        JsonPath jsonPath = pathBuilder.build("/tasks/2", queryContext);
         CollectionGetController sut = new CollectionGetController();
         sut.init(controllerContext);
 
@@ -62,7 +62,7 @@ public class CollectionGetControllerTest extends ControllerTestBase {
     public void onGivenRequestCollectionGetShouldHandleIt() {
         // GIVEN
 
-        JsonPath jsonPath = pathBuilder.build("/tasks/");
+        JsonPath jsonPath = pathBuilder.build("/tasks/", queryContext);
         CollectionGetController sut = new CollectionGetController();
         sut.init(controllerContext);
 
@@ -77,7 +77,7 @@ public class CollectionGetControllerTest extends ControllerTestBase {
     public void onGivenRequestCollectionWithIdsGetShouldHandleIt() {
         // GIVEN
 
-        JsonPath jsonPath = pathBuilder.build("/tasks/1,2");
+        JsonPath jsonPath = pathBuilder.build("/tasks/1,2", queryContext);
         CollectionGetController sut = new CollectionGetController();
         sut.init(controllerContext);
 
@@ -98,7 +98,7 @@ public class CollectionGetControllerTest extends ControllerTestBase {
         data.setType("tasks");
         data.setId(Long.toString(taskId));
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
 
@@ -117,7 +117,7 @@ public class CollectionGetControllerTest extends ControllerTestBase {
         Document newTaskBody = new Document();
         Resource data = createTask();
         newTaskBody.setData(Nullable.of(data));
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
 
@@ -135,7 +135,7 @@ public class CollectionGetControllerTest extends ControllerTestBase {
         Document newProjectBody = new Document();
         data = createProject();
         newProjectBody.setData(Nullable.of(data));
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN -- adding a project
         Response projectResponse = resourcePost.handle(projectPath, emptyProjectQuery, newProjectBody);
@@ -157,7 +157,7 @@ public class CollectionGetControllerTest extends ControllerTestBase {
         data.setType("projects");
         data.setId(projectId.toString());
 
-        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/includedProjects");
+        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/includedProjects", queryContext);
         RelationshipsPostController sut = new RelationshipsPostController();
         sut.init(controllerContext);
 
@@ -173,7 +173,7 @@ public class CollectionGetControllerTest extends ControllerTestBase {
         assertThat(projects.get(0).getId()).isEqualTo(projectId);
 
         // Given
-        JsonPath jsonPath = pathBuilder.build("/tasks/" + taskId);
+        JsonPath jsonPath = pathBuilder.build("/tasks/" + taskId, queryContext);
         ResourceGetController responseGetResp = new ResourceGetController();
         responseGetResp.init(controllerContext);
         QuerySpec queryParams1 = new QuerySpec(Task.class);
@@ -201,7 +201,7 @@ public class CollectionGetControllerTest extends ControllerTestBase {
         newTaskBody.setData(Nullable.of(data));
         data.setType("tasks");
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
 
@@ -220,7 +220,7 @@ public class CollectionGetControllerTest extends ControllerTestBase {
         data = createProject();
         newProjectBody.setData(Nullable.of(data));
 
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN -- adding a project
         Response projectResponse = resourcePost.handle(projectPath, emptyProjectQuery, newProjectBody);
@@ -242,7 +242,7 @@ public class CollectionGetControllerTest extends ControllerTestBase {
         data.setType("projects");
         data.setId(projectId.toString());
 
-        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/projects");
+        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/projects", queryContext);
         RelationshipsPostController sut =
                 new RelationshipsPostController();
         sut.init(controllerContext);
@@ -260,7 +260,7 @@ public class CollectionGetControllerTest extends ControllerTestBase {
         assertThat(projects.get(0).getId()).isNotNull();
 
         // Given
-        JsonPath jsonPath = pathBuilder.build("/tasks/" + taskId);
+        JsonPath jsonPath = pathBuilder.build("/tasks/" + taskId, queryContext);
         ResourceGetController responseGetResp = new ResourceGetController();
         responseGetResp.init(controllerContext);
         QuerySpec requestParams = new QuerySpec(Task.class);

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/ControllerTestBase.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/ControllerTestBase.java
@@ -1,5 +1,11 @@
 package io.crnk.core.engine.internal.dispatcher.controller;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.crnk.core.CoreTestContainer;
@@ -13,6 +19,7 @@ import io.crnk.core.engine.internal.document.mapper.DocumentMapper;
 import io.crnk.core.engine.internal.document.mapper.DocumentMappingConfig;
 import io.crnk.core.engine.parser.TypeParser;
 import io.crnk.core.engine.properties.PropertiesProvider;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.engine.result.Result;
 import io.crnk.core.mock.models.ComplexPojo;
@@ -30,12 +37,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 public abstract class ControllerTestBase {
 
@@ -55,6 +56,8 @@ public abstract class ControllerTestBase {
     protected TypeParser typeParser;
 
     protected DocumentMapper documentMapper;
+
+    protected QueryContext queryContext = new QueryContext().setRequestVersion(0);
 
     protected ModuleRegistry moduleRegistry;
 
@@ -136,7 +139,7 @@ public abstract class ControllerTestBase {
         data.setId("1");
         try {
             data.setAttribute("name", objectMapper.readTree("\"sample task\""));
-            data.setAttribute("data", objectMapper.readTree("\"asd\""));
+            data.setAttribute("category", objectMapper.readTree("\"asd\""));
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/FieldGetControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/FieldGetControllerTest.java
@@ -31,7 +31,7 @@ public class FieldGetControllerTest extends ControllerTestBase {
 	@Test
 	public void onValidRequestShouldAcceptIt() {
 		// GIVEN
-		JsonPath jsonPath = pathBuilder.build("tasks/1/project");
+		JsonPath jsonPath = pathBuilder.build("tasks/1/project", queryContext);
 		FieldResourceGetController sut = new FieldResourceGetController();
 		sut.init(controllerContext);
 
@@ -45,7 +45,7 @@ public class FieldGetControllerTest extends ControllerTestBase {
 	@Test
 	public void onRelationshipRequestShouldDenyIt() {
 		// GIVEN
-		JsonPath jsonPath = pathBuilder.build("tasks/1/relationships/project");
+		JsonPath jsonPath = pathBuilder.build("tasks/1/relationships/project", queryContext);
 		FieldResourceGetController sut = new FieldResourceGetController();
 		sut.init(controllerContext);
 
@@ -59,7 +59,7 @@ public class FieldGetControllerTest extends ControllerTestBase {
 	@Test
 	public void onNonRelationRequestShouldDenyIt() {
 		// GIVEN
-		JsonPath jsonPath = pathBuilder.build("tasks");
+		JsonPath jsonPath = pathBuilder.build("tasks", queryContext);
 		FieldResourceGetController sut = new FieldResourceGetController();
 		sut.init(controllerContext);
 
@@ -74,7 +74,7 @@ public class FieldGetControllerTest extends ControllerTestBase {
 	public void onGivenRequestFieldResourceGetShouldHandleIt() {
 		// GIVEN
 
-		JsonPath jsonPath = pathBuilder.build("/tasks/1/project");
+		JsonPath jsonPath = pathBuilder.build("/tasks/1/project", queryContext);
 		FieldResourceGetController sut = new FieldResourceGetController();
 		sut.init(controllerContext);
 
@@ -89,7 +89,7 @@ public class FieldGetControllerTest extends ControllerTestBase {
 	public void onGivenRequestFieldResourcesGetShouldHandleIt() {
 		// GIVEN
 
-		JsonPath jsonPath = pathBuilder.build("/users/1/assignedProjects");
+		JsonPath jsonPath = pathBuilder.build("/users/1/assignedProjects", queryContext);
 		FieldResourceGetController sut = new FieldResourceGetController();
 		sut.init(controllerContext);
 
@@ -137,7 +137,7 @@ public class FieldGetControllerTest extends ControllerTestBase {
 		queryParams.includeRelation(PathSpec.of("includedTask"));
 
 		QueryAdapter queryAdapter = container.toQueryAdapter(queryParams);
-		JsonPath jsonPath = pathBuilder.build("/users/1/assignedProjects");
+		JsonPath jsonPath = pathBuilder.build("/users/1/assignedProjects", queryContext);
 		FieldResourceGetController sut = new FieldResourceGetController();
 		sut.init(controllerContext);
 

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/FieldPostControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/FieldPostControllerTest.java
@@ -26,7 +26,7 @@ public class FieldPostControllerTest extends ControllerTestBase {
     @Test
     public void onValidRequestShouldAcceptIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("tasks/1/project");
+        JsonPath jsonPath = pathBuilder.build("tasks/1/project", queryContext);
         FieldResourcePost sut = new FieldResourcePost();
         sut.init(controllerContext);
 
@@ -40,7 +40,7 @@ public class FieldPostControllerTest extends ControllerTestBase {
     @Test
     public void onRelationshipRequestShouldDenyIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("tasks/1/relationships/project");
+        JsonPath jsonPath = pathBuilder.build("tasks/1/relationships/project", queryContext);
         FieldResourcePost sut = new FieldResourcePost();
         sut.init(controllerContext);
 
@@ -54,7 +54,7 @@ public class FieldPostControllerTest extends ControllerTestBase {
     @Test
     public void onNonRelationRequestShouldDenyIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("tasks");
+        JsonPath jsonPath = pathBuilder.build("tasks", queryContext);
         FieldResourcePost sut = new FieldResourcePost();
         sut.init(controllerContext);
 
@@ -71,7 +71,7 @@ public class FieldPostControllerTest extends ControllerTestBase {
         Document newTaskDocument = new Document();
         newTaskDocument.setData(Nullable.of(createTask()));
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
 
@@ -89,7 +89,7 @@ public class FieldPostControllerTest extends ControllerTestBase {
         Document newProjectDocument = new Document();
         newProjectDocument.setData(Nullable.of(createProject()));
 
-        JsonPath projectPath = pathBuilder.build("/tasks/" + taskId + "/project");
+        JsonPath projectPath = pathBuilder.build("/tasks/" + taskId + "/project", queryContext);
         FieldResourcePost sut = new FieldResourcePost();
         sut.init(controllerContext);
 
@@ -122,7 +122,7 @@ public class FieldPostControllerTest extends ControllerTestBase {
         Document newTaskDocument = new Document();
         newTaskDocument.setData(Nullable.of(createTask()));
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
 
@@ -140,7 +140,7 @@ public class FieldPostControllerTest extends ControllerTestBase {
         Document newProjectDocument = new Document();
         newProjectDocument.setData(Nullable.of(createProject()));
 
-        JsonPath projectPath = pathBuilder.build("/tasks/" + taskId + "/projects");
+        JsonPath projectPath = pathBuilder.build("/tasks/" + taskId + "/projects", queryContext);
         FieldResourcePost sut = new FieldResourcePost();
         sut.init(controllerContext);
 

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/RelationshipsDeleteControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/RelationshipsDeleteControllerTest.java
@@ -36,7 +36,7 @@ public class RelationshipsDeleteControllerTest extends ControllerTestBase {
     @Test
     public void onValidRequestShouldAcceptIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("tasks/1/relationships/project");
+        JsonPath jsonPath = pathBuilder.build("tasks/1/relationships/project", queryContext);
         RelationsDeleteController sut = new RelationsDeleteController();
         sut.init(controllerContext);
 
@@ -50,7 +50,7 @@ public class RelationshipsDeleteControllerTest extends ControllerTestBase {
     @Test
     public void onNonRelationRequestShouldDenyIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("tasks");
+        JsonPath jsonPath = pathBuilder.build("tasks", queryContext);
         RelationsDeleteController sut = new RelationsDeleteController();
         sut.init(controllerContext);
 
@@ -69,7 +69,7 @@ public class RelationshipsDeleteControllerTest extends ControllerTestBase {
         newTaskBody.setData(Nullable.of(data));
         data.setType("tasks");
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
 
@@ -88,7 +88,7 @@ public class RelationshipsDeleteControllerTest extends ControllerTestBase {
         data = createProject();
         newProjectBody.setData(Nullable.of(data));
 
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN -- adding a project
         Response projectResponse = resourcePost.handle(projectPath, emptyProjectQuery, newProjectBody);
@@ -109,7 +109,7 @@ public class RelationshipsDeleteControllerTest extends ControllerTestBase {
         data.setType("projects");
         data.setId(projectId.toString());
 
-        JsonPath projectRelationPath = pathBuilder.build("/tasks/" + taskId + "/relationships/project");
+        JsonPath projectRelationPath = pathBuilder.build("/tasks/" + taskId + "/relationships/project", queryContext);
         RelationshipsPostController relationshipsPostController = new RelationshipsPostController();
         relationshipsPostController.init(controllerContext);
 
@@ -146,7 +146,7 @@ public class RelationshipsDeleteControllerTest extends ControllerTestBase {
         Document newUserDocument = new Document();
         newUserDocument.setData(Nullable.of(createUser()));
 
-        JsonPath taskPath = pathBuilder.build("/users");
+        JsonPath taskPath = pathBuilder.build("/users", queryContext);
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
 
@@ -164,7 +164,7 @@ public class RelationshipsDeleteControllerTest extends ControllerTestBase {
         Document newProjectDocument = new Document();
         newProjectDocument.setData(Nullable.of(createProject()));
 
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN -- adding a project
         Response projectResponse = resourcePost.handle(projectPath, emptyProjectQuery, newProjectDocument);
@@ -182,7 +182,7 @@ public class RelationshipsDeleteControllerTest extends ControllerTestBase {
         Document newProjectDocument2 = new Document();
         newProjectDocument2.setData(Nullable.of(createProject(projectId.toString())));
 
-        JsonPath savedTaskPath = pathBuilder.build("/users/" + userId + "/relationships/assignedProjects");
+        JsonPath savedTaskPath = pathBuilder.build("/users/" + userId + "/relationships/assignedProjects", queryContext);
         RelationshipsPostController relationshipsPostController = new RelationshipsPostController();
         relationshipsPostController.init(controllerContext);
 
@@ -222,7 +222,7 @@ public class RelationshipsDeleteControllerTest extends ControllerTestBase {
         Document body = new Document();
         ResourceIdentifier id = new ResourceIdentifier("13", "things");
         body.setData(Nullable.of(id));
-        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/statusThing");
+        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/statusThing", queryContext);
         RelationsDeleteController sut = new RelationsDeleteController();
         sut.init(controllerContext);
 

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/RelationshipsGetControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/RelationshipsGetControllerTest.java
@@ -34,7 +34,7 @@ public class RelationshipsGetControllerTest extends ControllerTestBase {
     @Test
     public void onValidRequestShouldAcceptIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("tasks/1/relationships/project");
+        JsonPath jsonPath = pathBuilder.build("tasks/1/relationships/project", queryContext);
         RelationshipsResourceGetController sut = new RelationshipsResourceGetController();
         sut.init(controllerContext);
 
@@ -48,7 +48,7 @@ public class RelationshipsGetControllerTest extends ControllerTestBase {
     @Test
     public void onFieldRequestShouldDenyIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("tasks/1/project");
+        JsonPath jsonPath = pathBuilder.build("tasks/1/project", queryContext);
         RelationshipsResourceGetController sut = new RelationshipsResourceGetController();
         sut.init(controllerContext);
 
@@ -62,7 +62,7 @@ public class RelationshipsGetControllerTest extends ControllerTestBase {
     @Test
     public void onNonRelationRequestShouldDenyIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("tasks");
+        JsonPath jsonPath = pathBuilder.build("tasks", queryContext);
         RelationshipsResourceGetController sut = new RelationshipsResourceGetController();
         sut.init(controllerContext);
 
@@ -77,7 +77,7 @@ public class RelationshipsGetControllerTest extends ControllerTestBase {
     public void onGivenRequestLinkResourceGetShouldReturnNullData() {
         // GIVEN
 
-        JsonPath jsonPath = pathBuilder.build("/tasks/1/relationships/project");
+        JsonPath jsonPath = pathBuilder.build("/tasks/1/relationships/project", queryContext);
         RelationshipsResourceGetController sut = new RelationshipsResourceGetController();
         sut.init(controllerContext);
 
@@ -96,7 +96,7 @@ public class RelationshipsGetControllerTest extends ControllerTestBase {
         projectRepository.save(project);
 
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("/tasks/1/relationships/project");
+        JsonPath jsonPath = pathBuilder.build("/tasks/1/relationships/project", queryContext);
         RelationshipsResourceGetController sut = new RelationshipsResourceGetController();
         sut.init(controllerContext);
         TaskToProjectRepository relationship = (TaskToProjectRepository) container.getRepository(Task.class, "project");

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/RelationshipsPatchControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/RelationshipsPatchControllerTest.java
@@ -48,7 +48,7 @@ public class RelationshipsPatchControllerTest extends ControllerTestBase {
     @Test
     public void onValidRequestShouldAcceptIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("tasks/1/relationships/project");
+        JsonPath jsonPath = pathBuilder.build("tasks/1/relationships/project", queryContext);
         RelationshipsPatchController sut = new RelationshipsPatchController();
         sut.init(controllerContext);
 
@@ -62,7 +62,7 @@ public class RelationshipsPatchControllerTest extends ControllerTestBase {
     @Test
     public void onNonRelationRequestShouldDenyIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("tasks");
+        JsonPath jsonPath = pathBuilder.build("tasks", queryContext);
         RelationshipsPatchController sut = new RelationshipsPatchController();
         sut.init(controllerContext);
 
@@ -81,7 +81,7 @@ public class RelationshipsPatchControllerTest extends ControllerTestBase {
         newTaskBody.setData(Nullable.of(data));
         data.setType("tasks");
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
 
@@ -100,7 +100,7 @@ public class RelationshipsPatchControllerTest extends ControllerTestBase {
         data = createProject();
         newProjectBody.setData(Nullable.of(data));
 
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN -- adding a project
         Response projectResponse = resourcePost.handle(projectPath, emptyProjectQuery, newProjectBody);
@@ -122,7 +122,7 @@ public class RelationshipsPatchControllerTest extends ControllerTestBase {
         data.setType("projects");
         data.setId(projectId.toString());
 
-        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/project");
+        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/project", queryContext);
         RelationshipsPatchController sut = new RelationshipsPatchController();
         sut.init(controllerContext);
 
@@ -145,7 +145,7 @@ public class RelationshipsPatchControllerTest extends ControllerTestBase {
         Resource data = createUser();
         newUserBody.setData(Nullable.of(data));
 
-        JsonPath taskPath = pathBuilder.build("/users");
+        JsonPath taskPath = pathBuilder.build("/users", queryContext);
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
 
@@ -164,7 +164,7 @@ public class RelationshipsPatchControllerTest extends ControllerTestBase {
         data = createProject();
         newProjectBody.setData(Nullable.of(data));
 
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN -- adding a project
         Response projectResponse = resourcePost.handle(projectPath, emptyProjectQuery, newProjectBody);
@@ -185,7 +185,7 @@ public class RelationshipsPatchControllerTest extends ControllerTestBase {
         data.setId(projectId.toString());
         newTaskToProjectBody.setData(Nullable.of(Collections.singletonList(data)));
 
-        JsonPath savedTaskPath = pathBuilder.build("/users/" + userId + "/relationships/assignedProjects");
+        JsonPath savedTaskPath = pathBuilder.build("/users/" + userId + "/relationships/assignedProjects", queryContext);
         RelationshipsPatchController sut = new RelationshipsPatchController();
         sut.init(controllerContext);
 
@@ -206,7 +206,7 @@ public class RelationshipsPatchControllerTest extends ControllerTestBase {
         Resource data = createTask();
         newTaskBody.setData(Nullable.of(data));
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
 
@@ -224,7 +224,7 @@ public class RelationshipsPatchControllerTest extends ControllerTestBase {
         Document newTaskToProjectBody = new Document();
         newTaskToProjectBody.setData(Nullable.nullValue());
 
-        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/project");
+        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/project", queryContext);
         RelationshipsPatchController sut = new RelationshipsPatchController();
         sut.init(controllerContext);
 
@@ -247,7 +247,7 @@ public class RelationshipsPatchControllerTest extends ControllerTestBase {
         data.setType(ClassUtils.getAnnotation(Task.class, JsonApiResource.class).get().type());
         newTaskBody.setData(Nullable.of(data));
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
 
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
@@ -274,7 +274,7 @@ public class RelationshipsPatchControllerTest extends ControllerTestBase {
                         "tasks"),
                 new ResourceIdentifier(taskIdThree.toString(), "tasks"))));
         newProjectBody.setData(Nullable.of(data));
-        JsonPath projectPolymorphicTypePath = pathBuilder.build("/" + type);
+        JsonPath projectPolymorphicTypePath = pathBuilder.build("/" + type, queryContext);
 
         Response projectResponse = resourcePost.handle(projectPolymorphicTypePath, emptyProjectQuery, newProjectBody);
 
@@ -291,7 +291,7 @@ public class RelationshipsPatchControllerTest extends ControllerTestBase {
                 (ProjectPolymorphic) resourceRepository.findOne(projectId, new QuerySpec(ProjectPolymorphic.class));
         assertEquals(2, projectPolymorphicObj.getTasks().size());
 
-        projectPolymorphicTypePath = pathBuilder.build("/" + type + "/" + projectPolymorphic.getId());
+        projectPolymorphicTypePath = pathBuilder.build("/" + type + "/" + projectPolymorphic.getId(), queryContext);
         ResourcePatchController resourcePatch = new ResourcePatchController();
         resourcePatch.init(controllerContext);
         data = newProjectBody.getSingleData().get();
@@ -326,7 +326,7 @@ public class RelationshipsPatchControllerTest extends ControllerTestBase {
         Document body = new Document();
         ResourceIdentifier id = new ResourceIdentifier("13", "things");
         body.setData(Nullable.of(id));
-        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/statusThing");
+        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/statusThing", queryContext);
         RelationshipsPatchController sut = new RelationshipsPatchController();
         sut.init(controllerContext);
 

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/RelationshipsPostControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/RelationshipsPostControllerTest.java
@@ -53,7 +53,7 @@ public class RelationshipsPostControllerTest extends ControllerTestBase {
     @Test
     public void onValidRequestShouldAcceptIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("tasks/1/relationships/project");
+        JsonPath jsonPath = pathBuilder.build("tasks/1/relationships/project", queryContext);
         RelationshipsPostController sut = new RelationshipsPostController();
         sut.init(controllerContext);
 
@@ -67,7 +67,7 @@ public class RelationshipsPostControllerTest extends ControllerTestBase {
     @Test
     public void onNonRelationRequestShouldDenyIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("tasks");
+        JsonPath jsonPath = pathBuilder.build("tasks", queryContext);
         RelationshipsPostController sut = new RelationshipsPostController();
         sut.init(controllerContext);
 
@@ -80,7 +80,7 @@ public class RelationshipsPostControllerTest extends ControllerTestBase {
 
     @Test(expected = RequestBodyNotFoundException.class)
     public void onMissingBodyThrowException() {
-        JsonPath savedTaskPath = pathBuilder.build("/tasks/1/relationships/project");
+        JsonPath savedTaskPath = pathBuilder.build("/tasks/1/relationships/project", queryContext);
         RelationshipsPostController sut = new RelationshipsPostController();
         sut.init(controllerContext);
 
@@ -96,7 +96,7 @@ public class RelationshipsPostControllerTest extends ControllerTestBase {
         Document newTaskBody = new Document();
         newTaskBody.setData(Nullable.of(createTask()));
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
 
@@ -114,7 +114,7 @@ public class RelationshipsPostControllerTest extends ControllerTestBase {
         Document newProjectBody = new Document();
         newProjectBody.setData(Nullable.of(createProject()));
 
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN -- adding a project
         Response projectResponse = resourcePost.handle(projectPath, emptyProjectQuery,
@@ -134,7 +134,7 @@ public class RelationshipsPostControllerTest extends ControllerTestBase {
         Document newTaskToProjectBody = new Document();
         newTaskToProjectBody.setData(Nullable.of(createProject(Long.toString(projectId))));
 
-        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/project");
+        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/project", queryContext);
         RelationshipsPostController sut = new RelationshipsPostController();
         sut.init(controllerContext);
 
@@ -163,7 +163,7 @@ public class RelationshipsPostControllerTest extends ControllerTestBase {
         Resource data = createUser();
         newUserBody.setData(Nullable.of(data));
 
-        JsonPath taskPath = pathBuilder.build("/users");
+        JsonPath taskPath = pathBuilder.build("/users", queryContext);
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
 
@@ -183,7 +183,7 @@ public class RelationshipsPostControllerTest extends ControllerTestBase {
         newProjectBody.setData(Nullable.of(data));
         data.setType("projects");
 
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN -- adding a project
         Response projectResponse = resourcePost.handle(projectPath, emptyProjectQuery, newProjectBody);
@@ -205,7 +205,7 @@ public class RelationshipsPostControllerTest extends ControllerTestBase {
         data.setType("projects");
         data.setId(projectId.toString());
 
-        JsonPath savedTaskPath = pathBuilder.build("/users/" + userId + "/relationships/assignedProjects");
+        JsonPath savedTaskPath = pathBuilder.build("/users/" + userId + "/relationships/assignedProjects", queryContext);
         RelationshipsPostController sut = new RelationshipsPostController();
         sut.init(controllerContext);
 
@@ -227,7 +227,7 @@ public class RelationshipsPostControllerTest extends ControllerTestBase {
         Resource data = createTask();
         newTaskBody.setData(Nullable.of(data));
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
 
@@ -245,7 +245,7 @@ public class RelationshipsPostControllerTest extends ControllerTestBase {
         Document newTaskToProjectBody = new Document();
         newTaskToProjectBody.setData(Nullable.nullValue());
 
-        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/project");
+        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/project", queryContext);
         RelationshipsPostController sut = new RelationshipsPostController();
         sut.init(controllerContext);
 
@@ -268,7 +268,7 @@ public class RelationshipsPostControllerTest extends ControllerTestBase {
         Resource data = createTask();
         newTaskBody.setData(Nullable.of(data));
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
 
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
@@ -294,7 +294,7 @@ public class RelationshipsPostControllerTest extends ControllerTestBase {
                         "tasks"),
                 new ResourceIdentifier(taskIdThree.toString(), "tasks"))));
         newProjectBody.setData(Nullable.of(data));
-        JsonPath projectPolymorphicTypePath = pathBuilder.build("/" + type);
+        JsonPath projectPolymorphicTypePath = pathBuilder.build("/" + type, queryContext);
 
         // WHEN
         Response projectResponse =
@@ -327,7 +327,7 @@ public class RelationshipsPostControllerTest extends ControllerTestBase {
         Document body = new Document();
         ResourceIdentifier id = new ResourceIdentifier("13", "things");
         body.setData(Nullable.of(id));
-        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/statusThing");
+        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + taskId + "/relationships/statusThing", queryContext);
         RelationshipsPostController sut = new RelationshipsPostController();
         sut.init(controllerContext);
 

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/ResourceDeleteControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/ResourceDeleteControllerTest.java
@@ -13,7 +13,7 @@ public class ResourceDeleteControllerTest extends ControllerTestBase {
 	@Test
 	public void onValidRequestShouldAcceptIt() {
 		// GIVEN
-		JsonPath jsonPath = pathBuilder.build("tasks/1");
+		JsonPath jsonPath = pathBuilder.build("tasks/1", queryContext);
 		ResourceDeleteController sut = new ResourceDeleteController();
 		sut.init(controllerContext);
 
@@ -27,7 +27,7 @@ public class ResourceDeleteControllerTest extends ControllerTestBase {
 	@Test
 	public void onNonRelationRequestShouldDenyIt() {
 		// GIVEN
-		JsonPath jsonPath = pathBuilder.build("tasks/1/relationships/project");
+		JsonPath jsonPath = pathBuilder.build("tasks/1/relationships/project", queryContext);
 		ResourceDeleteController sut = new ResourceDeleteController();
 		sut.init(controllerContext);
 
@@ -42,7 +42,7 @@ public class ResourceDeleteControllerTest extends ControllerTestBase {
 	public void onGivenRequestResourceGetShouldHandleIt() {
 		// GIVEN
 
-		JsonPath jsonPath = pathBuilder.build("/tasks/1");
+		JsonPath jsonPath = pathBuilder.build("/tasks/1", queryContext);
 		ResourceDeleteController sut = new ResourceDeleteController();
 		sut.init(controllerContext);
 

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/ResourceGetControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/ResourceGetControllerTest.java
@@ -37,7 +37,7 @@ public class ResourceGetControllerTest extends ControllerTestBase {
     @Test
     public void onGivenRequestCollectionGetShouldDenyIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("/tasks/");
+        JsonPath jsonPath = pathBuilder.build("/tasks/", queryContext);
         ResourceGetController sut = new ResourceGetController();
         sut.init(controllerContext);
 
@@ -51,7 +51,7 @@ public class ResourceGetControllerTest extends ControllerTestBase {
     @Test
     public void onGivenRequestResourceGetShouldAcceptIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("/tasks/2");
+        JsonPath jsonPath = pathBuilder.build("/tasks/2", queryContext);
         ResourceGetController sut = new ResourceGetController();
         sut.init(controllerContext);
 
@@ -65,7 +65,7 @@ public class ResourceGetControllerTest extends ControllerTestBase {
     @Test
     public void onMethodMismatchShouldDenyIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("/tasks/2");
+        JsonPath jsonPath = pathBuilder.build("/tasks/2", queryContext);
         ResourceGetController sut = new ResourceGetController();
         sut.init(controllerContext);
 
@@ -83,7 +83,7 @@ public class ResourceGetControllerTest extends ControllerTestBase {
         Resource data = createTask();
         newTaskBody.setData(Nullable.of(data));
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
 
         // WHEN
         ResourcePostController resourcePost = new ResourcePostController();
@@ -94,7 +94,7 @@ public class ResourceGetControllerTest extends ControllerTestBase {
         assertThat(taskId).isNotNull();
 
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("/tasks/" + taskId);
+        JsonPath jsonPath = pathBuilder.build("/tasks/" + taskId, queryContext);
         ResourceGetController sut = new ResourceGetController();
         sut.init(controllerContext);
 
@@ -108,7 +108,7 @@ public class ResourceGetControllerTest extends ControllerTestBase {
     @Test(expected = ResourceNotFoundException.class)
     public void onGivenRequestResourceGetShouldThrowError() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("/tasks/" + -1);
+        JsonPath jsonPath = pathBuilder.build("/tasks/" + -1, queryContext);
         ResourceGetController sut = new ResourceGetController();
         sut.init(controllerContext);
 
@@ -122,7 +122,7 @@ public class ResourceGetControllerTest extends ControllerTestBase {
     @Test
     public void onGivenRequestResourceShouldLoadAutoIncludeFields() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("/task-with-lookup/1");
+        JsonPath jsonPath = pathBuilder.build("/task-with-lookup/1", queryContext);
         ResourceGetController responseGetResp = new ResourceGetController();
         responseGetResp.init(controllerContext);
         Map<String, Set<String>> queryParams = new HashMap<>();
@@ -155,7 +155,7 @@ public class ResourceGetControllerTest extends ControllerTestBase {
         Resource data = createTask();
         newTaskBody.setData(Nullable.of(data));
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
 
@@ -173,7 +173,7 @@ public class ResourceGetControllerTest extends ControllerTestBase {
         Document newProjectBody = new Document();
         newProjectBody.setData(Nullable.of(createProject()));
 
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN -- adding a project
         Response projectResponse = resourcePost.handle(projectPath, emptyProjectQuery, newProjectBody);
@@ -193,7 +193,7 @@ public class ResourceGetControllerTest extends ControllerTestBase {
         data.setType("projects");
         data.setId("2");
 
-        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + TASK_ID + "/relationships/project");
+        JsonPath savedTaskPath = pathBuilder.build("/tasks/" + TASK_ID + "/relationships/project", queryContext);
         RelationshipsPostController sut = new RelationshipsPostController();
         sut.init(controllerContext);
 
@@ -209,7 +209,7 @@ public class ResourceGetControllerTest extends ControllerTestBase {
         assertThat(project.getId()).isEqualTo(PROJECT_ID);
 
         // Given
-        JsonPath jsonPath = pathBuilder.build("/tasks/" + TASK_ID);
+        JsonPath jsonPath = pathBuilder.build("/tasks/" + TASK_ID, queryContext);
         ResourceGetController responseGetResp = new ResourceGetController();
         responseGetResp.init(controllerContext);
         QuerySpec requestParams = new QuerySpec(Task.class);

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/ResourceIdControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/ResourceIdControllerTest.java
@@ -86,7 +86,7 @@ public class ResourceIdControllerTest extends ControllerTestBase {
 		resource.getRelationships().put("testLookupAlways", new Relationship(schedule3Id));
 		Document newDocument = createDocument(resource);
 
-		JsonPath postPath = pathBuilder.build("/relationIdTest");
+		JsonPath postPath = pathBuilder.build("/relationIdTest", queryContext);
 
 		// WHEN POST
 		ResourcePostController sut = new ResourcePostController();
@@ -116,7 +116,7 @@ public class ResourceIdControllerTest extends ControllerTestBase {
 	}
 
 	private Resource checkPatchResource(Resource resource) {
-		JsonPath path = pathBuilder.build("/relationIdTest/" + resource.getId());
+		JsonPath path = pathBuilder.build("/relationIdTest/" + resource.getId(), queryContext);
 
 		resource.getRelationships().put("testLookupAlways", new Relationship(schedule2Id));
 		Document newDocument = createDocument(resource);
@@ -149,7 +149,7 @@ public class ResourceIdControllerTest extends ControllerTestBase {
 
 	private void checkPatchRelationship(Resource resource, ResourceIdentifier scheduleId) {
 
-		JsonPath path = pathBuilder.build("/relationIdTest/" + resource.getId() + "/relationships/testLookupAlways");
+		JsonPath path = pathBuilder.build("/relationIdTest/" + resource.getId() + "/relationships/testLookupAlways", queryContext);
 		Document newDocument = createDocument(scheduleId);
 
 		// WHEN PATCH

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/ResourcePatchControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/ResourcePatchControllerTest.java
@@ -1,5 +1,11 @@
 package io.crnk.core.engine.internal.dispatcher.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import io.crnk.core.boot.CrnkProperties;
 import io.crnk.core.engine.dispatcher.Response;
@@ -27,12 +33,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class ResourcePatchControllerTest extends ControllerTestBase {
 
     private static final String REQUEST_TYPE = "PATCH";
@@ -40,7 +40,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
     @Test
     public void onGivenRequestCollectionGetShouldDenyIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("/tasks/");
+        JsonPath jsonPath = pathBuilder.build("/tasks/", queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 
@@ -54,7 +54,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
     @Test
     public void onGivenRequestResourceGetShouldAcceptIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("/tasks/1");
+        JsonPath jsonPath = pathBuilder.build("/tasks/1", queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 
@@ -75,7 +75,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         expectedException.expect(RuntimeException.class);
 
         // WHEN
-        JsonPath path = pathBuilder.build("/frides");
+        JsonPath path = pathBuilder.build("/frides", queryContext);
         sut.handle(path, emptyProjectQuery, null);
     }
 
@@ -86,7 +86,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         Resource data = createTask();
         newTaskBody.setData(Nullable.of(data));
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
 
         // WHEN
         ResourcePostController resourcePost = new ResourcePostController();
@@ -101,7 +101,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         data = createTask();
         taskPatch.setData(Nullable.of(data));
         data.setAttribute("name", objectMapper.readTree("\"task updated\""));
-        JsonPath jsonPath = pathBuilder.build("/tasks/" + taskId);
+        JsonPath jsonPath = pathBuilder.build("/tasks/" + taskId, queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 
@@ -133,7 +133,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         data.setId(Long.toString(ProjectRepository.RETURN_NULL_ON_CREATE_ID));
         newProjectBody.setData(Nullable.of(data));
 
-        JsonPath projectPath = pathBuilder.build("/projects/" + ProjectRepository.RETURN_NULL_ON_CREATE_ID);
+        JsonPath projectPath = pathBuilder.build("/projects/" + ProjectRepository.RETURN_NULL_ON_CREATE_ID, queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 
@@ -152,7 +152,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         data = createTask();
         taskPatch.setData(Nullable.of(data));
         data.setAttribute("name", objectMapper.readTree("\"task updated\""));
-        JsonPath jsonPath = pathBuilder.build("/tasks/1234567");
+        JsonPath jsonPath = pathBuilder.build("/tasks/1234567", queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 
@@ -167,7 +167,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         Resource data = createTask();
         requestDocument.setData(Nullable.of(data));
 
-        JsonPath postPath = pathBuilder.build("/tasks");
+        JsonPath postPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController post = new ResourcePostController();
         post.init(controllerContext);
         post.handle(postPath, emptyTaskQuery, requestDocument);
@@ -181,7 +181,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
 
         // WHEN
         try {
-            JsonPath patchPath = pathBuilder.build("/tasks/" + data.getId());
+            JsonPath patchPath = pathBuilder.build("/tasks/" + data.getId(), queryContext);
             sut.handle(patchPath, emptyTaskQuery, requestDocument);
             Assert.fail("should not be allowed to update read-only field");
         } catch (ForbiddenException e) {
@@ -197,7 +197,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         newTaskBody.setData(Nullable.of(data));
         data.setType("tasks");
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
 
         // WHEN
         ResourcePostController resourcePost = new ResourcePostController();
@@ -213,7 +213,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         taskPatch.setData(Nullable.of(data));
         data.setType("WRONG_AND_MISSING_TYPE");
         data.setAttribute("name", objectMapper.readTree("\"task updated\""));
-        JsonPath jsonPath = pathBuilder.build("/tasks/" + taskId);
+        JsonPath jsonPath = pathBuilder.build("/tasks/" + taskId, queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 
@@ -240,7 +240,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         data.setAttribute("title", objectMapper.readTree("\"some title\""));
         data.setAttribute("body", objectMapper.readTree("\"sample body\""));
 
-        JsonPath documentsPath = pathBuilder.build("/documents");
+        JsonPath documentsPath = pathBuilder.build("/documents", queryContext);
 
         ResourcePostController resourcePost = new ResourcePostController();
         resourcePost.init(controllerContext);
@@ -262,7 +262,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         data.setType("memoranda");
         data.setAttribute("title", objectMapper.readTree("\"new title\""));
         data.setAttribute("body", objectMapper.readTree("\"new body\""));
-        JsonPath documentPath = pathBuilder.build("/documents/" + memorandumId);
+        JsonPath documentPath = pathBuilder.build("/documents/" + memorandumId, queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 
@@ -292,7 +292,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         ResourceRepository<Task, Object> taskRepository = container.getRepository(Task.class);
         taskRepository.save(task);
 
-        JsonPath taskPath = pathBuilder.build("/tasks/" + task.getId());
+        JsonPath taskPath = pathBuilder.build("/tasks/" + task.getId(), queryContext);
 
         // verify relationship available
         ResourceGetController resourceGet = new ResourceGetController();
@@ -310,13 +310,12 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         Document taskPatch = new Document();
         Resource data = createTask();
         data.setId(taskId.toString());
-        data.setAttribute("id", objectMapper.readTree("\"task updated\""));
         data.setAttribute("name", objectMapper.readTree("\"task updated\""));
         Relationship nulledRelationship = new Relationship();
         nulledRelationship.setData(Nullable.nullValue());
         data.getRelationships().put("project", nulledRelationship);
         taskPatch.setData(Nullable.of(data));
-        JsonPath jsonPath = pathBuilder.build("/tasks/" + taskId);
+        JsonPath jsonPath = pathBuilder.build("/tasks/" + taskId, queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
         Response response = sut.handle(jsonPath, emptyTaskQuery, taskPatch);
@@ -346,7 +345,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         scheduleRepository.save(schedule);
         assertThat(schedule.getId()).isNotNull();
 
-        JsonPath schedulePath = pathBuilder.build("/schedules/" + schedule.getId());
+        JsonPath schedulePath = pathBuilder.build("/schedules/" + schedule.getId(), queryContext);
 
         // verify relationship available
         ResourceGetController resourceGet = new ResourceGetController();
@@ -390,7 +389,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         ResourceRepository<Task, Object> taskRepository = container.getRepository(Task.class);
         taskRepository.save(task);
 
-        JsonPath taskPath = pathBuilder.build("/tasks/" + task.getId());
+        JsonPath taskPath = pathBuilder.build("/tasks/" + task.getId(), queryContext);
 
         // try set relationship
         Document taskPatch = new Document();
@@ -423,7 +422,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         newTaskBody.setData(Nullable.of(data));
         data.setType("tasks");
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController post = new ResourcePostController();
         post.init(controllerContext);
         Response taskResponse = post.handle(taskPath, emptyTaskQuery, newTaskBody);
@@ -436,7 +435,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
                 .put("tasks", new Relationship(Collections.singletonList(new ResourceIdentifier(taskId.toString(), "tasks"))));
         newProjectBody.setData(Nullable.of(data));
 
-        JsonPath projectsPath = pathBuilder.build("/projects");
+        JsonPath projectsPath = pathBuilder.build("/projects", queryContext);
         Response projectsResponse = post.handle(projectsPath, emptyProjectQuery, newProjectBody);
         assertThat(projectsResponse.getDocument().getSingleData().get().getRelationships().get("tasks").getCollectionData()
                 .get())
@@ -449,7 +448,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         Nullable<Object> emptyRelation = Nullable.of(new ArrayList<ResourceIdentifier>());
         data.getRelationships().get("tasks").setData(emptyRelation);
         projectsResponse =
-                patch.handle(pathBuilder.build("/projects/2"), emptyProjectQuery, newProjectBody);
+                patch.handle(pathBuilder.build("/projects/2", queryContext), emptyProjectQuery, newProjectBody);
         assertThat(projectsResponse.getDocument().getSingleData().get().getType()).isEqualTo("projects");
         assertThat(projectsResponse.getDocument().getSingleData().get().getAttributes().get("name").asText())
                 .isEqualTo("sample project");
@@ -465,7 +464,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         Document newProjectBody = new Document();
         Resource data = createProject();
         newProjectBody.setData(Nullable.of(data));
-        JsonPath taskPath = pathBuilder.build("/projects");
+        JsonPath taskPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN
         ResourcePostController resourcePost = new ResourcePostController();
@@ -481,7 +480,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
 
         Document projectPatch = new Document();
         projectPatch.setData(Nullable.of(data));
-        JsonPath jsonPath = pathBuilder.build("/projects/" + savedProject.getId());
+        JsonPath jsonPath = pathBuilder.build("/projects/" + savedProject.getId(), queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 
@@ -499,7 +498,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         Document newProjectBody = new Document();
         Resource data = createProject();
         newProjectBody.setData(Nullable.of(data));
-        JsonPath taskPath = pathBuilder.build("/projects");
+        JsonPath taskPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN
         ResourcePostController resourcePost = new ResourcePostController();
@@ -515,7 +514,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
 
         Document projectPatch = new Document();
         projectPatch.setData(Nullable.of(data));
-        JsonPath jsonPath = pathBuilder.build("/projects/" + savedProject.getId());
+        JsonPath jsonPath = pathBuilder.build("/projects/" + savedProject.getId(), queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 
@@ -534,7 +533,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         Resource data = createProject();
         data.getAttributes().remove("data");
         newProjectBody.setData(Nullable.of(data));
-        JsonPath taskPath = pathBuilder.build("/projects");
+        JsonPath taskPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN
         ResourcePostController resourcePost = new ResourcePostController();
@@ -554,7 +553,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
 
         Document projectPatch = new Document();
         projectPatch.setData(Nullable.of(data));
-        JsonPath jsonPath = pathBuilder.build("/projects/" + projectId);
+        JsonPath jsonPath = pathBuilder.build("/projects/" + projectId, queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 
@@ -575,7 +574,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         Document newProjectBody = new Document();
         Resource data = createProject();
         newProjectBody.setData(Nullable.of(data));
-        JsonPath taskPath = pathBuilder.build("/projects");
+        JsonPath taskPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN
         ResourcePostController resourcePost = new ResourcePostController();
@@ -598,7 +597,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
 
         Document projectPatch = new Document();
         projectPatch.setData(Nullable.of(data));
-        JsonPath jsonPath = pathBuilder.build("/projects/" + projectId);
+        JsonPath jsonPath = pathBuilder.build("/projects/" + projectId, queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 
@@ -620,7 +619,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         Document newProjectBody = new Document();
         Resource data = createProject(Long.toString(PROJECT_ID), "projects-patch-strategy");
         newProjectBody.setData(Nullable.of(data));
-        JsonPath taskPath = pathBuilder.build("/projects-patch-strategy");
+        JsonPath taskPath = pathBuilder.build("/projects-patch-strategy", queryContext);
 
         // WHEN
         ResourcePostController resourcePost = new ResourcePostController();
@@ -640,7 +639,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
 
         Document projectPatch = new Document();
         projectPatch.setData(Nullable.of(data));
-        JsonPath jsonPath = pathBuilder.build(taskPath + "/" + projectId);
+        JsonPath jsonPath = pathBuilder.build(taskPath + "/" + projectId, queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 
@@ -663,7 +662,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         newTaskBody.setData(Nullable.of(data));
         data.setType("tasks");
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController post = new ResourcePostController();
         post.init(controllerContext);
         Response taskResponse = post.handle(taskPath, emptyTaskQuery, newTaskBody);
@@ -676,7 +675,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
                 .put("tasks", new Relationship(Collections.singletonList(new ResourceIdentifier(taskId.toString(), "tasks"))));
         newProjectBody.setData(Nullable.of(data));
 
-        JsonPath projectsPath = pathBuilder.build("/projects");
+        JsonPath projectsPath = pathBuilder.build("/projects", queryContext);
         Response projectsResponse = post.handle(projectsPath, emptyProjectQuery, newProjectBody);
         assertThat(projectsResponse.getDocument().getSingleData().get().getRelationships().get("tasks").getCollectionData()
                 .get())
@@ -689,7 +688,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         data.getRelationships().remove("tasks");
         data.getAttributes().put("name", objectMapper.readTree("\"updated project\""));
         projectsResponse =
-                patch.handle(pathBuilder.build("/projects/2"), emptyProjectQuery, newProjectBody);
+                patch.handle(pathBuilder.build("/projects/2", queryContext), emptyProjectQuery, newProjectBody);
         assertThat(projectsResponse.getDocument().getSingleData().get().getType()).isEqualTo("projects");
         assertThat(projectsResponse.getDocument().getSingleData().get().getAttributes().get("name").asText())
                 .isEqualTo("updated project");
@@ -701,7 +700,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
     @Test
     public void onGivenRequestResourcePatchShouldHandleMissingFields() throws Exception {
 
-        JsonPath complexPojoPath = pathBuilder.build("/complexpojos/1");
+        JsonPath complexPojoPath = pathBuilder.build("/complexpojos/1", queryContext);
 
         // WHEN
         ResourceGetController resourceGet = new ResourceGetController();
@@ -724,7 +723,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         data.setAttribute("containedPojo", objectMapper.readTree(rawContainedPatchData));
         data.setAttribute("updateableProperty", objectMapper.readTree("\"wasNullBefore\""));
 
-        JsonPath jsonPath = pathBuilder.build("/complexpojos/" + complexPojoId);
+        JsonPath jsonPath = pathBuilder.build("/complexpojos/" + complexPojoId, queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 
@@ -760,7 +759,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         taskPatch.setData(Nullable.of(data));
         data.setType("tasks");
         data.setAttribute("name", objectMapper.readTree("\"Mary Jane\""));
-        JsonPath jsonPath = pathBuilder.build("/tasks/" + task.getId());
+        JsonPath jsonPath = pathBuilder.build("/tasks/" + task.getId(), queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 
@@ -792,7 +791,7 @@ public class ResourcePatchControllerTest extends ControllerTestBase {
         data.setAttribute("category", objectMapper.readTree("\"TestCategory\""));
         Document taskPatch = new Document();
         taskPatch.setData(Nullable.of(data));
-        JsonPath jsonPath = pathBuilder.build("/tasks/" + task.getId());
+        JsonPath jsonPath = pathBuilder.build("/tasks/" + task.getId(), queryContext);
         ResourcePatchController sut = new ResourcePatchController();
         sut.init(controllerContext);
 

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/ResourcePostControllerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/controller/ResourcePostControllerTest.java
@@ -44,7 +44,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
     @Test
     public void onGivenRequestCollectionGetShouldDenyIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("/tasks/1");
+        JsonPath jsonPath = pathBuilder.build("/tasks/1", queryContext);
         ResourcePostController sut = new ResourcePostController();
         sut.init(controllerContext);
 
@@ -58,7 +58,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
     @Test
     public void onGivenRequestResourceGetShouldAcceptIt() {
         // GIVEN
-        JsonPath jsonPath = pathBuilder.build("/tasks/");
+        JsonPath jsonPath = pathBuilder.build("/tasks/", queryContext);
         ResourcePostController sut = new ResourcePostController();
         sut.init(controllerContext);
 
@@ -76,7 +76,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         Resource data = createProject();
         newProjectBody.setData(Nullable.of(data));
 
-        JsonPath projectPath = pathBuilder.build("/tasks");
+        JsonPath projectPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController sut = new ResourcePostController();
         sut.init(controllerContext);
 
@@ -94,7 +94,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         Resource data = createProject();
         newProjectBody.setData(Nullable.of(new ArrayList<>()));
 
-        JsonPath projectPath = pathBuilder.build("/tasks");
+        JsonPath projectPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController sut = new ResourcePostController();
         sut.init(controllerContext);
 
@@ -116,7 +116,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         expectedException.expect(RequestBodyNotFoundException.class);
 
         // WHEN
-        JsonPath path = pathBuilder.build("tasks");
+        JsonPath path = pathBuilder.build("tasks", queryContext);
         sut.handle(path, emptyTaskQuery, null);
     }
 
@@ -127,7 +127,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         Resource data = createProject();
         newProjectBody.setData(Nullable.of(data));
 
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
         ResourcePostController sut = new ResourcePostController();
         sut.init(controllerContext);
 
@@ -154,7 +154,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         newTasksBody.getSingleData().get().getRelationships()
                 .put("project", new Relationship(new ResourceIdentifier(projectId.toString(), "projects")));
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
 
         // WHEN
         Response taskResponse = sut.handle(taskPath, emptyTaskQuery, newTasksBody);
@@ -180,7 +180,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         data.setId(Long.toString(ProjectRepository.RETURN_NULL_ON_CREATE_ID));
         newProjectBody.setData(Nullable.of(data));
 
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
         ResourcePostController sut = new ResourcePostController();
         sut.init(controllerContext);
 
@@ -205,7 +205,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
 		data.setId(Long.toString(ProjectRepository.RETURN_NO_ID_ON_CREATE));
 		newProjectBody.setData(Nullable.of(data));
 
-		JsonPath projectPath = pathBuilder.build("/projects");
+		JsonPath projectPath = pathBuilder.build("/projects", queryContext);
 		ResourcePostController sut = new ResourcePostController();
 		sut.init(controllerContext);
 
@@ -228,7 +228,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         data.getAttributes().put("readOnlyValue", objectMapper.readTree("\"newValue\""));
         requestDocument.setData(Nullable.of(data));
 
-        JsonPath path = pathBuilder.build("/tasks");
+        JsonPath path = pathBuilder.build("/tasks", queryContext);
 
         Mockito.when(propertiesProvider.getProperty(Mockito.eq(CrnkProperties.RESOURCE_FIELD_IMMUTABLE_WRITE_BEHAVIOR)))
                 .thenReturn(ResourceFieldImmutableWriteBehavior.FAIL.toString());
@@ -254,7 +254,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         data.getAttributes().put("readOnlyValue", objectMapper.readTree("\"newValue\""));
         requestDocument.setData(Nullable.of(data));
 
-        JsonPath path = pathBuilder.build("/tasks");
+        JsonPath path = pathBuilder.build("/tasks", queryContext);
         PropertiesProvider propertiesProvider = new PropertiesProvider() {
 
             @Override
@@ -282,7 +282,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         newProjectBody.setData(Nullable.of(data));
         data.setType("projects");
 
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
         ResourcePostController sut = new ResourcePostController();
         sut.init(controllerContext);
 
@@ -311,7 +311,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
                 "projects"));
         data.getRelationships().put("assignedProjects", new Relationship(projectIds));
 
-        JsonPath taskPath = pathBuilder.build("/users");
+        JsonPath taskPath = pathBuilder.build("/users", queryContext);
 
         // WHEN
         Response taskResponse = sut.handle(taskPath, emptyUserQuery, newUserBody);
@@ -339,7 +339,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         newProjectBody.setData(Nullable.of(data));
         data.setType("projects");
 
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
         ResourcePostController sut = new ResourcePostController();
         sut.init(controllerContext);
 
@@ -370,7 +370,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
 
         data.getRelationships().put("assignedProjects", new Relationship(projectIds));
 
-        JsonPath taskPath = pathBuilder.build("/users");
+        JsonPath taskPath = pathBuilder.build("/users", queryContext);
 
         // WHEN
         try {
@@ -390,7 +390,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         newTaskBody.setData(Nullable.of(data));
         data.setType("tasks");
 
-        JsonPath taskPath = pathBuilder.build("/tasks");
+        JsonPath taskPath = pathBuilder.build("/tasks", queryContext);
         ResourcePostController sut = new ResourcePostController();
         sut.init(controllerContext);
 
@@ -415,7 +415,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         data.getRelationships().put("tasks", new Relationship(taskIds));
         newProjectBody.setData(Nullable.of(data));
 
-        JsonPath projectsPath = pathBuilder.build("/projects");
+        JsonPath projectsPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN
         Response projectsResponse = sut.handle(projectsPath, emptyProjectQuery, newProjectBody);
@@ -448,7 +448,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         data.setType("projects");
         newProjectBody.setData(Nullable.of(data));
 
-        JsonPath projectsPath = pathBuilder.build("/projects");
+        JsonPath projectsPath = pathBuilder.build("/projects", queryContext);
 
         // WHEN
         Response projectsResponse = sut.handle(projectsPath, emptyProjectQuery, newProjectBody);
@@ -474,7 +474,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         data.setAttribute("title", objectMapper.readTree("\"sample title\""));
         data.setAttribute("body", objectMapper.readTree("\"sample body\""));
 
-        JsonPath projectPath = pathBuilder.build("/documents");
+        JsonPath projectPath = pathBuilder.build("/documents", queryContext);
         ResourcePostController sut = new ResourcePostController();
         sut.init(controllerContext);
 
@@ -498,7 +498,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         Resource data = createProject();
         newProjectBody.setData(Nullable.of(data));
 
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
         ResourcePostController sut = new ResourcePostController();
         sut.init(controllerContext);
 
@@ -526,7 +526,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         pojoData.getRelationships().put("some-projects",
                 new Relationship(Arrays.asList(new ResourceIdentifier(Long.toString(projectId), "projects"))));
 
-        JsonPath pojoPath = pathBuilder.build("/pojo");
+        JsonPath pojoPath = pathBuilder.build("/pojo", queryContext);
 
         // WHEN
         QuerySpec querySpec = new QuerySpec(Pojo.class);
@@ -558,7 +558,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         Resource data = createProject();
         newProjectBody.setData(Nullable.of(data));
 
-        JsonPath projectPath = pathBuilder.build("/projects");
+        JsonPath projectPath = pathBuilder.build("/projects", queryContext);
         ResourcePostController sut = new ResourcePostController();
         sut.init(controllerContext);
 
@@ -585,7 +585,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
         pojoData.getRelationships()
                 .put(invalidRelationshipName, new Relationship(new ResourceIdentifier(Long.toString(projectId), "projects")));
 
-        JsonPath pojoPath = pathBuilder.build("/pojo");
+        JsonPath pojoPath = pathBuilder.build("/pojo", queryContext);
 
         // THEN
         expectedException.expect(ResourceException.class);
@@ -597,7 +597,7 @@ public class ResourcePostControllerTest extends ControllerTestBase {
 
     @Test
     public void ignoreNonPostableRelationship() throws Exception {
-        JsonPath taskPath = pathBuilder.build("/tasks/");
+        JsonPath taskPath = pathBuilder.build("/tasks/", queryContext);
 
         // try set relationship
         Document taskPatch = new Document();

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/path/PathBuilderTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/path/PathBuilderTest.java
@@ -1,14 +1,11 @@
 package io.crnk.core.engine.internal.dispatcher.path;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Arrays;
-
 import io.crnk.core.CoreTestContainer;
 import io.crnk.core.CoreTestModule;
 import io.crnk.core.engine.information.repository.RepositoryAction;
 import io.crnk.core.engine.information.repository.ResourceRepositoryInformation;
 import io.crnk.core.engine.internal.resource.NestedResourceTest;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.exception.BadRequestException;
 import io.crnk.core.mock.models.Task;
@@ -24,324 +21,330 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class PathBuilderTest {
 
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-
-	private PathBuilder pathBuilder;
-
-	@Before
-	public void prepare() {
-		SimpleModule notExposedModule = new SimpleModule("notExposed");
-		notExposedModule.addRepository(new NotExposedRepository());
-		notExposedModule.addRepository(new NestedResourceTest.TestRepository());
-		notExposedModule.addRepository(new NestedResourceTest.OneNestedRepository());
-		notExposedModule.addRepository(new NestedResourceTest.ManyNestedRepository());
-		notExposedModule.addRepository(new NestedResourceTest.OneGrandchildRepository());
-		notExposedModule.addRepository(new NestedResourceTest.ManyGrandchildrenRepository());
-
-		CoreTestContainer container = new CoreTestContainer();
-		container.addModule(new CoreTestModule());
-		container.addModule(notExposedModule);
-		container.boot();
-
-		pathBuilder = new PathBuilder(container.getResourceRegistry(), container.getBoot().getModuleRegistry().getTypeParser());
-
-		RegistryEntry entry = container.getEntry(Task.class);
-		ResourceRepositoryInformation repositoryInformation = entry.getRepositoryInformation();
-		repositoryInformation.getActions().put("someRepositoryAction", Mockito.mock(RepositoryAction.class));
-		repositoryInformation.getActions().put("someResourceAction", Mockito.mock(RepositoryAction.class));
-	}
-
-	@JsonApiExposed(false)
-	public static class NotExposedRepository extends InMemoryResourceRepository<NotExposedResource, String> {
-
-		public NotExposedRepository() {
-			super(NotExposedResource.class);
-		}
-	}
-
-	@JsonApiResource(type = "notExposed")
-	public static class NotExposedResource {
-
-		@JsonApiId
-		private String id;
-
-		public String getId() {
-			return id;
-		}
-
-		public void setId(String id) {
-			this.id = id;
-		}
-	}
-
-	@Test
-	public void onEmptyPathReturnsNull() {
-		// GIVEN
-		String path = "/";
-
-		// WHEN
-		JsonPath jsonPath = pathBuilder.build(path);
-
-		// THEN
-		assertThat(jsonPath).isNull();
-	}
-
-	@Test
-	public void onFlatResourcePathShouldReturnFlatPath() {
-		// GIVEN
-		String path = "/tasks/";
-
-		// WHEN
-		JsonPath jsonPath = pathBuilder.build(path);
-
-		// THEN
-		assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
-		assertThat(jsonPath.isCollection()).isTrue();
-		assertThat(jsonPath.toGroupPath()).isEqualTo("tasks");
-	}
-
-	@Test
-	public void onFlatResourceInstancePathShouldReturnFlatPath() {
-		// GIVEN
-		String path = "/tasks/1";
-
-		// WHEN
-		JsonPath jsonPath = pathBuilder.build(path);
-
-		// THEN
-		assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
-		assertThat(jsonPath.getId()).isEqualTo(1L);
-		assertThat(jsonPath.isCollection()).isFalse();
-		assertThat(jsonPath.toGroupPath()).isEqualTo("tasks/{id}");
-	}
-
-	@Test
-	public void onRepositoryActionShouldActionPath() {
-		// GIVEN
-		String path = "/tasks/someRepositoryAction";
-
-		// WHEN
-		ActionPath jsonPath = (ActionPath) pathBuilder.build(path);
-
-		// THEN
-		assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
-		Assert.assertEquals("someRepositoryAction", jsonPath.getActionName());
-		Assert.assertNull(jsonPath.getIds());
-		assertThat(jsonPath.toGroupPath()).isEqualTo("tasks/someRepositoryAction");
-	}
-
-	@Test
-	public void onResourceActionShouldActionPath() {
-		// GIVEN
-		String path = "/tasks/123/someResourceAction";
-
-		// WHEN
-		ActionPath jsonPath = (ActionPath) pathBuilder.build(path);
-
-		// THEN
-		assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
-		Assert.assertEquals("someResourceAction", jsonPath.getActionName());
-		Assert.assertEquals(123L, jsonPath.getId());
-		assertThat(jsonPath.toGroupPath()).isEqualTo("tasks/{id}/someResourceAction");
-	}
-
-
-	@Test
-	public void onNestedResourcePathShouldReturnNestedPath() {
-		// GIVEN
-		String path = "/tasks/1/project";
-
-		// WHEN
-		FieldPath jsonPath = (FieldPath) pathBuilder.build(path);
-
-		// THEN
-		assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
-		Assert.assertEquals(1L, jsonPath.getId());
-		Assert.assertEquals("project", jsonPath.getField().getJsonName());
-		assertThat(jsonPath.toGroupPath()).isEqualTo("tasks/{id}/project");
-	}
-
-	@Test
-	public void onNestedResourceInstancePathShouldThrowException() {
-		// GIVEN
-		String path = "/tasks/1/project/2";
-
-		// THEN
-		expectedException.expect(BadRequestException.class);
-
-		// WHEN
-		pathBuilder.build(path);
-	}
-
-	@Test
-	public void onNestedResourceRelationshipPathShouldReturnNestedPath() {
-		// GIVEN
-		String path = "/tasks/1/relationships/project/";
-
-		// WHEN
-		RelationshipsPath jsonPath = (RelationshipsPath) pathBuilder.build(path);
-
-		// THEN
-		assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
-		Assert.assertEquals(1L, jsonPath.getId());
-		Assert.assertEquals("project", jsonPath.getRelationship().getJsonName());
-		assertThat(jsonPath.toGroupPath()).isEqualTo("tasks/{id}/relationships/project");
-	}
-
-	@Test
-	public void onNonRelationshipFieldShouldThrowException() {
-		// GIVEN
-		String path = "/tasks/1/relationships/name/";
-
-		// THEN
-		expectedException.expect(BadRequestException.class);
-
-		// WHEN
-		pathBuilder.build(path);
-	}
-
-	@Test
-	public void onRelationshipFieldInRelationshipsShouldThrowException() {
-		// GIVEN
-		String path = "/users/1/relationships/projects";
-
-		// THEN
-		expectedException.expect(BadRequestException.class);
-		expectedException.expectMessage("projects");
-
-		// WHEN
-		pathBuilder.build(path);
-	}
-
-	@Test
-	public void onNestedWrongResourceRelationshipPathShouldThrowException() {
-		// GIVEN
-		String path = "/tasks/1/relationships/";
-
-		// THEN
-		expectedException.expect(BadRequestException.class);
-
-		// WHEN
-		pathBuilder.build(path);
-	}
-
-	@Test
-	public void onRelationshipsPathWithIdShouldThrowException() {
-		// GIVEN
-		String path = "/tasks/1/relationships/project/1";
-
-		// THEN
-		expectedException.expect(BadRequestException.class);
-
-		// WHEN
-		pathBuilder.build(path);
-	}
-
-	@Test
-	public void onNonExistingFieldShouldThrowException() {
-		// GIVEN
-		String path = "/tasks/1/nonExistingField/";
-
-		// THEN
-		expectedException.expect(BadRequestException.class);
-		expectedException.expectMessage("nonExistingField");
-
-		// WHEN
-		pathBuilder.build(path);
-	}
-
-
-	@Test
-	public void singularSingularNestedRelationshipPath() {
-		// GIVEN
-		String path = "/test/1/oneNested/";
-
-		// WHEN
-		ResourcePath jsonPath = (ResourcePath) pathBuilder.build(path);
-
-		// THEN
-		assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("oneNested");
-		Assert.assertEquals("1", jsonPath.getId());
-		Assert.assertEquals("oneNested", jsonPath.getParentField().getUnderlyingName());
-		assertThat(jsonPath.toGroupPath()).isEqualTo("test/{id}/oneNested");
-	}
-
-	@Test
-	public void checkMultivaluedRelationshipPath() {
-		// GIVEN
-		String path = "/test/1/manyNested/";
-
-		// WHEN
-		FieldPath jsonPath = (FieldPath) pathBuilder.build(path);
-
-		// THEN
-		assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("test");
-		Assert.assertEquals("1", jsonPath.getId());
-		Assert.assertEquals("manyNested", jsonPath.getField().getUnderlyingName());
-		assertThat(jsonPath.toGroupPath()).isEqualTo("test/{id}/manyNested");
-	}
-
-	@Test
-	public void checkMultivaluedRelationshipIdPath() {
-		// GIVEN
-		String path = "/test/1/manyNested/2";
-
-		// WHEN
-		ResourcePath jsonPath = (ResourcePath) pathBuilder.build(path);
-
-		// THEN
-		assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("manyNested");
-		Assert.assertEquals("1-2", jsonPath.getId().toString());
-		Assert.assertEquals("manyNested", jsonPath.getParentField().getUnderlyingName());
-		assertThat(jsonPath.toGroupPath()).isEqualTo("test/{id}/manyNested/{id}");
-	}
-
-	@Test
-	public void onNonExistingResourceShouldThrowException() {
-		String path = "/nonExistingResource";
-		Assert.assertNull(pathBuilder.build(path));
-	}
-
-	@Test
-	public void onResourceStaringWithRelationshipsShouldThrowException() {
-		String path = "/relationships";
-		Assert.assertNull(pathBuilder.build(path));
-	}
-
-	@Test
-	public void onMultipleResourceInstancesPathShouldReturnCollectionPath() {
-		// GIVEN
-		String path = "/tasks/1,2";
-
-		// WHEN
-		JsonPath jsonPath = pathBuilder.build(path);
-
-		// THEN
-		assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
-		Assert.assertEquals(Arrays.asList(1L, 2L), jsonPath.getIds());
-		assertThat(jsonPath.toGroupPath()).isEqualTo("tasks/{id}");
-	}
-
-	@Test
-	public void onUrlEncodedMultipleResourceInstancesPathShouldReturnCollectionPath() {
-		// GIVEN
-		String path = "/tasks/1%2C2";
-
-		// WHEN
-		JsonPath jsonPath = pathBuilder.build(path);
-
-		// THEN
-		assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
-		Assert.assertEquals(Arrays.asList(1L, 2L), jsonPath.getIds());
-	}
-
-	@Test
-	public void ignoreEntriesNotBeingExposed() {
-		String path = "/notExposed/1/";
-		JsonPath jsonPath = pathBuilder.build(path);
-		Assert.assertNull(jsonPath);
-	}
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private PathBuilder pathBuilder;
+
+    private QueryContext queryContext = new QueryContext().setRequestVersion(0);
+
+    @Before
+    public void prepare() {
+        SimpleModule notExposedModule = new SimpleModule("notExposed");
+        notExposedModule.addRepository(new NotExposedRepository());
+        notExposedModule.addRepository(new NestedResourceTest.TestRepository());
+        notExposedModule.addRepository(new NestedResourceTest.OneNestedRepository());
+        notExposedModule.addRepository(new NestedResourceTest.ManyNestedRepository());
+        notExposedModule.addRepository(new NestedResourceTest.OneGrandchildRepository());
+        notExposedModule.addRepository(new NestedResourceTest.ManyGrandchildrenRepository());
+
+        CoreTestContainer container = new CoreTestContainer();
+        container.addModule(new CoreTestModule());
+        container.addModule(notExposedModule);
+        container.boot();
+
+        pathBuilder = new PathBuilder(container.getResourceRegistry(), container.getBoot().getModuleRegistry().getTypeParser());
+
+        RegistryEntry entry = container.getEntry(Task.class);
+        ResourceRepositoryInformation repositoryInformation = entry.getRepositoryInformation();
+        repositoryInformation.getActions().put("someRepositoryAction", Mockito.mock(RepositoryAction.class));
+        repositoryInformation.getActions().put("someResourceAction", Mockito.mock(RepositoryAction.class));
+    }
+
+    @JsonApiExposed(false)
+    public static class NotExposedRepository extends InMemoryResourceRepository<NotExposedResource, String> {
+
+        public NotExposedRepository() {
+            super(NotExposedResource.class);
+        }
+    }
+
+    @JsonApiResource(type = "notExposed")
+    public static class NotExposedResource {
+
+        @JsonApiId
+        private String id;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+    }
+
+    @Test
+    public void onEmptyPathReturnsNull() {
+        // GIVEN
+        String path = "/";
+
+        // WHEN
+        JsonPath jsonPath = pathBuilder.build(path, queryContext);
+
+        // THEN
+        assertThat(jsonPath).isNull();
+    }
+
+    @Test
+    public void onFlatResourcePathShouldReturnFlatPath() {
+        // GIVEN
+        String path = "/tasks/";
+
+        // WHEN
+        JsonPath jsonPath = pathBuilder.build(path, queryContext);
+
+        // THEN
+        assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
+        assertThat(jsonPath.isCollection()).isTrue();
+        assertThat(jsonPath.toGroupPath()).isEqualTo("tasks");
+    }
+
+    @Test
+    public void onFlatResourceInstancePathShouldReturnFlatPath() {
+        // GIVEN
+        String path = "/tasks/1";
+
+        // WHEN
+        JsonPath jsonPath = pathBuilder.build(path, queryContext);
+
+        // THEN
+        assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
+        assertThat(jsonPath.getId()).isEqualTo(1L);
+        assertThat(jsonPath.isCollection()).isFalse();
+        assertThat(jsonPath.toGroupPath()).isEqualTo("tasks/{id}");
+    }
+
+    @Test
+    public void onRepositoryActionShouldActionPath() {
+        // GIVEN
+        String path = "/tasks/someRepositoryAction";
+
+        // WHEN
+        ActionPath jsonPath = (ActionPath) pathBuilder.build(path, queryContext);
+
+        // THEN
+        assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
+        Assert.assertEquals("someRepositoryAction", jsonPath.getActionName());
+        Assert.assertNull(jsonPath.getIds());
+        assertThat(jsonPath.toGroupPath()).isEqualTo("tasks/someRepositoryAction");
+    }
+
+    @Test
+    public void onResourceActionShouldActionPath() {
+        // GIVEN
+        String path = "/tasks/123/someResourceAction";
+
+        // WHEN
+        ActionPath jsonPath = (ActionPath) pathBuilder.build(path, queryContext);
+
+        // THEN
+        assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
+        Assert.assertEquals("someResourceAction", jsonPath.getActionName());
+        Assert.assertEquals(123L, jsonPath.getId());
+        assertThat(jsonPath.toGroupPath()).isEqualTo("tasks/{id}/someResourceAction");
+    }
+
+
+    @Test
+    public void onNestedResourcePathShouldReturnNestedPath() {
+        // GIVEN
+        String path = "/tasks/1/project";
+
+        // WHEN
+        FieldPath jsonPath = (FieldPath) pathBuilder.build(path, queryContext);
+
+        // THEN
+        assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
+        Assert.assertEquals(1L, jsonPath.getId());
+        Assert.assertEquals("project", jsonPath.getField().getJsonName());
+        assertThat(jsonPath.toGroupPath()).isEqualTo("tasks/{id}/project");
+    }
+
+    @Test
+    public void onNestedResourceInstancePathShouldThrowException() {
+        // GIVEN
+        String path = "/tasks/1/project/2";
+
+        // THEN
+        expectedException.expect(BadRequestException.class);
+
+        // WHEN
+        pathBuilder.build(path, queryContext);
+    }
+
+    @Test
+    public void onNestedResourceRelationshipPathShouldReturnNestedPath() {
+        // GIVEN
+        String path = "/tasks/1/relationships/project/";
+
+        // WHEN
+        RelationshipsPath jsonPath = (RelationshipsPath) pathBuilder.build(path, queryContext);
+
+        // THEN
+        assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
+        Assert.assertEquals(1L, jsonPath.getId());
+        Assert.assertEquals("project", jsonPath.getRelationship().getJsonName());
+        assertThat(jsonPath.toGroupPath()).isEqualTo("tasks/{id}/relationships/project");
+    }
+
+    @Test
+    public void onNonRelationshipFieldShouldThrowException() {
+        // GIVEN
+        String path = "/tasks/1/relationships/name/";
+
+        // THEN
+        expectedException.expect(BadRequestException.class);
+
+        // WHEN
+        pathBuilder.build(path, queryContext);
+    }
+
+    @Test
+    public void onRelationshipFieldInRelationshipsShouldThrowException() {
+        // GIVEN
+        String path = "/users/1/relationships/projects";
+
+        // THEN
+        expectedException.expect(BadRequestException.class);
+        expectedException.expectMessage("projects");
+
+        // WHEN
+        pathBuilder.build(path, queryContext);
+    }
+
+    @Test
+    public void onNestedWrongResourceRelationshipPathShouldThrowException() {
+        // GIVEN
+        String path = "/tasks/1/relationships/";
+
+        // THEN
+        expectedException.expect(BadRequestException.class);
+
+        // WHEN
+        pathBuilder.build(path, queryContext);
+    }
+
+    @Test
+    public void onRelationshipsPathWithIdShouldThrowException() {
+        // GIVEN
+        String path = "/tasks/1/relationships/project/1";
+
+        // THEN
+        expectedException.expect(BadRequestException.class);
+
+        // WHEN
+        pathBuilder.build(path, queryContext);
+    }
+
+    @Test
+    public void onNonExistingFieldShouldThrowException() {
+        // GIVEN
+        String path = "/tasks/1/nonExistingField/";
+
+        // THEN
+        expectedException.expect(BadRequestException.class);
+        expectedException.expectMessage("nonExistingField");
+
+        // WHEN
+        pathBuilder.build(path, queryContext);
+    }
+
+
+    @Test
+    public void singularSingularNestedRelationshipPath() {
+        // GIVEN
+        String path = "/test/1/oneNested/";
+
+        // WHEN
+        ResourcePath jsonPath = (ResourcePath) pathBuilder.build(path, queryContext);
+
+        // THEN
+        assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("oneNested");
+        Assert.assertEquals("1", jsonPath.getId());
+        Assert.assertEquals("oneNested", jsonPath.getParentField().getUnderlyingName());
+        assertThat(jsonPath.toGroupPath()).isEqualTo("test/{id}/oneNested");
+    }
+
+    @Test
+    public void checkMultivaluedRelationshipPath() {
+        // GIVEN
+        String path = "/test/1/manyNested/";
+
+        // WHEN
+        FieldPath jsonPath = (FieldPath) pathBuilder.build(path, queryContext);
+
+        // THEN
+        assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("test");
+        Assert.assertEquals("1", jsonPath.getId());
+        Assert.assertEquals("manyNested", jsonPath.getField().getUnderlyingName());
+        assertThat(jsonPath.toGroupPath()).isEqualTo("test/{id}/manyNested");
+    }
+
+    @Test
+    public void checkMultivaluedRelationshipIdPath() {
+        // GIVEN
+        String path = "/test/1/manyNested/2";
+
+        // WHEN
+        ResourcePath jsonPath = (ResourcePath) pathBuilder.build(path, queryContext);
+
+        // THEN
+        assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("manyNested");
+        Assert.assertEquals("1-2", jsonPath.getId().toString());
+        Assert.assertEquals("manyNested", jsonPath.getParentField().getUnderlyingName());
+        assertThat(jsonPath.toGroupPath()).isEqualTo("test/{id}/manyNested/{id}");
+    }
+
+    @Test
+    public void onNonExistingResourceShouldThrowException() {
+        String path = "/nonExistingResource";
+        Assert.assertNull(pathBuilder.build(path, queryContext));
+    }
+
+    @Test
+    public void onResourceStaringWithRelationshipsShouldThrowException() {
+        String path = "/relationships";
+        Assert.assertNull(pathBuilder.build(path, queryContext));
+    }
+
+    @Test
+    public void onMultipleResourceInstancesPathShouldReturnCollectionPath() {
+        // GIVEN
+        String path = "/tasks/1,2";
+
+        // WHEN
+        JsonPath jsonPath = pathBuilder.build(path, queryContext);
+
+        // THEN
+        assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
+        Assert.assertEquals(Arrays.asList(1L, 2L), jsonPath.getIds());
+        assertThat(jsonPath.toGroupPath()).isEqualTo("tasks/{id}");
+    }
+
+    @Test
+    public void onUrlEncodedMultipleResourceInstancesPathShouldReturnCollectionPath() {
+        // GIVEN
+        String path = "/tasks/1%2C2";
+
+        // WHEN
+        JsonPath jsonPath = pathBuilder.build(path, queryContext);
+
+        // THEN
+        assertThat(jsonPath.getRootEntry().getResourceInformation().getResourceType()).isEqualTo("tasks");
+        Assert.assertEquals(Arrays.asList(1L, 2L), jsonPath.getIds());
+    }
+
+    @Test
+    public void ignoreEntriesNotBeingExposed() {
+        String path = "/notExposed/1/";
+        JsonPath jsonPath = pathBuilder.build(path, queryContext);
+        Assert.assertNull(jsonPath);
+    }
 }

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/registry/ControllerRegistryTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/dispatcher/registry/ControllerRegistryTest.java
@@ -5,6 +5,7 @@ import io.crnk.core.CoreTestModule;
 import io.crnk.core.engine.internal.dispatcher.ControllerRegistry;
 import io.crnk.core.engine.internal.dispatcher.path.JsonPath;
 import io.crnk.core.engine.internal.dispatcher.path.PathBuilder;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.exception.BadRequestException;
 import org.junit.Before;
@@ -14,31 +15,32 @@ import org.junit.rules.ExpectedException;
 
 public class ControllerRegistryTest {
 
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-	private ResourceRegistry resourceRegistry;
-	private PathBuilder pathBuilder;
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    private ResourceRegistry resourceRegistry;
+    private PathBuilder pathBuilder;
+    private QueryContext queryContext = new QueryContext().setRequestVersion(0);
 
-	@Before
-	public void prepare() {
-		CoreTestContainer container = new CoreTestContainer();
-		container.addModule(new CoreTestModule());
-		container.boot();
-		resourceRegistry = container.getResourceRegistry();
-		pathBuilder = new PathBuilder(resourceRegistry, container.getModuleRegistry().getTypeParser());
-	}
+    @Before
+    public void prepare() {
+        CoreTestContainer container = new CoreTestContainer();
+        container.addModule(new CoreTestModule());
+        container.boot();
+        resourceRegistry = container.getResourceRegistry();
+        pathBuilder = new PathBuilder(resourceRegistry, container.getModuleRegistry().getTypeParser());
+    }
 
-	@Test
-	public void onUnsupportedRequestRegisterShouldThrowError() {
-		// GIVEN
-		JsonPath jsonPath = pathBuilder.build("/tasks/");
-		String requestType = "PATCH";
-		ControllerRegistry sut = new ControllerRegistry(null);
+    @Test
+    public void onUnsupportedRequestRegisterShouldThrowError() {
+        // GIVEN
+        JsonPath jsonPath = pathBuilder.build("/tasks/", queryContext);
+        String requestType = "PATCH";
+        ControllerRegistry sut = new ControllerRegistry(null);
 
-		// THEN
-		expectedException.expect(BadRequestException.class);
+        // THEN
+        expectedException.expect(BadRequestException.class);
 
-		// WHEN
-		sut.getController(jsonPath, requestType);
-	}
+        // WHEN
+        sut.getController(jsonPath, requestType);
+    }
 }

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/resource/InheritanceWithoutSubtypeRepositoryTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/resource/InheritanceWithoutSubtypeRepositoryTest.java
@@ -124,7 +124,7 @@ public class InheritanceWithoutSubtypeRepositoryTest extends ControllerTestBase 
 		resource.getRelationships().put("related", relationship);
 		Document document = new Document();
 		document.setData(Nullable.of(resource));
-		JsonPath path = pathBuilder.build("/testA");
+		JsonPath path = pathBuilder.build("/testA", queryContext);
 
 		QuerySpecAdapter queryAdapter = container.toQueryAdapter(new QuerySpec(TestResourceB.class));
 		Controller postController = boot.getControllerRegistry().getController(path, HttpMethod.POST.toString());
@@ -136,7 +136,7 @@ public class InheritanceWithoutSubtypeRepositoryTest extends ControllerTestBase 
 
 		// PATCH resource
 		document.setData(Nullable.of(createdResource));
-		path = pathBuilder.build("/testA/b");
+		path = pathBuilder.build("/testA/b", queryContext);
 		createdResource.setAttribute("value", toJson("valueB"));
 		Controller patchController = boot.getControllerRegistry().getController(path, HttpMethod.PATCH.toString());
 		response = patchController.handleAsync(path, queryAdapter, document).get();

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/resource/NestedResourceTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/resource/NestedResourceTest.java
@@ -136,7 +136,7 @@ public class NestedResourceTest extends ControllerTestBase {
 	@Test
 	public void checkOneFieldPath() {
 		PathBuilder pathBuilder = new PathBuilder(resourceRegistry, typeParser);
-		FieldPath path = (FieldPath) pathBuilder.build("test/b/oneNested/value");
+		FieldPath path = (FieldPath) pathBuilder.build("test/b/oneNested/value", queryContext);
 		Assert.assertEquals("oneNested", path.getRootEntry().getResourceInformation().getResourceType());
 		Assert.assertEquals("b", path.getId());
 		Assert.assertEquals("value", path.getField().getJsonName());
@@ -146,7 +146,7 @@ public class NestedResourceTest extends ControllerTestBase {
 	@Test
 	public void checkManyFieldPath() {
 		PathBuilder pathBuilder = new PathBuilder(resourceRegistry, typeParser);
-		FieldPath path = (FieldPath) pathBuilder.build("test/b/manyNested");
+		FieldPath path = (FieldPath) pathBuilder.build("test/b/manyNested", queryContext);
 		Assert.assertEquals("test", path.getRootEntry().getResourceInformation().getResourceType());
 		Assert.assertEquals("b", path.getId());
 		Assert.assertEquals("manyNested", path.getField().getJsonName());
@@ -155,7 +155,7 @@ public class NestedResourceTest extends ControllerTestBase {
 	@Test
 	public void checkOneNestedResourcePath() {
 		PathBuilder pathBuilder = new PathBuilder(resourceRegistry, typeParser);
-		ResourcePath path = (ResourcePath) pathBuilder.build("test/b/oneNested");
+		ResourcePath path = (ResourcePath) pathBuilder.build("test/b/oneNested", queryContext);
 		Assert.assertEquals("oneNested", path.getRootEntry().getResourceInformation().getResourceType());
 
 		String id = (String) path.getId();
@@ -165,7 +165,7 @@ public class NestedResourceTest extends ControllerTestBase {
 	@Test
 	public void checkManyNestedResourcePath() {
 		PathBuilder pathBuilder = new PathBuilder(resourceRegistry, typeParser);
-		ResourcePath path = (ResourcePath) pathBuilder.build("test/b/manyNested/a");
+		ResourcePath path = (ResourcePath) pathBuilder.build("test/b/manyNested/a", queryContext);
 		Assert.assertEquals("manyNested", path.getRootEntry().getResourceInformation().getResourceType());
 
 		ManyNestedId id = (ManyNestedId) path.getId();
@@ -176,7 +176,7 @@ public class NestedResourceTest extends ControllerTestBase {
 	@Test
 	public void checkOneRelationshipPath() {
 		PathBuilder pathBuilder = new PathBuilder(resourceRegistry, typeParser);
-		RelationshipsPath path = (RelationshipsPath) pathBuilder.build("test/b/oneNested/relationships/related");
+		RelationshipsPath path = (RelationshipsPath) pathBuilder.build("test/b/oneNested/relationships/related", queryContext);
 		Assert.assertEquals("oneNested", path.getRootEntry().getResourceInformation().getResourceType());
 
 		String id = (String) path.getId();
@@ -188,7 +188,7 @@ public class NestedResourceTest extends ControllerTestBase {
 	@Test
 	public void checkManyNestedRelationshipPath() {
 		PathBuilder pathBuilder = new PathBuilder(resourceRegistry, typeParser);
-		RelationshipsPath path = (RelationshipsPath) pathBuilder.build("test/b/manyNested/a/relationships/related");
+		RelationshipsPath path = (RelationshipsPath) pathBuilder.build("test/b/manyNested/a/relationships/related", queryContext);
 		Assert.assertEquals("manyNested", path.getRootEntry().getResourceInformation().getResourceType());
 
 		ManyNestedId id = (ManyNestedId) path.getId();
@@ -202,7 +202,7 @@ public class NestedResourceTest extends ControllerTestBase {
 	@Test
 	public void checkOneNestedFieldPath() {
 		PathBuilder pathBuilder = new PathBuilder(resourceRegistry, typeParser);
-		FieldPath path = (FieldPath) pathBuilder.build("test/b/oneNested/related");
+		FieldPath path = (FieldPath) pathBuilder.build("test/b/oneNested/related", queryContext);
 		Assert.assertEquals("oneNested", path.getRootEntry().getResourceInformation().getResourceType());
 
 		String id = (String) path.getId();
@@ -213,7 +213,7 @@ public class NestedResourceTest extends ControllerTestBase {
 	@Test
 	public void checkManyNestedFieldPath() {
 		PathBuilder pathBuilder = new PathBuilder(resourceRegistry, typeParser);
-		FieldPath path = (FieldPath) pathBuilder.build("test/b/manyNested/a/related");
+		FieldPath path = (FieldPath) pathBuilder.build("test/b/manyNested/a/related", queryContext);
 		Assert.assertEquals("manyNested", path.getRootEntry().getResourceInformation().getResourceType());
 
 		ManyNestedId id = (ManyNestedId) path.getId();
@@ -233,7 +233,7 @@ public class NestedResourceTest extends ControllerTestBase {
 		resource.getRelationships().put("related", relationship);
 		Document document = new Document();
 		document.setData(Nullable.of(resource));
-		JsonPath path = pathBuilder.build("test/b/oneNested");
+		JsonPath path = pathBuilder.build("test/b/oneNested", queryContext);
 
 		QuerySpecAdapter queryAdapter = container.toQueryAdapter(new QuerySpec(ManyNestedResource.class));
 		Controller postController = boot.getControllerRegistry().getController(path, HttpMethod.POST.toString());
@@ -245,7 +245,7 @@ public class NestedResourceTest extends ControllerTestBase {
 
 		// PATCH resource
 		document.setData(Nullable.of(createdResource));
-		path = pathBuilder.build("test/b/oneNested");
+		path = pathBuilder.build("test/b/oneNested", queryContext);
 		Assert.assertNotNull(path);
 		createdResource.setAttribute("value", toJson("valueB"));
 		Controller patchController = boot.getControllerRegistry().getController(path, HttpMethod.PATCH.toString());
@@ -297,7 +297,7 @@ public class NestedResourceTest extends ControllerTestBase {
 		child.setId("b");
 		Document document = new Document();
 		document.setData(Nullable.of(child));
-		JsonPath childPath = pathBuilder.build("test/b/oneNested");
+		JsonPath childPath = pathBuilder.build("test/b/oneNested", queryContext);
 
 		QuerySpecAdapter queryAdapter = container.toQueryAdapter(new QuerySpec(ManyNestedResource.class));
 		Controller postController = boot.getControllerRegistry().getController(childPath, HttpMethod.POST.toString());
@@ -313,7 +313,7 @@ public class NestedResourceTest extends ControllerTestBase {
 		grandchild.setId("b");
 		document = new Document();
 		document.setData(Nullable.of(grandchild));
-		response = postController.handleAsync(pathBuilder.build("test/b/oneNested/oneGrandchild"),
+		response = postController.handleAsync(pathBuilder.build("test/b/oneNested/oneGrandchild", queryContext),
 								   queryAdapter, document).get();
 		Resource createdGrandchild = response.getDocument().getSingleData().get();
 		Assert.assertEquals("http://127.0.0.1/test/b/oneNested/oneGrandchild", createdGrandchild.getLinks().get("self").asText());
@@ -321,7 +321,7 @@ public class NestedResourceTest extends ControllerTestBase {
 
 		// PATCH resource
 		document.setData(Nullable.of(createdGrandchild));
-		JsonPath path = pathBuilder.build("test/b/oneNested/oneGrandchild");
+		JsonPath path = pathBuilder.build("test/b/oneNested/oneGrandchild", queryContext);
 		Assert.assertNotNull(path);
 		createdGrandchild.setAttribute("value", toJson("valueB"));
 		Controller patchController = boot.getControllerRegistry().getController(path, HttpMethod.PATCH.toString());
@@ -378,7 +378,7 @@ public class NestedResourceTest extends ControllerTestBase {
 		resource.getRelationships().put("related", relationship);
 		Document document = new Document();
 		document.setData(Nullable.of(resource));
-		JsonPath path = pathBuilder.build("test/b/manyNested");
+		JsonPath path = pathBuilder.build("test/b/manyNested", queryContext);
 
 		QuerySpecAdapter queryAdapter = container.toQueryAdapter(new QuerySpec(ManyNestedResource.class));
 		Controller postController = boot.getControllerRegistry().getController(path, HttpMethod.POST.toString());
@@ -390,7 +390,7 @@ public class NestedResourceTest extends ControllerTestBase {
 
 		// PATCH resource
 		document.setData(Nullable.of(createdResource));
-		path = pathBuilder.build("test/b/manyNested/a");
+		path = pathBuilder.build("test/b/manyNested/a", queryContext);
 		Assert.assertNotNull(path);
 		createdResource.setAttribute("value", toJson("valueB"));
 		Controller patchController = boot.getControllerRegistry().getController(path, HttpMethod.PATCH.toString());
@@ -442,7 +442,7 @@ public class NestedResourceTest extends ControllerTestBase {
 		child.setId("b-a");
 		Document document = new Document();
 		document.setData(Nullable.of(child));
-		JsonPath childPath = pathBuilder.build("test/b/manyNested");
+		JsonPath childPath = pathBuilder.build("test/b/manyNested", queryContext);
 
 		QuerySpecAdapter queryAdapter = container.toQueryAdapter(new QuerySpec(ManyNestedResource.class));
 		Controller postController = boot.getControllerRegistry().getController(childPath, HttpMethod.POST.toString());
@@ -458,7 +458,7 @@ public class NestedResourceTest extends ControllerTestBase {
 		grandchild.setId("b-a-c");
 		document = new Document();
 		document.setData(Nullable.of(grandchild));
-		JsonPath grandchildPath = pathBuilder.build("test/b/manyNested/a/manyGrandchildren");
+		JsonPath grandchildPath = pathBuilder.build("test/b/manyNested/a/manyGrandchildren", queryContext);
 
 		response = postController.handleAsync(grandchildPath, queryAdapter, document).get();
 		Assert.assertEquals(HttpStatus.CREATED_201, response.getHttpStatus().intValue());
@@ -468,7 +468,7 @@ public class NestedResourceTest extends ControllerTestBase {
 
 		// PATCH resource
 		document.setData(Nullable.of(createdGrandchild));
-		grandchildPath = pathBuilder.build("test/b/manyNested/a/manyGrandchildren/c");
+		grandchildPath = pathBuilder.build("test/b/manyNested/a/manyGrandchildren/c", queryContext);
 		Assert.assertNotNull(grandchildPath);
 		createdGrandchild.setAttribute("value", toJson("valueC"));
 		Controller patchController = boot.getControllerRegistry().getController(grandchildPath, HttpMethod.PATCH.toString());

--- a/crnk-core/src/test/java/io/crnk/core/engine/registry/DefaultResourceRegistryPartTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/registry/DefaultResourceRegistryPartTest.java
@@ -1,6 +1,8 @@
 package io.crnk.core.engine.registry;
 
 import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.information.resource.VersionRange;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -22,12 +24,15 @@ public class DefaultResourceRegistryPartTest {
 
 		ResourceInformation resourceInformation = Mockito.mock(ResourceInformation.class);
 		Mockito.when(resourceInformation.getResourceType()).thenReturn("test");
+		Mockito.when(resourceInformation.getVersionRange()).thenReturn(VersionRange.UNBOUNDED);
 
 		ResourceInformation resourceInformation2 = Mockito.mock(ResourceInformation.class);
 		Mockito.when(resourceInformation2.getResourceType()).thenReturn("test2");
+		Mockito.when(resourceInformation2.getVersionRange()).thenReturn(VersionRange.of(1, 3));
 
 		ResourceInformation resourceInformation3 = Mockito.mock(ResourceInformation.class);
 		Mockito.when(resourceInformation3.getResourceType()).thenReturn("test3");
+		Mockito.when(resourceInformation3.getVersionRange()).thenReturn(VersionRange.UNBOUNDED);
 
 		entry = Mockito.mock(RegistryEntry.class);
 		Mockito.when(entry.getResourceInformation()).thenReturn(resourceInformation);
@@ -63,5 +68,14 @@ public class DefaultResourceRegistryPartTest {
 		part.addListener(listener);
 		part.addEntry(entry3);
 		Mockito.verify(listener, Mockito.times(2)).onChanged(Mockito.any(ResourceRegistryPartEvent.class));
+	}
+
+	@Test
+	public void checkLatestVersionComputation() {
+		part.addEntry(entry);
+		Assert.assertEquals(0, part.getLatestVersion());
+
+		part.addEntry(entry2);
+		Assert.assertEquals(3, part.getLatestVersion());
 	}
 }

--- a/crnk-core/src/test/java/io/crnk/core/engine/registry/HierarchicalResourceRegistryPartTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/registry/HierarchicalResourceRegistryPartTest.java
@@ -1,13 +1,14 @@
 package io.crnk.core.engine.registry;
 
 
+import java.util.Collection;
+
 import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.information.resource.VersionRange;
 import io.crnk.core.module.TestResource;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import java.util.Collection;
 
 public class HierarchicalResourceRegistryPartTest {
 
@@ -38,6 +39,7 @@ public class HierarchicalResourceRegistryPartTest {
 		Mockito.when(information.getResourceType()).thenReturn("test");
 		Mockito.when(information.getImplementationClass()).thenReturn((Class) TestResource.class);
 		Mockito.when(information.getImplementationType()).thenReturn(TestResource.class);
+		Mockito.when(information.getVersionRange()).thenReturn(VersionRange.UNBOUNDED);
 		Mockito.when(information.getResourcePath()).thenReturn("path");
 		RegistryEntry entry = Mockito.mock(RegistryEntry.class);
 		Mockito.when(entry.getResourceInformation()).thenReturn(information);
@@ -63,6 +65,7 @@ public class HierarchicalResourceRegistryPartTest {
 		ResourceInformation information = Mockito.mock(ResourceInformation.class);
 		Mockito.when(information.getResourceType()).thenReturn("child/test");
 		Mockito.when(information.getImplementationType()).thenReturn(TestResource.class);
+		Mockito.when(information.getVersionRange()).thenReturn(VersionRange.UNBOUNDED);
 		RegistryEntry entry = Mockito.mock(RegistryEntry.class);
 		Mockito.when(entry.getResourceInformation()).thenReturn(information);
 		RegistryEntry savedEntry = part.addEntry(entry);
@@ -85,6 +88,7 @@ public class HierarchicalResourceRegistryPartTest {
 		ResourceInformation information = Mockito.mock(ResourceInformation.class);
 		Mockito.when(information.getResourceType()).thenReturn("child/test");
 		Mockito.when(information.getResourceClass()).thenReturn((Class) TestResource.class);
+		Mockito.when(information.getVersionRange()).thenReturn(VersionRange.UNBOUNDED);
 		RegistryEntry entry = Mockito.mock(RegistryEntry.class);
 		Mockito.when(entry.getResourceInformation()).thenReturn(information);
 		part.addEntry(entry);

--- a/crnk-core/src/test/java/io/crnk/core/module/internal/ResourceFilterDirectoryImplTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/module/internal/ResourceFilterDirectoryImplTest.java
@@ -19,6 +19,7 @@ import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.engine.result.ImmediateResultFactory;
+import io.crnk.core.module.ModuleRegistry;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,8 +49,11 @@ public class ResourceFilterDirectoryImplTest {
     public void setup() {
         queryContext = new QueryContext();
 
+		resourceRegistry = Mockito.mock(ResourceRegistry.class);
         resultFactory = new ImmediateResultFactory();
-        requestContextProvider = new HttpRequestContextProvider(() -> resultFactory);
+		ModuleRegistry moduleRegistry = Mockito.mock(ModuleRegistry.class);
+		Mockito.when(moduleRegistry.getResourceRegistry()).thenReturn(resourceRegistry);
+		requestContextProvider = new HttpRequestContextProvider(() -> resultFactory, moduleRegistry);
 
         filter = Mockito.mock(ResourceFilter.class);
         filters.add(filter);
@@ -57,7 +61,6 @@ public class ResourceFilterDirectoryImplTest {
         resourceInformation = Mockito.mock(ResourceInformation.class);
         resourceField = Mockito.mock(ResourceField.class);
         Mockito.when(resourceField.getAccess()).thenReturn(new ResourceFieldAccess(true, true, true, true, true, true));
-        resourceRegistry = Mockito.mock(ResourceRegistry.class);
 
         directory = new ResourceFilterDirectoryImpl(filters, requestContextProvider, resourceRegistry);
     }

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/AbstractQuerySpecTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/AbstractQuerySpecTest.java
@@ -1,12 +1,5 @@
 package io.crnk.core.queryspec;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import io.crnk.core.CoreTestContainer;
 import io.crnk.core.CoreTestModule;
 import io.crnk.core.engine.information.InformationBuilder;
@@ -17,88 +10,101 @@ import io.crnk.core.engine.information.resource.ResourceFieldAccess;
 import io.crnk.core.engine.information.resource.ResourceFieldAccessor;
 import io.crnk.core.engine.internal.information.DefaultInformationBuilder;
 import io.crnk.core.engine.parser.TypeParser;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.mock.models.Task;
 import io.crnk.core.module.ModuleRegistry;
 import io.crnk.core.module.SimpleModule;
+import io.crnk.core.queryspec.mapper.QuerySpecUrlContext;
 import io.crnk.core.queryspec.pagingspec.OffsetLimitPagingSpec;
 import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public abstract class AbstractQuerySpecTest {
 
 
-	protected ResourceRegistry resourceRegistry;
+    protected ResourceRegistry resourceRegistry;
 
-	protected ModuleRegistry moduleRegistry;
+    protected ModuleRegistry moduleRegistry;
 
-	protected CoreTestContainer container;
+    protected CoreTestContainer container;
 
-	protected static void addParams(Map<String, Set<String>> params, String key, String value) {
-		params.put(key, new HashSet<>(Arrays.asList(value)));
-	}
+    protected QuerySpecUrlContext deserializerContext;
 
-	@Before
-	public void setup() {
-		container = new CoreTestContainer();
-		ResourceFieldContributor contributor = new ResourceFieldContributor() {
-			@Override
-			public List<ResourceField> getResourceFields(ResourceFieldContributorContext context) {
-				List<ResourceField> fields = new ArrayList<>();
-				if (context.getResourceInformation().getResourceClass() == Task.class) {
-					// add additional field that is not defined on the class
-					String name = "computedAttribute";
-					ResourceFieldAccess access = new ResourceFieldAccess(true, true, true, true, true);
+    protected QueryContext queryContext = new QueryContext().setRequestVersion(0);
 
-					InformationBuilder informationBuilder = new DefaultInformationBuilder(new TypeParser());
+    protected static void addParams(Map<String, Set<String>> params, String key, String value) {
+        params.put(key, new HashSet<>(Arrays.asList(value)));
+    }
 
-					InformationBuilder.FieldInformationBuilder fieldBuilder = informationBuilder.createResourceField();
-					fieldBuilder.type(Integer.class);
-					fieldBuilder.jsonName(name);
-					fieldBuilder.underlyingName(name);
-					fieldBuilder.access(access);
-					fieldBuilder.accessor(new ResourceFieldAccessor() {
+    @Before
+    public void setup() {
+        container = new CoreTestContainer();
+        ResourceFieldContributor contributor = new ResourceFieldContributor() {
+            @Override
+            public List<ResourceField> getResourceFields(ResourceFieldContributorContext context) {
+                List<ResourceField> fields = new ArrayList<>();
+                if (context.getResourceInformation().getResourceClass() == Task.class) {
+                    // add additional field that is not defined on the class
+                    String name = "computedAttribute";
+                    ResourceFieldAccess access = new ResourceFieldAccess(true, true, true, true, true);
 
-						public Object getValue(Object resource) {
-							return 13;
-						}
+                    InformationBuilder informationBuilder = new DefaultInformationBuilder(new TypeParser());
 
-						public void setValue(Object resource, Object fieldValue) {
+                    InformationBuilder.FieldInformationBuilder fieldBuilder = informationBuilder.createResourceField();
+                    fieldBuilder.type(Integer.class);
+                    fieldBuilder.jsonName(name);
+                    fieldBuilder.underlyingName(name);
+                    fieldBuilder.access(access);
+                    fieldBuilder.accessor(new ResourceFieldAccessor() {
 
-						}
+                        public Object getValue(Object resource) {
+                            return 13;
+                        }
 
-						@Override
-						public Class getImplementationClass() {
-							return Integer.class;
-						}
-					});
-					fields.add(fieldBuilder.build());
+                        public void setValue(Object resource, Object fieldValue) {
 
-				}
-				return fields;
-			}
-		};
-		SimpleModule module = new SimpleModule("test");
-		module.addResourceFieldContributor(contributor);
+                        }
 
-		setup(container);
-		container.addModule(module);
-		container.boot();
+                        @Override
+                        public Class getImplementationClass() {
+                            return Integer.class;
+                        }
+                    });
+                    fields.add(fieldBuilder.build());
 
-		moduleRegistry = container.getModuleRegistry();
-		resourceRegistry = container.getResourceRegistry();
-	}
+                }
+                return fields;
+            }
+        };
+        SimpleModule module = new SimpleModule("test");
+        module.addResourceFieldContributor(contributor);
 
-	protected void setup(CoreTestContainer container) {
-		container.addModule(new CoreTestModule());
-	}
+        setup(container);
+        container.addModule(module);
+        container.boot();
 
-	protected QuerySpec querySpec(Long offset, Long limit) {
-		QuerySpec querySpec = new QuerySpec(Task.class);
-		querySpec.setPaging(new OffsetLimitPagingSpec(offset, limit));
-		return querySpec;
-	}
+        moduleRegistry = container.getModuleRegistry();
+        resourceRegistry = container.getResourceRegistry();
+    }
 
-	protected QuerySpec querySpec() {
-		return querySpec(0L, null);
-	}
+    protected void setup(CoreTestContainer container) {
+        container.addModule(new CoreTestModule());
+    }
+
+    protected QuerySpec querySpec(Long offset, Long limit) {
+        QuerySpec querySpec = new QuerySpec(Task.class);
+        querySpec.setPaging(new OffsetLimitPagingSpec(offset, limit));
+        return querySpec;
+    }
+
+    protected QuerySpec querySpec() {
+        return querySpec(0L, null);
+    }
 }

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapperDeserializerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapperDeserializerTest.java
@@ -1,5 +1,6 @@
 package io.crnk.core.queryspec.mapper;
 
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.exception.BadRequestException;
 import io.crnk.core.exception.ParametersDeserializationException;
 import io.crnk.core.mock.models.Project;
@@ -17,6 +18,8 @@ import java.util.Set;
 public class DefaultQuerySpecUrlMapperDeserializerTest extends DefaultQuerySpecUrlMapperDeserializerTestBase {
 
 
+    private QueryContext queryContext = new QueryContext().setRequestVersion(0);
+
     @Before
     public void setup() {
         super.setup();
@@ -28,7 +31,7 @@ public class DefaultQuerySpecUrlMapperDeserializerTest extends DefaultQuerySpecU
     public void testDotNotationDisallowsBrackets() {
         Map<String, Set<String>> params = new HashMap<>();
         add(params, "filter[projects][tasks][name]", "test");
-        urlMapper.deserialize(taskInformation, params);
+        urlMapper.deserialize(taskInformation, params, queryContext);
     }
 
     @Test
@@ -36,7 +39,7 @@ public class DefaultQuerySpecUrlMapperDeserializerTest extends DefaultQuerySpecU
         Map<String, Set<String>> params = new HashMap<>();
         add(params, "filter[deleted]", "true");
         try {
-            urlMapper.deserialize(taskInformation, params);
+            urlMapper.deserialize(taskInformation, params, queryContext);
             Assert.fail();
         } catch (BadRequestException e) {
             Assert.assertEquals("path [deleted] is not filterable", e.getMessage());
@@ -48,7 +51,7 @@ public class DefaultQuerySpecUrlMapperDeserializerTest extends DefaultQuerySpecU
         Map<String, Set<String>> params = new HashMap<>();
         add(params, "sort", "deleted");
         try {
-            urlMapper.deserialize(taskInformation, params);
+            urlMapper.deserialize(taskInformation, params, queryContext);
             Assert.fail();
         } catch (BadRequestException e) {
             Assert.assertEquals("path [deleted] is not sortable", e.getMessage());
@@ -62,7 +65,7 @@ public class DefaultQuerySpecUrlMapperDeserializerTest extends DefaultQuerySpecU
         // note that there is both a type and an attribute on tasks called
         // projects
         add(params, "filter[projects][name]", "test");
-        QuerySpec querySpec = urlMapper.deserialize(taskInformation, params);
+        QuerySpec querySpec = urlMapper.deserialize(taskInformation, params, queryContext);
         Assert.assertEquals(Task.class, querySpec.getResourceClass());
         Assert.assertEquals(0, querySpec.getFilters().size());
         QuerySpec projectQuerySpec = querySpec.getQuerySpec(Project.class);
@@ -77,7 +80,7 @@ public class DefaultQuerySpecUrlMapperDeserializerTest extends DefaultQuerySpecU
         Map<String, Set<String>> params = new HashMap<>();
         add(params, "filter[projects]", "someValue");
         urlMapper.setIgnoreParseExceptions(true);
-        QuerySpec querySpec = urlMapper.deserialize(taskInformation, params);
+        QuerySpec querySpec = urlMapper.deserialize(taskInformation, params, queryContext);
         Assert.assertEquals(Task.class, querySpec.getResourceClass());
         Assert.assertEquals(Arrays.asList("projects"), querySpec.getFilters().get(0).getAttributePath());
         Assert.assertNull(querySpec.getQuerySpec(Project.class));

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapperDeserializerTestBase.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapperDeserializerTestBase.java
@@ -1,11 +1,5 @@
 package io.crnk.core.queryspec.mapper;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.crnk.core.CoreTestContainer;
 import io.crnk.core.CoreTestModule;
@@ -19,6 +13,9 @@ import io.crnk.core.mock.models.Project;
 import io.crnk.core.mock.models.Schedule;
 import io.crnk.core.mock.models.Task;
 import io.crnk.core.mock.models.TaskWithLookup;
+import io.crnk.core.mock.repository.TaskWithPagingBehavior;
+import io.crnk.core.mock.repository.TaskWithPagingBehaviorRepository;
+import io.crnk.core.mock.repository.TaskWithPagingBehaviorToProjectRepository;
 import io.crnk.core.module.SimpleModule;
 import io.crnk.core.queryspec.AbstractQuerySpecTest;
 import io.crnk.core.queryspec.Direction;
@@ -32,760 +29,763 @@ import io.crnk.core.queryspec.SortSpec;
 import io.crnk.core.queryspec.pagingspec.CustomOffsetLimitPagingBehavior;
 import io.crnk.core.queryspec.pagingspec.OffsetLimitPagingBehavior;
 import io.crnk.core.queryspec.pagingspec.OffsetLimitPagingSpec;
-import io.crnk.core.mock.repository.TaskWithPagingBehavior;
-import io.crnk.core.mock.repository.TaskWithPagingBehaviorRepository;
-import io.crnk.core.mock.repository.TaskWithPagingBehaviorToProjectRepository;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 public abstract class DefaultQuerySpecUrlMapperDeserializerTestBase extends AbstractQuerySpecTest {
 
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-
-	protected DefaultQuerySpecUrlMapper urlMapper;
-
-	protected ResourceInformation taskInformation;
-
-	private ResourceInformation taskWithPagingBehaviorInformation;
-
-	private QuerySpecUrlContext deserializerContext;
-
-	@Before
-	public void setup() {
-		super.setup();
-
-		deserializerContext = new QuerySpecUrlContext() {
-
-			@Override
-			public ResourceRegistry getResourceRegistry() {
-				return resourceRegistry;
-			}
-
-			@Override
-			public TypeParser getTypeParser() {
-				return moduleRegistry.getTypeParser();
-			}
-
-			@Override
-			public ObjectMapper getObjectMapper() {
-				return container.getObjectMapper();
-			}
-		};
-
-		urlMapper = new DefaultQuerySpecUrlMapper();
-		urlMapper.init(deserializerContext);
-
-		RegistryEntry taskEntry = resourceRegistry.getEntry(Task.class);
-		taskInformation = taskEntry.getResourceInformation();
-		taskWithPagingBehaviorInformation = resourceRegistry.getEntry(TaskWithPagingBehavior.class).getResourceInformation();
-	}
-
-
-	@Override
-	protected void setup(CoreTestContainer container) {
-		container.addModule(new CoreTestModule());
-
-		SimpleModule customPagingModule = new SimpleModule("customPaging");
-		customPagingModule.addRepository(new TaskWithPagingBehaviorRepository());
-		customPagingModule.addRepository(new TaskWithPagingBehaviorToProjectRepository());
-		customPagingModule.addPagingBehavior(new OffsetLimitPagingBehavior());
-		customPagingModule.addPagingBehavior(new CustomOffsetLimitPagingBehavior());
-		container.addModule(customPagingModule);
-	}
-
-	@Test
-	public void operations() {
-		Assert.assertFalse(urlMapper.getAllowUnknownAttributes());
-		urlMapper.setAllowUnknownAttributes(true);
-		Assert.assertTrue(urlMapper.getAllowUnknownAttributes());
-		urlMapper.getSupportedOperators().clear();
-		urlMapper.setDefaultOperator(FilterOperator.LIKE);
-		urlMapper.addSupportedOperator(FilterOperator.LIKE);
-		Assert.assertEquals(FilterOperator.LIKE, urlMapper.getDefaultOperator());
-		Assert.assertEquals(1, urlMapper.getSupportedOperators().size());
-	}
-
-	@Test
-	public void checkIgnoreParseExceptions() {
-		Assert.assertFalse(urlMapper.isIgnoreParseExceptions());
-		urlMapper.setIgnoreParseExceptions(true);
-		Assert.assertTrue(urlMapper.isIgnoreParseExceptions());
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[id]", "notAnInteger");
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(new FilterSpec(Arrays.asList("id"), FilterOperator.EQ, "notAnInteger"));
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test(expected = ParametersDeserializationException.class)
-	public void throwParseExceptionsByDefault() {
-		Assert.assertFalse(urlMapper.isIgnoreParseExceptions());
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[id]", "notAnInteger");
-		urlMapper.deserialize(taskInformation, params);
-	}
-
-	@Test(expected = ParametersDeserializationException.class)
-	public void throwParseExceptionsForMultiValuedOffset() {
-		Map<String, Set<String>> params = new HashMap<>();
-		params.put("page[offset]", new HashSet<>(Arrays.asList("1", "2")));
-		urlMapper.deserialize(taskInformation, params);
-	}
-
-	@Test(expected = ParametersDeserializationException.class)
-	public void throwParseExceptionsWhenBracketsNotClosed() {
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[", "someValue");
-		urlMapper.deserialize(taskInformation, params);
-	}
-
-	@Test
-	public void testFindAll() {
-		Map<String, Set<String>> params = new HashMap<>();
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void defaultPaginationOnRoot() {
-		Map<String, Set<String>> params = new HashMap<>();
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(0L, actualSpec.getOffset());
-		Assert.assertNull(actualSpec.getLimit());
-	}
-
-	@Test
-	public void defaultPaginationOnRelation() {
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "sort[projects]", "name");
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(0L, actualSpec.getOffset());
-		Assert.assertNull(actualSpec.getLimit());
-		QuerySpec projectQuerySpec = actualSpec.getQuerySpec(Project.class);
-		Assert.assertNotNull(projectQuerySpec);
-		Assert.assertEquals(0L, projectQuerySpec.getOffset());
-		Assert.assertNull(projectQuerySpec.getLimit());
-
-		Map<String, Set<String>> serialized = urlMapper.serialize(actualSpec);
-		Assert.assertEquals(serialized, params);
-	}
-
-	@Test
-	public void mapJsonToJavaNames() {
-		ResourceInformation scheduleInformation = resourceRegistry.getEntry(Schedule.class).getResourceInformation();
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "sort", "description");
-		add(params, "filter[description]", "test");
-		add(params, "fields", "description");
-		add(params, "include", "followup");
-		QuerySpec actualSpec = urlMapper.deserialize(scheduleInformation, params);
-
-		Assert.assertEquals(1, actualSpec.getSort().size());
-		Assert.assertEquals(1, actualSpec.getFilters().size());
-		Assert.assertEquals(1, actualSpec.getIncludedFields().size());
-		Assert.assertEquals(1, actualSpec.getIncludedRelations().size());
-
-		SortSpec sortSpec = actualSpec.getSort().get(0);
-		FilterSpec filterSpec = actualSpec.getFilters().get(0);
-		IncludeRelationSpec includeRelationSpec = actualSpec.getIncludedRelations().get(0);
-		IncludeFieldSpec includeFieldSpec = actualSpec.getIncludedFields().get(0);
-
-		Assert.assertEquals(Arrays.asList("desc"), sortSpec.getAttributePath());
-		Assert.assertEquals(Arrays.asList("desc"), filterSpec.getAttributePath());
-		Assert.assertEquals(Arrays.asList("followupProject"), includeRelationSpec.getAttributePath());
-		Assert.assertEquals(Arrays.asList("desc"), includeFieldSpec.getAttributePath());
-	}
-
-	@Test
-	public void customPaginationOnRoot() {
-		Map<String, Set<String>> params = new HashMap<>();
-		QuerySpec actualSpec = urlMapper.deserialize(taskWithPagingBehaviorInformation, params);
-		Assert.assertEquals(1L, actualSpec.getOffset());
-		Assert.assertEquals(10L, actualSpec.getLimit().longValue());
-	}
-
-	@Test
-	public void customPaginationOnRelation() {
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "sort[projects]", "name");
-		QuerySpec actualSpec = urlMapper.deserialize(taskWithPagingBehaviorInformation, params);
-		Assert.assertEquals(1L, actualSpec.getOffset());
-		Assert.assertEquals(10L, actualSpec.getLimit().longValue());
-		QuerySpec projectQuerySpec = actualSpec.getQuerySpec(Project.class);
-		Assert.assertNotNull(projectQuerySpec);
-		Assert.assertEquals(0L, projectQuerySpec.getOffset());
-		Assert.assertNull(projectQuerySpec.getLimit());
-	}
-
-	@Test
-	public void testFindAllOrderByAsc() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addSort(new SortSpec(Arrays.asList("name"), Direction.ASC));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "sort", "name");
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-
-		Map<String, Set<String>> serialized = urlMapper.serialize(actualSpec);
-		Assert.assertEquals(serialized, params);
-	}
-
-	@Test
-	public void testFollowNestedObjectWithinResource() {
-		// follow ProjectData.data
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addSort(new SortSpec(Arrays.asList("data", "data"), Direction.ASC));
-
-		ResourceInformation projectInformation = resourceRegistry.getEntry(Project.class).getResourceInformation();
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "sort", "data.data");
-		QuerySpec actualSpec = urlMapper.deserialize(projectInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-
-		Map<String, Set<String>> serialized = urlMapper.serialize(actualSpec);
-		Assert.assertEquals(new HashSet(Arrays.asList("data.data")), serialized.get("sort"));
-	}
-
-	@Test
-	public void testOrderByMultipleAttributes() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addSort(new SortSpec(Arrays.asList("name"), Direction.ASC));
-		expectedSpec.addSort(new SortSpec(Arrays.asList("id"), Direction.ASC));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "sort", "name,id");
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-
-		Map<String, Set<String>> serialized = urlMapper.serialize(actualSpec);
-		Assert.assertEquals(serialized, params);
-	}
-
-	@Test
-	public void testFindAllOrderByDesc() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addSort(new SortSpec(Arrays.asList("name"), Direction.DESC));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "sort", "-name");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-
-		Map<String, Set<String>> serialized = urlMapper.serialize(actualSpec);
-		Assert.assertEquals(serialized, params);
-	}
-
-	@Test
-	public void testFilterWithDefaultOp() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(new FilterSpec(Arrays.asList("name"), FilterOperator.EQ, "value"));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[tasks][name]", "value");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void testFilterWithPrettyJson() {
-		String expectedJson = "{ \"OR\": [ {\"id\": [12, 13, 14]}, {\"completed\": true} ] }";
-		QuerySpec jsonSpec = new QuerySpec(Task.class);
-		jsonSpec.addFilter(new FilterSpec(expectedJson));
-
-		Map<String, Set<String>> expectedParams = new HashMap<>();
-		add(expectedParams, "filter", "{\"OR\":[{\"id\":[12,13,14]},{\"completed\":true}]}");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, expectedParams);
-
-		FilterSpec idFilterSpec = PathSpec.of("id").filter(FilterOperator.EQ, Arrays.asList(12L, 13L, 14L));
-		FilterSpec completedFilterSpec = PathSpec.of("completed").filter(FilterOperator.EQ, true);
-		QuerySpec expectedQuerySpec = new QuerySpec(Task.class);
-		expectedQuerySpec.addFilter(FilterSpec.or(idFilterSpec, completedFilterSpec));
-		Assert.assertEquals(expectedQuerySpec.getFilters(), actualSpec.getFilters());
-		Assert.assertEquals(expectedQuerySpec, actualSpec);
-
-		Map<String, Set<String>> actualParams = urlMapper.serialize(actualSpec);
-		Assert.assertEquals(expectedParams, actualParams);
-	}
-
-	@Test
-	public void testFilterSpecJsonWithDefaultOperator() {
-		String expectedJson = "[{ \"path\": \"completed\", \"value\": true }]";
-		QuerySpec jsonSpec = new QuerySpec(Task.class);
-		jsonSpec.addFilter(new FilterSpec(expectedJson));
-
-		Map<String, Set<String>> expectedParams = new HashMap<>();
-		add(expectedParams, "filter", expectedJson);
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, expectedParams);
-		FilterSpec actualFilter = actualSpec.getFilters().get(0);
-		Assert.assertEquals(PathSpec.of("completed"), actualFilter.getPath());
-		Assert.assertEquals(FilterOperator.EQ, actualFilter.getOperator());
-		Assert.assertEquals(Boolean.TRUE, actualFilter.getValue());
-	}
-
-	@Test
-	public void testFilterSpecJsonWithOperator() {
-		String expectedJson = "[{ \"path\": \"completed\", \"operator\": \"NEQ\", \"value\": true }]";
-		QuerySpec jsonSpec = new QuerySpec(Task.class);
-		jsonSpec.addFilter(new FilterSpec(expectedJson));
-
-		Map<String, Set<String>> expectedParams = new HashMap<>();
-		add(expectedParams, "filter", expectedJson);
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, expectedParams);
-		FilterSpec actualFilter = actualSpec.getFilters().get(0);
-		Assert.assertEquals(PathSpec.of("completed"), actualFilter.getPath());
-		Assert.assertEquals(FilterOperator.NEQ, actualFilter.getOperator());
-		Assert.assertEquals(Boolean.TRUE, actualFilter.getValue());
-	}
-
-	@Test
-	public void testFilterSpecJsonWithNestedFilters() {
-		String expectedJson = "[{ \"operator\": \"OR\", \"expression\": [{ \"path\": \"completed\", \"operator\": \"NEQ\", \"value\": true }] }]";
-		QuerySpec jsonSpec = new QuerySpec(Task.class);
-		jsonSpec.addFilter(new FilterSpec(expectedJson));
-
-		Map<String, Set<String>> expectedParams = new HashMap<>();
-		add(expectedParams, "filter", expectedJson);
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, expectedParams);
-		FilterSpec actualFilter = actualSpec.getFilters().get(0);
-		Assert.assertEquals(FilterOperator.OR, actualFilter.getOperator());
-
-		Assert.assertEquals(1, actualFilter.getExpression().size());
-		FilterSpec nestedFilter = actualFilter.getExpression().get(0);
-		Assert.assertEquals(PathSpec.of("completed"), nestedFilter.getPath());
-		Assert.assertEquals(FilterOperator.NEQ, nestedFilter.getOperator());
-		Assert.assertEquals(Boolean.TRUE, nestedFilter.getValue());
-	}
-
-	@Test
-	public void testFilterOnRelatedWithJson() {
-		Map<String, Set<String>> expectedParams = new HashMap<>();
-		add(expectedParams, "filter[projects]", "{\"OR\":[{\"id\":[12,13,14]},{\"name\":\"Test\"}]}");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, expectedParams);
-		Assert.assertTrue("must filter on related", actualSpec.getFilters().isEmpty());
-		QuerySpec actualRelatedSpec = actualSpec.getQuerySpec(Project.class);
-		Assert.assertNotNull(actualRelatedSpec);
-
-		FilterSpec idFilterSpec = PathSpec.of("id").filter(FilterOperator.EQ, Arrays.asList(12L, 13L, 14L));
-		FilterSpec nameFilterSpec = PathSpec.of("name").filter(FilterOperator.EQ, "Test");
-		QuerySpec expectedRelatedQuerySpec = new QuerySpec(Project.class);
-		expectedRelatedQuerySpec.addFilter(FilterSpec.or(idFilterSpec, nameFilterSpec));
-		QuerySpec expectedQuerySpec = new QuerySpec(Task.class);
-		expectedQuerySpec.putRelatedSpec(Project.class, expectedRelatedQuerySpec);
-
-		Assert.assertEquals(expectedQuerySpec.getFilters(), actualSpec.getFilters());
-		Assert.assertEquals(expectedRelatedQuerySpec.getFilters(), actualRelatedSpec.getFilters());
-		Assert.assertEquals(expectedRelatedQuerySpec, actualRelatedSpec);
-
-		Map<String, Set<String>> actualParams = urlMapper.serialize(actualSpec);
-		Assert.assertEquals(expectedParams, actualParams);
-	}
-
-	@Test
-	public void testFilterByNull() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(new FilterSpec(Arrays.asList("name"), FilterOperator.EQ, null));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[name]", "null");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void testFilterWithComputedAttribute() {
-		// if computeAttribte is not found, module order is wrong
-		// tests setup with information builder must be hardened
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(new FilterSpec(Arrays.asList("computedAttribute"), FilterOperator.EQ, 13));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[tasks][computedAttribute]", "13");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void testFilterWithDotNotation() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(new FilterSpec(Arrays.asList("project", "name"), FilterOperator.EQ, "value"));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[project.name]", "value");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-
-		Map<String, Set<String>> serialized = urlMapper.serialize(actualSpec);
-		Assert.assertEquals(new HashSet(Arrays.asList("value")), serialized.get("filter[project.name]"));
-	}
-
-	@Test
-	public void testFilterWithCommaSeparation() {
-		Assert.assertTrue(urlMapper.getAllowCommaSeparatedValue());
-		HashSet<String> values = new HashSet<>();
-		values.add("john");
-		values.add("jane");
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(new FilterSpec(Arrays.asList("name"), FilterOperator.EQ, values));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[name]", "john,jane");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec.getFilters(), actualSpec.getFilters());
-	}
-
-	@Test
-	public void testFilterWithoutCommaSeparation() {
-		urlMapper.setAllowCommaSeparatedValue(false);
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(new FilterSpec(Arrays.asList("name"), FilterOperator.EQ, "john,jane"));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[name]", "john,jane");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec.getFilters(), actualSpec.getFilters());
-	}
-
-	@Test
-	public void testFilterWithDotNotationMultipleElements() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(new FilterSpec(Arrays.asList("project", "task", "name"), FilterOperator.EQ, "value"));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[project.task.name]", "value");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-
-		Assert.assertEquals(expectedSpec, actualSpec);
-
-		Map<String, Set<String>> serialized = urlMapper.serialize(actualSpec);
-		Assert.assertEquals(new HashSet(Arrays.asList("value")), serialized.get("filter[project.task.name]"));
-	}
-
-	@Test
-	public void testUnknownPropertyAllowed() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(new FilterSpec(Arrays.asList("doesNotExists"), FilterOperator.EQ, "value"));
-
-		urlMapper.setAllowUnknownAttributes(true);
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[tasks][doesNotExists]", "value");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test(expected = BadRequestException.class)
-	public void testUnknownPropertyNotAllowed() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(new FilterSpec(Arrays.asList("doesNotExists"), FilterOperator.EQ, "value"));
-
-		urlMapper.setAllowUnknownAttributes(false);
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[tasks][doesNotExists]", "value");
-
-		urlMapper.deserialize(taskInformation, params);
-	}
-
-	@Test
-	public void testUnknownParameterAllowed() {
-		urlMapper.setAllowUnknownParameters(true);
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "doesNotExists[tasks]", "value");
-
-		Assert.assertNotNull(urlMapper.deserialize(taskInformation, params));
-	}
-
-	@Test(expected = ParametersDeserializationException.class)
-	public void testUnknownParameterNotAllowed() {
-		urlMapper.setAllowUnknownParameters(false);
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "doesNotExists[tasks]", "value");
-
-		urlMapper.deserialize(taskInformation, params);
-	}
-
-	@Test
-	public void testFilterByOne() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(new FilterSpec(Arrays.asList("name"), FilterOperator.EQ, "value"));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[tasks][name][EQ]", "value");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void testFilterByMany() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(
-				new FilterSpec(Arrays.asList("name"), FilterOperator.EQ, new HashSet<>(Arrays.asList("value1", "value2"))));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		params.put("filter[tasks][name][EQ]", new HashSet<>(Arrays.asList("value1", "value2")));
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void testFilterEquals() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(new FilterSpec(Arrays.asList("id"), FilterOperator.EQ, 1L));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[tasks][id][EQ]", "1");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void testFilterGreater() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(new FilterSpec(Arrays.asList("id"), FilterOperator.LE, 1L));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[tasks][id][LE]", "1");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void testFilterGreaterOnRoot() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addFilter(new FilterSpec(Arrays.asList("id"), FilterOperator.LE, 1L));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[id][LE]", "1");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void testPaging() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.setPaging(new OffsetLimitPagingSpec(1L, 2L));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "page[offset]", "1");
-		add(params, "page[limit]", "2");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void deserializeUnknownParameter() {
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "doesNotExist[something]", "someValue");
-
-		final boolean[] deserialized = new boolean[1];
-		urlMapper = new DefaultQuerySpecUrlMapper() {
-
-			@Override
-			protected void deserializeUnknown(final QuerySpec querySpec, final QueryParameter parameter) {
-				Assert.assertEquals(QueryParameterType.UNKNOWN, parameter.getType());
-				Assert.assertEquals("doesNotExist[something]", parameter.getName());
-				Assert.assertNull(parameter.getResourceInformation());
-				Assert.assertEquals(FilterOperator.EQ, parameter.getOperator());
-				Assert.assertNull(parameter.getAttributePath());
-				Assert.assertEquals(1, parameter.getValues().size());
-				deserialized[0] = true;
-			}
-		};
-		urlMapper.init(deserializerContext);
-		urlMapper.deserialize(taskInformation, params);
-		Assert.assertTrue(deserialized[0]);
-	}
-
-
-	@Test(expected = ParametersDeserializationException.class)
-	public void testInvalidPagingType() {
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "page[doesNotExist]", "1");
-		urlMapper.deserialize(taskInformation, params);
-	}
-
-	@Test(expected = ParametersDeserializationException.class)
-	public void testPagingError() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.setLimit(2L);
-		expectedSpec.setOffset(1L);
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "page[offset]", "notANumber");
-		add(params, "page[limit]", "2");
-
-		urlMapper.deserialize(taskInformation, params);
-	}
-
-	@Test
-	public void testPagingMaxLimitNotAllowed() {
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "page[offset]", "1");
-		add(params, "page[limit]", "30");
-
-		expectedException.expect(BadRequestException.class);
-
-		urlMapper.deserialize(taskWithPagingBehaviorInformation, params);
-	}
-
-	@Test
-	public void testPagingMaxLimitAllowed() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.setOffset(1L);
-		expectedSpec.setLimit(5L);
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "page[offset]", "1");
-		add(params, "page[limit]", "5");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void testIncludeRelations() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.includeRelation(Arrays.asList("project"));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "include[tasks]", "project");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void testIncludeRelationsOnRoot() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.includeRelation(Arrays.asList("project"));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "include", "project");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void testIncludeAttributes() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.includeField(Arrays.asList("name"));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "fields[tasks]", "name");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void testIncludeAttributesOnRoot() {
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.includeField(Arrays.asList("name"));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "fields", "name");
-
-		QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void testHyphenIsAllowedInResourceName() {
-
-		QuerySpec expectedSpec = new QuerySpec(Task.class);
-		expectedSpec.addSort(new SortSpec(Arrays.asList("id"), Direction.ASC));
-
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "sort[task-with-lookup]", "id");
-
-		ResourceInformation taskWithLookUpInformation =
-				resourceRegistry.getEntry(TaskWithLookup.class).getResourceInformation();
-		QuerySpec actualSpec = urlMapper.deserialize(taskWithLookUpInformation, params);
-		Assert.assertEquals(expectedSpec, actualSpec);
-	}
-
-	@Test
-	public void testIngoreParseException() {
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[id]", "NotAnId");
-		urlMapper.setIgnoreParseExceptions(true);
-		QuerySpec querySpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(Task.class, querySpec.getResourceClass());
-		Assert.assertEquals(Arrays.asList("id"), querySpec.getFilters().get(0).getAttributePath());
-		Assert.assertEquals("NotAnId", querySpec.getFilters().get(0).getValue());
-		Assert.assertNull(querySpec.getQuerySpec(Project.class));
-	}
-
-	@Test
-	public void testGenericCast() {
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[id]", "12");
-		add(params, "filter[name]", "test");
-		add(params, "filter[completed]", "true");
-		urlMapper.setIgnoreParseExceptions(false);
-		QuerySpec querySpec = urlMapper.deserialize(taskInformation, params);
-		Assert.assertEquals(Task.class, querySpec.getResourceClass());
-		Assert.assertEquals(Arrays.asList("id"), querySpec.getFilters().get(2).getAttributePath());
-		Long id = querySpec.getFilters().get(2).getValue();
-		Assert.assertEquals(Long.valueOf(12), id);
-		String name = querySpec.getFilters().get(0).getValue();
-		Assert.assertEquals("test", name);
-		Boolean completed = querySpec.getFilters().get(1).getValue();
-		Assert.assertEquals(Boolean.TRUE, completed);
-		Assert.assertNull(querySpec.getQuerySpec(Project.class));
-	}
-
-	@Test(expected = ParametersDeserializationException.class)
-	public void testFailOnParseException() {
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "filter[id]", "NotAnId");
-		urlMapper.setIgnoreParseExceptions(false);
-		urlMapper.deserialize(taskInformation, params);
-	}
-
-	@Test(expected = ParametersDeserializationException.class)
-	public void testUnknownProperty() {
-		Map<String, Set<String>> params = new HashMap<>();
-		add(params, "group", "test");
-		urlMapper.setIgnoreParseExceptions(false);
-		urlMapper.deserialize(taskInformation, params);
-	}
-
-	protected void add(Map<String, Set<String>> params, String key, String... value) {
-		params.put(key, new HashSet<>(Arrays.asList(value)));
-	}
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    protected DefaultQuerySpecUrlMapper urlMapper;
+
+    protected ResourceInformation taskInformation;
+
+    private ResourceInformation taskWithPagingBehaviorInformation;
+
+    private QuerySpecUrlContext deserializerContext;
+
+    @Before
+    public void setup() {
+        super.setup();
+
+        deserializerContext = new QuerySpecUrlContext() {
+
+            @Override
+            public ResourceRegistry getResourceRegistry() {
+                return resourceRegistry;
+            }
+
+            @Override
+            public TypeParser getTypeParser() {
+                return moduleRegistry.getTypeParser();
+            }
+
+            @Override
+            public ObjectMapper getObjectMapper() {
+                return container.getObjectMapper();
+            }
+        };
+
+        urlMapper = new DefaultQuerySpecUrlMapper();
+        urlMapper.init(deserializerContext);
+
+        RegistryEntry taskEntry = resourceRegistry.getEntry(Task.class);
+        taskInformation = taskEntry.getResourceInformation();
+        taskWithPagingBehaviorInformation = resourceRegistry.getEntry(TaskWithPagingBehavior.class).getResourceInformation();
+    }
+
+
+    @Override
+    protected void setup(CoreTestContainer container) {
+        container.addModule(new CoreTestModule());
+
+        SimpleModule customPagingModule = new SimpleModule("customPaging");
+        customPagingModule.addRepository(new TaskWithPagingBehaviorRepository());
+        customPagingModule.addRepository(new TaskWithPagingBehaviorToProjectRepository());
+        customPagingModule.addPagingBehavior(new OffsetLimitPagingBehavior());
+        customPagingModule.addPagingBehavior(new CustomOffsetLimitPagingBehavior());
+        container.addModule(customPagingModule);
+    }
+
+    @Test
+    public void operations() {
+        Assert.assertFalse(urlMapper.getAllowUnknownAttributes());
+        urlMapper.setAllowUnknownAttributes(true);
+        Assert.assertTrue(urlMapper.getAllowUnknownAttributes());
+        urlMapper.getSupportedOperators().clear();
+        urlMapper.setDefaultOperator(FilterOperator.LIKE);
+        urlMapper.addSupportedOperator(FilterOperator.LIKE);
+        Assert.assertEquals(FilterOperator.LIKE, urlMapper.getDefaultOperator());
+        Assert.assertEquals(1, urlMapper.getSupportedOperators().size());
+    }
+
+    @Test
+    public void checkIgnoreParseExceptions() {
+        Assert.assertFalse(urlMapper.isIgnoreParseExceptions());
+        urlMapper.setIgnoreParseExceptions(true);
+        Assert.assertTrue(urlMapper.isIgnoreParseExceptions());
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[id]", "notAnInteger");
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(new FilterSpec(Arrays.asList("id"), FilterOperator.EQ, "notAnInteger"));
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test(expected = ParametersDeserializationException.class)
+    public void throwParseExceptionsByDefault() {
+        Assert.assertFalse(urlMapper.isIgnoreParseExceptions());
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[id]", "notAnInteger");
+        urlMapper.deserialize(taskInformation, params, queryContext);
+    }
+
+    @Test(expected = ParametersDeserializationException.class)
+    public void throwParseExceptionsForMultiValuedOffset() {
+        Map<String, Set<String>> params = new HashMap<>();
+        params.put("page[offset]", new HashSet<>(Arrays.asList("1", "2")));
+        urlMapper.deserialize(taskInformation, params, queryContext);
+    }
+
+    @Test(expected = ParametersDeserializationException.class)
+    public void throwParseExceptionsWhenBracketsNotClosed() {
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[", "someValue");
+        urlMapper.deserialize(taskInformation, params, queryContext);
+    }
+
+    @Test
+    public void testFindAll() {
+        Map<String, Set<String>> params = new HashMap<>();
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void defaultPaginationOnRoot() {
+        Map<String, Set<String>> params = new HashMap<>();
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(0L, actualSpec.getOffset());
+        Assert.assertNull(actualSpec.getLimit());
+    }
+
+    @Test
+    public void defaultPaginationOnRelation() {
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "sort[projects]", "name");
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(0L, actualSpec.getOffset());
+        Assert.assertNull(actualSpec.getLimit());
+        QuerySpec projectQuerySpec = actualSpec.getQuerySpec(Project.class);
+        Assert.assertNotNull(projectQuerySpec);
+        Assert.assertEquals(0L, projectQuerySpec.getOffset());
+        Assert.assertNull(projectQuerySpec.getLimit());
+
+        Map<String, Set<String>> serialized = urlMapper.serialize(actualSpec, queryContext);
+        Assert.assertEquals(serialized, params);
+    }
+
+    @Test
+    public void mapJsonToJavaNames() {
+        ResourceInformation scheduleInformation = resourceRegistry.getEntry(Schedule.class).getResourceInformation();
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "sort", "description");
+        add(params, "filter[description]", "test");
+        add(params, "fields", "description");
+        add(params, "include", "followup");
+        QuerySpec actualSpec = urlMapper.deserialize(scheduleInformation, params, queryContext);
+
+        Assert.assertEquals(1, actualSpec.getSort().size());
+        Assert.assertEquals(1, actualSpec.getFilters().size());
+        Assert.assertEquals(1, actualSpec.getIncludedFields().size());
+        Assert.assertEquals(1, actualSpec.getIncludedRelations().size());
+
+        SortSpec sortSpec = actualSpec.getSort().get(0);
+        FilterSpec filterSpec = actualSpec.getFilters().get(0);
+        IncludeRelationSpec includeRelationSpec = actualSpec.getIncludedRelations().get(0);
+        IncludeFieldSpec includeFieldSpec = actualSpec.getIncludedFields().get(0);
+
+        Assert.assertEquals(Arrays.asList("desc"), sortSpec.getAttributePath());
+        Assert.assertEquals(Arrays.asList("desc"), filterSpec.getAttributePath());
+        Assert.assertEquals(Arrays.asList("followupProject"), includeRelationSpec.getAttributePath());
+        Assert.assertEquals(Arrays.asList("desc"), includeFieldSpec.getAttributePath());
+    }
+
+    @Test
+    public void customPaginationOnRoot() {
+        Map<String, Set<String>> params = new HashMap<>();
+        QuerySpec actualSpec = urlMapper.deserialize(taskWithPagingBehaviorInformation, params, queryContext);
+        Assert.assertEquals(1L, actualSpec.getOffset());
+        Assert.assertEquals(10L, actualSpec.getLimit().longValue());
+    }
+
+    @Test
+    public void customPaginationOnRelation() {
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "sort[projects]", "name");
+        QuerySpec actualSpec = urlMapper.deserialize(taskWithPagingBehaviorInformation, params, queryContext);
+        Assert.assertEquals(1L, actualSpec.getOffset());
+        Assert.assertEquals(10L, actualSpec.getLimit().longValue());
+        QuerySpec projectQuerySpec = actualSpec.getQuerySpec(Project.class);
+        Assert.assertNotNull(projectQuerySpec);
+        Assert.assertEquals(0L, projectQuerySpec.getOffset());
+        Assert.assertNull(projectQuerySpec.getLimit());
+    }
+
+    @Test
+    public void testFindAllOrderByAsc() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addSort(new SortSpec(Arrays.asList("name"), Direction.ASC));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "sort", "name");
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+
+        Map<String, Set<String>> serialized = urlMapper.serialize(actualSpec, queryContext);
+        Assert.assertEquals(serialized, params);
+    }
+
+    @Test
+    public void testFollowNestedObjectWithinResource() {
+        // follow ProjectData.data
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addSort(new SortSpec(Arrays.asList("data", "data"), Direction.ASC));
+
+        ResourceInformation projectInformation = resourceRegistry.getEntry(Project.class).getResourceInformation();
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "sort", "data.data");
+        QuerySpec actualSpec = urlMapper.deserialize(projectInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+
+        Map<String, Set<String>> serialized = urlMapper.serialize(actualSpec, queryContext);
+        Assert.assertEquals(new HashSet(Arrays.asList("data.data")), serialized.get("sort"));
+    }
+
+    @Test
+    public void testOrderByMultipleAttributes() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addSort(new SortSpec(Arrays.asList("name"), Direction.ASC));
+        expectedSpec.addSort(new SortSpec(Arrays.asList("id"), Direction.ASC));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "sort", "name,id");
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+
+        Map<String, Set<String>> serialized = urlMapper.serialize(actualSpec, queryContext);
+        Assert.assertEquals(serialized, params);
+    }
+
+    @Test
+    public void testFindAllOrderByDesc() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addSort(new SortSpec(Arrays.asList("name"), Direction.DESC));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "sort", "-name");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+
+        Map<String, Set<String>> serialized = urlMapper.serialize(actualSpec, queryContext);
+        Assert.assertEquals(serialized, params);
+    }
+
+    @Test
+    public void testFilterWithDefaultOp() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(new FilterSpec(Arrays.asList("name"), FilterOperator.EQ, "value"));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[tasks][name]", "value");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void testFilterWithPrettyJson() {
+        String expectedJson = "{ \"OR\": [ {\"id\": [12, 13, 14]}, {\"completed\": true} ] }";
+        QuerySpec jsonSpec = new QuerySpec(Task.class);
+        jsonSpec.addFilter(new FilterSpec(expectedJson));
+
+        Map<String, Set<String>> expectedParams = new HashMap<>();
+        add(expectedParams, "filter", "{\"OR\":[{\"id\":[12,13,14]},{\"completed\":true}]}");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, expectedParams, queryContext);
+
+        FilterSpec idFilterSpec = PathSpec.of("id").filter(FilterOperator.EQ, Arrays.asList(12L, 13L, 14L));
+        FilterSpec completedFilterSpec = PathSpec.of("completed").filter(FilterOperator.EQ, true);
+        QuerySpec expectedQuerySpec = new QuerySpec(Task.class);
+        expectedQuerySpec.addFilter(FilterSpec.or(idFilterSpec, completedFilterSpec));
+        Assert.assertEquals(expectedQuerySpec.getFilters(), actualSpec.getFilters());
+        Assert.assertEquals(expectedQuerySpec, actualSpec);
+
+        Map<String, Set<String>> actualParams = urlMapper.serialize(actualSpec, queryContext);
+        Assert.assertEquals(expectedParams, actualParams);
+    }
+
+    @Test
+    public void testFilterSpecJsonWithDefaultOperator() {
+        String expectedJson = "[{ \"path\": \"completed\", \"value\": true }]";
+        QuerySpec jsonSpec = new QuerySpec(Task.class);
+        jsonSpec.addFilter(new FilterSpec(expectedJson));
+
+        Map<String, Set<String>> expectedParams = new HashMap<>();
+        add(expectedParams, "filter", expectedJson);
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, expectedParams, queryContext);
+        FilterSpec actualFilter = actualSpec.getFilters().get(0);
+        Assert.assertEquals(PathSpec.of("completed"), actualFilter.getPath());
+        Assert.assertEquals(FilterOperator.EQ, actualFilter.getOperator());
+        Assert.assertEquals(Boolean.TRUE, actualFilter.getValue());
+    }
+
+    @Test
+    public void testFilterSpecJsonWithOperator() {
+        String expectedJson = "[{ \"path\": \"completed\", \"operator\": \"NEQ\", \"value\": true }]";
+        QuerySpec jsonSpec = new QuerySpec(Task.class);
+        jsonSpec.addFilter(new FilterSpec(expectedJson));
+
+        Map<String, Set<String>> expectedParams = new HashMap<>();
+        add(expectedParams, "filter", expectedJson);
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, expectedParams, queryContext);
+        FilterSpec actualFilter = actualSpec.getFilters().get(0);
+        Assert.assertEquals(PathSpec.of("completed"), actualFilter.getPath());
+        Assert.assertEquals(FilterOperator.NEQ, actualFilter.getOperator());
+        Assert.assertEquals(Boolean.TRUE, actualFilter.getValue());
+    }
+
+    @Test
+    public void testFilterSpecJsonWithNestedFilters() {
+        String expectedJson = "[{ \"operator\": \"OR\", \"expression\": [{ \"path\": \"completed\", \"operator\": \"NEQ\", \"value\": true }] }]";
+        QuerySpec jsonSpec = new QuerySpec(Task.class);
+        jsonSpec.addFilter(new FilterSpec(expectedJson));
+
+        Map<String, Set<String>> expectedParams = new HashMap<>();
+        add(expectedParams, "filter", expectedJson);
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, expectedParams, queryContext);
+        FilterSpec actualFilter = actualSpec.getFilters().get(0);
+        Assert.assertEquals(FilterOperator.OR, actualFilter.getOperator());
+
+        Assert.assertEquals(1, actualFilter.getExpression().size());
+        FilterSpec nestedFilter = actualFilter.getExpression().get(0);
+        Assert.assertEquals(PathSpec.of("completed"), nestedFilter.getPath());
+        Assert.assertEquals(FilterOperator.NEQ, nestedFilter.getOperator());
+        Assert.assertEquals(Boolean.TRUE, nestedFilter.getValue());
+    }
+
+    @Test
+    public void testFilterOnRelatedWithJson() {
+        Map<String, Set<String>> expectedParams = new HashMap<>();
+        add(expectedParams, "filter[projects]", "{\"OR\":[{\"id\":[12,13,14]},{\"name\":\"Test\"}]}");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, expectedParams, queryContext);
+        Assert.assertTrue("must filter on related", actualSpec.getFilters().isEmpty());
+        QuerySpec actualRelatedSpec = actualSpec.getQuerySpec(Project.class);
+        Assert.assertNotNull(actualRelatedSpec);
+
+        FilterSpec idFilterSpec = PathSpec.of("id").filter(FilterOperator.EQ, Arrays.asList(12L, 13L, 14L));
+        FilterSpec nameFilterSpec = PathSpec.of("name").filter(FilterOperator.EQ, "Test");
+        QuerySpec expectedRelatedQuerySpec = new QuerySpec(Project.class);
+        expectedRelatedQuerySpec.addFilter(FilterSpec.or(idFilterSpec, nameFilterSpec));
+        QuerySpec expectedQuerySpec = new QuerySpec(Task.class);
+        expectedQuerySpec.putRelatedSpec(Project.class, expectedRelatedQuerySpec);
+
+        Assert.assertEquals(expectedQuerySpec.getFilters(), actualSpec.getFilters());
+        Assert.assertEquals(expectedRelatedQuerySpec.getFilters(), actualRelatedSpec.getFilters());
+        Assert.assertEquals(expectedRelatedQuerySpec, actualRelatedSpec);
+
+        Map<String, Set<String>> actualParams = urlMapper.serialize(actualSpec, queryContext);
+        Assert.assertEquals(expectedParams, actualParams);
+    }
+
+    @Test
+    public void testFilterByNull() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(new FilterSpec(Arrays.asList("name"), FilterOperator.EQ, null));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[name]", "null");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void testFilterWithComputedAttribute() {
+        // if computeAttribte is not found, module order is wrong
+        // tests setup with information builder must be hardened
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(new FilterSpec(Arrays.asList("computedAttribute"), FilterOperator.EQ, 13));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[tasks][computedAttribute]", "13");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void testFilterWithDotNotation() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(new FilterSpec(Arrays.asList("project", "name"), FilterOperator.EQ, "value"));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[project.name]", "value");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+
+        Map<String, Set<String>> serialized = urlMapper.serialize(actualSpec, queryContext);
+        Assert.assertEquals(new HashSet(Arrays.asList("value")), serialized.get("filter[project.name]"));
+    }
+
+    @Test
+    public void testFilterWithCommaSeparation() {
+        Assert.assertTrue(urlMapper.getAllowCommaSeparatedValue());
+        HashSet<String> values = new HashSet<>();
+        values.add("john");
+        values.add("jane");
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(new FilterSpec(Arrays.asList("name"), FilterOperator.EQ, values));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[name]", "john,jane");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec.getFilters(), actualSpec.getFilters());
+    }
+
+    @Test
+    public void testFilterWithoutCommaSeparation() {
+        urlMapper.setAllowCommaSeparatedValue(false);
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(new FilterSpec(Arrays.asList("name"), FilterOperator.EQ, "john,jane"));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[name]", "john,jane");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec.getFilters(), actualSpec.getFilters());
+    }
+
+    @Test
+    public void testFilterWithDotNotationMultipleElements() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(new FilterSpec(Arrays.asList("project", "task", "name"), FilterOperator.EQ, "value"));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[project.task.name]", "value");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+
+        Assert.assertEquals(expectedSpec, actualSpec);
+
+        Map<String, Set<String>> serialized = urlMapper.serialize(actualSpec, queryContext);
+        Assert.assertEquals(new HashSet(Arrays.asList("value")), serialized.get("filter[project.task.name]"));
+    }
+
+    @Test
+    public void testUnknownPropertyAllowed() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(new FilterSpec(Arrays.asList("doesNotExists"), FilterOperator.EQ, "value"));
+
+        urlMapper.setAllowUnknownAttributes(true);
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[tasks][doesNotExists]", "value");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testUnknownPropertyNotAllowed() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(new FilterSpec(Arrays.asList("doesNotExists"), FilterOperator.EQ, "value"));
+
+        urlMapper.setAllowUnknownAttributes(false);
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[tasks][doesNotExists]", "value");
+
+        urlMapper.deserialize(taskInformation, params, queryContext);
+    }
+
+    @Test
+    public void testUnknownParameterAllowed() {
+        urlMapper.setAllowUnknownParameters(true);
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "doesNotExists[tasks]", "value");
+
+        Assert.assertNotNull(urlMapper.deserialize(taskInformation, params, queryContext));
+    }
+
+    @Test(expected = ParametersDeserializationException.class)
+    public void testUnknownParameterNotAllowed() {
+        urlMapper.setAllowUnknownParameters(false);
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "doesNotExists[tasks]", "value");
+
+        urlMapper.deserialize(taskInformation, params, queryContext);
+    }
+
+    @Test
+    public void testFilterByOne() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(new FilterSpec(Arrays.asList("name"), FilterOperator.EQ, "value"));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[tasks][name][EQ]", "value");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void testFilterByMany() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(
+                new FilterSpec(Arrays.asList("name"), FilterOperator.EQ, new HashSet<>(Arrays.asList("value1", "value2"))));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        params.put("filter[tasks][name][EQ]", new HashSet<>(Arrays.asList("value1", "value2")));
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void testFilterEquals() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(new FilterSpec(Arrays.asList("id"), FilterOperator.EQ, 1L));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[tasks][id][EQ]", "1");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void testFilterGreater() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(new FilterSpec(Arrays.asList("id"), FilterOperator.LE, 1L));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[tasks][id][LE]", "1");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void testFilterGreaterOnRoot() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addFilter(new FilterSpec(Arrays.asList("id"), FilterOperator.LE, 1L));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[id][LE]", "1");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void testPaging() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.setPaging(new OffsetLimitPagingSpec(1L, 2L));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "page[offset]", "1");
+        add(params, "page[limit]", "2");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void deserializeUnknownParameter() {
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "doesNotExist[something]", "someValue");
+
+        final boolean[] deserialized = new boolean[1];
+        urlMapper = new DefaultQuerySpecUrlMapper() {
+
+            @Override
+            protected void deserializeUnknown(final QuerySpec querySpec, final QueryParameter parameter) {
+                Assert.assertEquals(QueryParameterType.UNKNOWN, parameter.getType());
+                Assert.assertEquals("doesNotExist[something]", parameter.getName());
+                Assert.assertNull(parameter.getResourceInformation());
+                Assert.assertEquals(FilterOperator.EQ, parameter.getOperator());
+                Assert.assertNull(parameter.getAttributePath());
+                Assert.assertEquals(1, parameter.getValues().size());
+                deserialized[0] = true;
+            }
+        };
+        urlMapper.init(deserializerContext);
+        urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertTrue(deserialized[0]);
+    }
+
+
+    @Test(expected = ParametersDeserializationException.class)
+    public void testInvalidPagingType() {
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "page[doesNotExist]", "1");
+        urlMapper.deserialize(taskInformation, params, queryContext);
+    }
+
+    @Test(expected = ParametersDeserializationException.class)
+    public void testPagingError() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.setLimit(2L);
+        expectedSpec.setOffset(1L);
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "page[offset]", "notANumber");
+        add(params, "page[limit]", "2");
+
+        urlMapper.deserialize(taskInformation, params, queryContext);
+    }
+
+    @Test
+    public void testPagingMaxLimitNotAllowed() {
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "page[offset]", "1");
+        add(params, "page[limit]", "30");
+
+        expectedException.expect(BadRequestException.class);
+
+        urlMapper.deserialize(taskWithPagingBehaviorInformation, params, queryContext);
+    }
+
+    @Test
+    public void testPagingMaxLimitAllowed() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.setOffset(1L);
+        expectedSpec.setLimit(5L);
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "page[offset]", "1");
+        add(params, "page[limit]", "5");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void testIncludeRelations() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.includeRelation(Arrays.asList("project"));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "include[tasks]", "project");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void testIncludeRelationsOnRoot() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.includeRelation(Arrays.asList("project"));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "include", "project");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void testIncludeAttributes() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.includeField(Arrays.asList("name"));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "fields[tasks]", "name");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void testIncludeAttributesOnRoot() {
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.includeField(Arrays.asList("name"));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "fields", "name");
+
+        QuerySpec actualSpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void testHyphenIsAllowedInResourceName() {
+
+        QuerySpec expectedSpec = new QuerySpec(Task.class);
+        expectedSpec.addSort(new SortSpec(Arrays.asList("id"), Direction.ASC));
+
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "sort[task-with-lookup]", "id");
+
+        ResourceInformation taskWithLookUpInformation =
+                resourceRegistry.getEntry(TaskWithLookup.class).getResourceInformation();
+        QuerySpec actualSpec = urlMapper.deserialize(taskWithLookUpInformation, params, queryContext);
+        Assert.assertEquals(expectedSpec, actualSpec);
+    }
+
+    @Test
+    public void testIngoreParseException() {
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[id]", "NotAnId");
+        urlMapper.setIgnoreParseExceptions(true);
+        QuerySpec querySpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(Task.class, querySpec.getResourceClass());
+        Assert.assertEquals(Arrays.asList("id"), querySpec.getFilters().get(0).getAttributePath());
+        Assert.assertEquals("NotAnId", querySpec.getFilters().get(0).getValue());
+        Assert.assertNull(querySpec.getQuerySpec(Project.class));
+    }
+
+    @Test
+    public void testGenericCast() {
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[id]", "12");
+        add(params, "filter[name]", "test");
+        add(params, "filter[completed]", "true");
+        urlMapper.setIgnoreParseExceptions(false);
+        QuerySpec querySpec = urlMapper.deserialize(taskInformation, params, queryContext);
+        Assert.assertEquals(Task.class, querySpec.getResourceClass());
+        Assert.assertEquals(Arrays.asList("id"), querySpec.getFilters().get(2).getAttributePath());
+        Long id = querySpec.getFilters().get(2).getValue();
+        Assert.assertEquals(Long.valueOf(12), id);
+        String name = querySpec.getFilters().get(0).getValue();
+        Assert.assertEquals("test", name);
+        Boolean completed = querySpec.getFilters().get(1).getValue();
+        Assert.assertEquals(Boolean.TRUE, completed);
+        Assert.assertNull(querySpec.getQuerySpec(Project.class));
+    }
+
+    @Test(expected = ParametersDeserializationException.class)
+    public void testFailOnParseException() {
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "filter[id]", "NotAnId");
+        urlMapper.setIgnoreParseExceptions(false);
+        urlMapper.deserialize(taskInformation, params, queryContext);
+    }
+
+    @Test(expected = ParametersDeserializationException.class)
+    public void testUnknownProperty() {
+        Map<String, Set<String>> params = new HashMap<>();
+        add(params, "group", "test");
+        urlMapper.setIgnoreParseExceptions(false);
+        urlMapper.deserialize(taskInformation, params, queryContext);
+    }
+
+    protected void add(Map<String, Set<String>> params, String key, String... value) {
+        params.put(key, new HashSet<>(Arrays.asList(value)));
+    }
 }

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/JsonFilterSpecMapperTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/JsonFilterSpecMapperTest.java
@@ -1,16 +1,12 @@
 package io.crnk.core.queryspec.mapper;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.crnk.core.CoreTestContainer;
 import io.crnk.core.CoreTestModule;
 import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.mock.models.Task;
 import io.crnk.core.queryspec.FilterOperator;
 import io.crnk.core.queryspec.FilterSpec;
@@ -22,219 +18,226 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
 public class JsonFilterSpecMapperTest {
 
-	private ResourceInformation resourceInformation;
+    private ResourceInformation resourceInformation;
 
-	private JsonFilterSpecMapper mapper;
+    private JsonFilterSpecMapper mapper;
 
-	private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper;
 
-	@Before
-	public void setup() {
-		CoreTestContainer container = new CoreTestContainer();
-		container.addModule(new CoreTestModule());
-		container.boot();
+    private QueryContext queryContext = new QueryContext().setRequestVersion(0);
 
-		QueryPathResolver pathResolver = new DefaultQueryPathResolver();
+    @Before
+    public void setup() {
+        CoreTestContainer container = new CoreTestContainer();
+        container.addModule(new CoreTestModule());
+        container.boot();
 
-		resourceInformation = container.getEntry(Task.class).getResourceInformation();
+        QueryPathResolver pathResolver = new DefaultQueryPathResolver();
 
-		HashMap<String, FilterOperator> supportedOperators = new HashMap<>();
-		supportedOperators.put("GE", FilterOperator.GE);
-		supportedOperators.put("LE", FilterOperator.LE);
-		supportedOperators.put("EQ", FilterOperator.EQ);
-		supportedOperators.put("AND", FilterOperator.AND);
-		supportedOperators.put("OR", FilterOperator.OR);
-		supportedOperators.put("NOT", FilterOperator.NOT);
-		supportedOperators.put("NEQ", FilterOperator.NEQ);
+        resourceInformation = container.getEntry(Task.class).getResourceInformation();
 
-		QuerySpecUrlContext urlContext = Mockito.mock(QuerySpecUrlContext.class);
-		Mockito.when(urlContext.getObjectMapper()).thenReturn(container.getObjectMapper());
-		Mockito.when(urlContext.getResourceRegistry()).thenReturn(container.getResourceRegistry());
+        HashMap<String, FilterOperator> supportedOperators = new HashMap<>();
+        supportedOperators.put("GE", FilterOperator.GE);
+        supportedOperators.put("LE", FilterOperator.LE);
+        supportedOperators.put("EQ", FilterOperator.EQ);
+        supportedOperators.put("AND", FilterOperator.AND);
+        supportedOperators.put("OR", FilterOperator.OR);
+        supportedOperators.put("NOT", FilterOperator.NOT);
+        supportedOperators.put("NEQ", FilterOperator.NEQ);
 
-		pathResolver.init(urlContext);
+        QuerySpecUrlContext urlContext = Mockito.mock(QuerySpecUrlContext.class);
+        Mockito.when(urlContext.getObjectMapper()).thenReturn(container.getObjectMapper());
+        Mockito.when(urlContext.getResourceRegistry()).thenReturn(container.getResourceRegistry());
 
-		objectMapper = container.getObjectMapper();
-		mapper = new JsonFilterSpecMapper(urlContext, supportedOperators, FilterOperator.EQ, pathResolver);
-	}
+        pathResolver.init(urlContext);
 
-	@Test
-	public void filterByString() throws IOException {
-		JsonNode jsonNode = objectMapper.readTree("{\"name\": \"test\"}");
-		List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation);
-		Assert.assertEquals(1, filterSpecs.size());
-		FilterSpec filterSpec = filterSpecs.get(0);
-		Assert.assertEquals(PathSpec.of("name"), filterSpec.getPath());
-		Assert.assertEquals(FilterOperator.EQ, filterSpec.getOperator());
-		Assert.assertEquals("test", filterSpec.getValue());
+        objectMapper = container.getObjectMapper();
+        mapper = new JsonFilterSpecMapper(urlContext, supportedOperators, FilterOperator.EQ, pathResolver);
+    }
 
-		JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
-		checkNodeEquals(jsonNode, serializedJsonNode);
-		Assert.assertFalse(mapper.isNested(filterSpecs));
-	}
+    @Test
+    public void filterByString() throws IOException {
+        JsonNode jsonNode = objectMapper.readTree("{\"name\": \"test\"}");
+        List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation, queryContext);
+        Assert.assertEquals(1, filterSpecs.size());
+        FilterSpec filterSpec = filterSpecs.get(0);
+        Assert.assertEquals(PathSpec.of("name"), filterSpec.getPath());
+        Assert.assertEquals(FilterOperator.EQ, filterSpec.getOperator());
+        Assert.assertEquals("test", filterSpec.getValue());
 
-	@Test
-	public void filterByBoolean() throws IOException {
-		JsonNode jsonNode = objectMapper.readTree("{\"completed\": true}");
-		List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation);
-		Assert.assertEquals(1, filterSpecs.size());
-		FilterSpec filterSpec = filterSpecs.get(0);
-		Assert.assertEquals(PathSpec.of("completed"), filterSpec.getPath());
-		Assert.assertEquals(FilterOperator.EQ, filterSpec.getOperator());
-		Assert.assertEquals(Boolean.TRUE, filterSpec.getValue());
+        JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
+        checkNodeEquals(jsonNode, serializedJsonNode);
+        Assert.assertFalse(mapper.isNested(filterSpecs));
+    }
 
-		JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
-		checkNodeEquals(jsonNode, serializedJsonNode);
-		Assert.assertFalse(mapper.isNested(filterSpecs));
-		Assert.assertFalse(mapper.isNested(filterSpecs));
-	}
+    @Test
+    public void filterByBoolean() throws IOException {
+        JsonNode jsonNode = objectMapper.readTree("{\"completed\": true}");
+        List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation, queryContext);
+        Assert.assertEquals(1, filterSpecs.size());
+        FilterSpec filterSpec = filterSpecs.get(0);
+        Assert.assertEquals(PathSpec.of("completed"), filterSpec.getPath());
+        Assert.assertEquals(FilterOperator.EQ, filterSpec.getOperator());
+        Assert.assertEquals(Boolean.TRUE, filterSpec.getValue());
 
-	@Test
-	public void filterByLong() throws IOException {
-		JsonNode jsonNode = objectMapper.readTree("{\"id\": 12}");
-		List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation);
-		Assert.assertEquals(1, filterSpecs.size());
-		FilterSpec filterSpec = filterSpecs.get(0);
-		Assert.assertEquals(PathSpec.of("id"), filterSpec.getPath());
-		Assert.assertEquals(FilterOperator.EQ, filterSpec.getOperator());
-		Assert.assertEquals((Long) 12L, filterSpec.getValue());
+        JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
+        checkNodeEquals(jsonNode, serializedJsonNode);
+        Assert.assertFalse(mapper.isNested(filterSpecs));
+        Assert.assertFalse(mapper.isNested(filterSpecs));
+    }
 
-		JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
-		checkNodeEquals(jsonNode, serializedJsonNode);
-		Assert.assertFalse(mapper.isNested(filterSpecs));
-	}
+    @Test
+    public void filterByLong() throws IOException {
+        JsonNode jsonNode = objectMapper.readTree("{\"id\": 12}");
+        List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation, queryContext);
+        Assert.assertEquals(1, filterSpecs.size());
+        FilterSpec filterSpec = filterSpecs.get(0);
+        Assert.assertEquals(PathSpec.of("id"), filterSpec.getPath());
+        Assert.assertEquals(FilterOperator.EQ, filterSpec.getOperator());
+        Assert.assertEquals((Long) 12L, filterSpec.getValue());
 
-	@Test
-	public void filterByLongArray() throws IOException {
-		JsonNode jsonNode = objectMapper.readTree("{\"id\": [12, 13, 14]}");
-		List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation);
-		Assert.assertEquals(1, filterSpecs.size());
-		FilterSpec filterSpec = filterSpecs.get(0);
-		Assert.assertEquals(PathSpec.of("id"), filterSpec.getPath());
-		Assert.assertEquals(FilterOperator.EQ, filterSpec.getOperator());
-		Assert.assertEquals(Arrays.asList(12L, 13L, 14L), filterSpec.getValue());
+        JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
+        checkNodeEquals(jsonNode, serializedJsonNode);
+        Assert.assertFalse(mapper.isNested(filterSpecs));
+    }
 
-		JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
-		checkNodeEquals(jsonNode, serializedJsonNode);
-		Assert.assertFalse(mapper.isNested(filterSpecs));
-	}
+    @Test
+    public void filterByLongArray() throws IOException {
+        JsonNode jsonNode = objectMapper.readTree("{\"id\": [12, 13, 14]}");
+        List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation, queryContext);
+        Assert.assertEquals(1, filterSpecs.size());
+        FilterSpec filterSpec = filterSpecs.get(0);
+        Assert.assertEquals(PathSpec.of("id"), filterSpec.getPath());
+        Assert.assertEquals(FilterOperator.EQ, filterSpec.getOperator());
+        Assert.assertEquals(Arrays.asList(12L, 13L, 14L), filterSpec.getValue());
 
-	@Test
-	public void filterNotEquals() throws IOException {
-		JsonNode jsonNode = objectMapper.readTree("{\"NEQ\": {\"id\": [12, 13, 14]}}");
-		List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation);
-		Assert.assertEquals(1, filterSpecs.size());
-		FilterSpec filterSpec = filterSpecs.get(0);
-		Assert.assertEquals(PathSpec.of("id"), filterSpec.getPath());
-		Assert.assertEquals(FilterOperator.NEQ, filterSpec.getOperator());
-		Assert.assertEquals(Arrays.asList(12L, 13L, 14L), filterSpec.getValue());
+        JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
+        checkNodeEquals(jsonNode, serializedJsonNode);
+        Assert.assertFalse(mapper.isNested(filterSpecs));
+    }
 
-		JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
-		checkNodeEquals(jsonNode, serializedJsonNode);
-		Assert.assertFalse(mapper.isNested(filterSpecs));
-	}
+    @Test
+    public void filterNotEquals() throws IOException {
+        JsonNode jsonNode = objectMapper.readTree("{\"NEQ\": {\"id\": [12, 13, 14]}}");
+        List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation, queryContext);
+        Assert.assertEquals(1, filterSpecs.size());
+        FilterSpec filterSpec = filterSpecs.get(0);
+        Assert.assertEquals(PathSpec.of("id"), filterSpec.getPath());
+        Assert.assertEquals(FilterOperator.NEQ, filterSpec.getOperator());
+        Assert.assertEquals(Arrays.asList(12L, 13L, 14L), filterSpec.getValue());
 
-	@Test
-	public void filterNEQ() throws IOException {
-		JsonNode jsonNode = objectMapper.readTree("{\"NEQ\": {\"id\": [12, 13, 14]}}");
-		List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation);
-		Assert.assertEquals(1, filterSpecs.size());
-		FilterSpec filterSpec = filterSpecs.get(0);
-		Assert.assertEquals(PathSpec.of("id"), filterSpec.getPath());
-		Assert.assertEquals(FilterOperator.NEQ, filterSpec.getOperator());
-		Assert.assertEquals(Arrays.asList(12L, 13L, 14L), filterSpec.getValue());
+        JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
+        checkNodeEquals(jsonNode, serializedJsonNode);
+        Assert.assertFalse(mapper.isNested(filterSpecs));
+    }
 
-		JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
-		checkNodeEquals(jsonNode, serializedJsonNode);
-		Assert.assertFalse(mapper.isNested(filterSpecs));
-	}
+    @Test
+    public void filterNEQ() throws IOException {
+        JsonNode jsonNode = objectMapper.readTree("{\"NEQ\": {\"id\": [12, 13, 14]}}");
+        List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation, queryContext);
+        Assert.assertEquals(1, filterSpecs.size());
+        FilterSpec filterSpec = filterSpecs.get(0);
+        Assert.assertEquals(PathSpec.of("id"), filterSpec.getPath());
+        Assert.assertEquals(FilterOperator.NEQ, filterSpec.getOperator());
+        Assert.assertEquals(Arrays.asList(12L, 13L, 14L), filterSpec.getValue());
+
+        JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
+        checkNodeEquals(jsonNode, serializedJsonNode);
+        Assert.assertFalse(mapper.isNested(filterSpecs));
+    }
 
 
-	@Test
-	public void filterOr() throws IOException {
-		JsonNode jsonNode = objectMapper.readTree("{ \"OR\": [ {\"id\": [12, 13, 14]}, {\"completed\": true} ] }");
-		List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation);
-		Assert.assertEquals(1, filterSpecs.size());
-		FilterSpec andFilter = filterSpecs.get(0);
-		Assert.assertEquals(FilterOperator.OR, andFilter.getOperator());
-		Assert.assertEquals(2, andFilter.getExpression().size());
+    @Test
+    public void filterOr() throws IOException {
+        JsonNode jsonNode = objectMapper.readTree("{ \"OR\": [ {\"id\": [12, 13, 14]}, {\"completed\": true} ] }");
+        List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation, queryContext);
+        Assert.assertEquals(1, filterSpecs.size());
+        FilterSpec andFilter = filterSpecs.get(0);
+        Assert.assertEquals(FilterOperator.OR, andFilter.getOperator());
+        Assert.assertEquals(2, andFilter.getExpression().size());
 
-		FilterSpec filterSpec1 = andFilter.getExpression().get(0);
-		Assert.assertEquals(PathSpec.of("id"), filterSpec1.getPath());
-		Assert.assertEquals(FilterOperator.EQ, filterSpec1.getOperator());
-		Assert.assertEquals(Arrays.asList(12L, 13L, 14L), filterSpec1.getValue());
+        FilterSpec filterSpec1 = andFilter.getExpression().get(0);
+        Assert.assertEquals(PathSpec.of("id"), filterSpec1.getPath());
+        Assert.assertEquals(FilterOperator.EQ, filterSpec1.getOperator());
+        Assert.assertEquals(Arrays.asList(12L, 13L, 14L), filterSpec1.getValue());
 
-		FilterSpec filterSpec2 = andFilter.getExpression().get(1);
-		Assert.assertEquals(PathSpec.of("completed"), filterSpec2.getPath());
-		Assert.assertEquals(FilterOperator.EQ, filterSpec2.getOperator());
-		Assert.assertEquals(Boolean.TRUE, filterSpec2.getValue());
+        FilterSpec filterSpec2 = andFilter.getExpression().get(1);
+        Assert.assertEquals(PathSpec.of("completed"), filterSpec2.getPath());
+        Assert.assertEquals(FilterOperator.EQ, filterSpec2.getOperator());
+        Assert.assertEquals(Boolean.TRUE, filterSpec2.getValue());
 
-		JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
-		checkNodeEquals(jsonNode, serializedJsonNode);
-		Assert.assertTrue(mapper.isNested(filterSpecs));
-	}
+        JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
+        checkNodeEquals(jsonNode, serializedJsonNode);
+        Assert.assertTrue(mapper.isNested(filterSpecs));
+    }
 
-	@Test
-	public void filterMultipleAttributes() throws IOException {
-		JsonNode jsonNode = objectMapper.readTree("{\"id\": [12, 13, 14], \"completed\": true }");
-		List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation);
-		Assert.assertEquals(2, filterSpecs.size());
-		FilterSpec filterSpec1 = filterSpecs.get(0);
-		Assert.assertEquals(PathSpec.of("id"), filterSpec1.getPath());
-		Assert.assertEquals(FilterOperator.EQ, filterSpec1.getOperator());
-		Assert.assertEquals(Arrays.asList(12L, 13L, 14L), filterSpec1.getValue());
+    @Test
+    public void filterMultipleAttributes() throws IOException {
+        JsonNode jsonNode = objectMapper.readTree("{\"id\": [12, 13, 14], \"completed\": true }");
+        List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation, queryContext);
+        Assert.assertEquals(2, filterSpecs.size());
+        FilterSpec filterSpec1 = filterSpecs.get(0);
+        Assert.assertEquals(PathSpec.of("id"), filterSpec1.getPath());
+        Assert.assertEquals(FilterOperator.EQ, filterSpec1.getOperator());
+        Assert.assertEquals(Arrays.asList(12L, 13L, 14L), filterSpec1.getValue());
 
-		FilterSpec filterSpec2 = filterSpecs.get(1);
-		Assert.assertEquals(PathSpec.of("completed"), filterSpec2.getPath());
-		Assert.assertEquals(FilterOperator.EQ, filterSpec2.getOperator());
-		Assert.assertEquals(Boolean.TRUE, filterSpec2.getValue());
+        FilterSpec filterSpec2 = filterSpecs.get(1);
+        Assert.assertEquals(PathSpec.of("completed"), filterSpec2.getPath());
+        Assert.assertEquals(FilterOperator.EQ, filterSpec2.getOperator());
+        Assert.assertEquals(Boolean.TRUE, filterSpec2.getValue());
 
-		JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
-		checkNodeEquals(jsonNode, serializedJsonNode);
-		Assert.assertFalse(mapper.isNested(filterSpecs));
-	}
+        JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
+        checkNodeEquals(jsonNode, serializedJsonNode);
+        Assert.assertFalse(mapper.isNested(filterSpecs));
+    }
 
-	@Test
-	public void filterByNestedAttributes() throws IOException {
-		JsonNode jsonNode = objectMapper.readTree("{\"project\": {\"id\": 1} }");
-		List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation);
-		Assert.assertEquals(1, filterSpecs.size());
-		FilterSpec filterSpec1 = filterSpecs.get(0);
-		Assert.assertEquals(PathSpec.of("project", "id"), filterSpec1.getPath());
-		Assert.assertEquals(FilterOperator.EQ, filterSpec1.getOperator());
-		Assert.assertEquals((Long) 1L, filterSpec1.getValue());
+    @Test
+    public void filterByNestedAttributes() throws IOException {
+        JsonNode jsonNode = objectMapper.readTree("{\"project\": {\"id\": 1} }");
+        List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation, queryContext);
+        Assert.assertEquals(1, filterSpecs.size());
+        FilterSpec filterSpec1 = filterSpecs.get(0);
+        Assert.assertEquals(PathSpec.of("project", "id"), filterSpec1.getPath());
+        Assert.assertEquals(FilterOperator.EQ, filterSpec1.getOperator());
+        Assert.assertEquals((Long) 1L, filterSpec1.getValue());
 
-		JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
-		checkNodeEquals(jsonNode, serializedJsonNode);
-		Assert.assertFalse(mapper.isNested(filterSpecs));
-	}
+        JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
+        checkNodeEquals(jsonNode, serializedJsonNode);
+        Assert.assertFalse(mapper.isNested(filterSpecs));
+    }
 
-	@Test
-	public void filterMixed() throws IOException {
-		JsonNode jsonNode = objectMapper.readTree("{\"name\": \"Great Task\", \"id\": 121, \"NEQ\": {\"id\": 122}}");
-		List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation);
-		Assert.assertEquals(3, filterSpecs.size());
-		FilterSpec filterSpec1 = filterSpecs.get(0);
-		Assert.assertEquals(PathSpec.of("name"), filterSpec1.getPath());
-		Assert.assertEquals(FilterOperator.EQ, filterSpec1.getOperator());
-		Assert.assertEquals("Great Task", filterSpec1.getValue());
+    @Test
+    public void filterMixed() throws IOException {
+        JsonNode jsonNode = objectMapper.readTree("{\"name\": \"Great Task\", \"id\": 121, \"NEQ\": {\"id\": 122}}");
+        List<FilterSpec> filterSpecs = mapper.deserialize(jsonNode, resourceInformation, queryContext);
+        Assert.assertEquals(3, filterSpecs.size());
+        FilterSpec filterSpec1 = filterSpecs.get(0);
+        Assert.assertEquals(PathSpec.of("name"), filterSpec1.getPath());
+        Assert.assertEquals(FilterOperator.EQ, filterSpec1.getOperator());
+        Assert.assertEquals("Great Task", filterSpec1.getValue());
 
-		FilterSpec filterSpec2 = filterSpecs.get(2);
-		Assert.assertEquals(PathSpec.of("id"), filterSpec2.getPath());
-		Assert.assertEquals(FilterOperator.NEQ, filterSpec2.getOperator());
-		Assert.assertEquals((Long) 122L, filterSpec2.getValue());
+        FilterSpec filterSpec2 = filterSpecs.get(2);
+        Assert.assertEquals(PathSpec.of("id"), filterSpec2.getPath());
+        Assert.assertEquals(FilterOperator.NEQ, filterSpec2.getOperator());
+        Assert.assertEquals((Long) 122L, filterSpec2.getValue());
 
-		JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
-		checkNodeEquals(jsonNode, serializedJsonNode);
-		Assert.assertFalse(mapper.isNested(filterSpecs));
-	}
+        JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
+        checkNodeEquals(jsonNode, serializedJsonNode);
+        Assert.assertFalse(mapper.isNested(filterSpecs));
+    }
 
-	private void checkNodeEquals(JsonNode expected, JsonNode actual) throws JsonProcessingException {
-		String strExpected = objectMapper.writeValueAsString(expected);
-		String strActual = objectMapper.writeValueAsString(actual);
-		Assert.assertEquals(strExpected, strActual);
-	}
+    private void checkNodeEquals(JsonNode expected, JsonNode actual) throws JsonProcessingException {
+        String strExpected = objectMapper.writeValueAsString(expected);
+        String strActual = objectMapper.writeValueAsString(actual);
+        Assert.assertEquals(strExpected, strActual);
+    }
 
 
 }

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/QueryPathResolverTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/QueryPathResolverTest.java
@@ -39,7 +39,7 @@ public class QueryPathResolverTest extends AbstractQuerySpecTest {
         ResourceInformation resourceInformation = resourceRegistry.getEntry(Task.class).getResourceInformation();
         List<String> jsonPath = Arrays.asList("name");
 
-        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test");
+        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test", queryContext);
         Assert.assertEquals(String.class, spec.getValueType());
         Assert.assertEquals(jsonPath, spec.getAttributePath());
     }
@@ -49,7 +49,7 @@ public class QueryPathResolverTest extends AbstractQuerySpecTest {
         ResourceInformation resourceInformation = resourceRegistry.getEntry(Task.class).getResourceInformation();
         List<String> jsonPath = Arrays.asList("id");
 
-        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test");
+        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test", queryContext);
         Assert.assertEquals(Long.class, spec.getValueType());
         Assert.assertEquals(jsonPath, spec.getAttributePath());
     }
@@ -60,7 +60,7 @@ public class QueryPathResolverTest extends AbstractQuerySpecTest {
         ResourceInformation resourceInformation = resourceRegistry.getEntry(Project.class).getResourceInformation();
         List<String> jsonPath = Arrays.asList("data", "data");
 
-        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test");
+        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test", queryContext);
         Assert.assertEquals(String.class, spec.getValueType());
         Assert.assertEquals(jsonPath, spec.getAttributePath());
     }
@@ -71,7 +71,7 @@ public class QueryPathResolverTest extends AbstractQuerySpecTest {
         ResourceInformation resourceInformation = resourceRegistry.getEntry(Project.class).getResourceInformation();
         List<String> jsonPath = Arrays.asList("data", "priorities", "foo");
 
-        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test");
+        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test", queryContext);
         Assert.assertEquals(Integer.class, spec.getValueType());
         Assert.assertEquals(jsonPath, spec.getAttributePath());
     }
@@ -81,7 +81,7 @@ public class QueryPathResolverTest extends AbstractQuerySpecTest {
         ResourceInformation resourceInformation = resourceRegistry.getEntry(Task.class).getResourceInformation();
         List<String> jsonPath = Arrays.asList("project");
 
-        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test");
+        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test", queryContext);
         Assert.assertEquals(Project.class, spec.getValueType());
         Assert.assertEquals(jsonPath, spec.getAttributePath());
     }
@@ -92,7 +92,7 @@ public class QueryPathResolverTest extends AbstractQuerySpecTest {
         List<String> jsonPath = Arrays.asList("doesNotExists");
 
         try {
-            resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test");
+            resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test", queryContext);
             Assert.fail();
         } catch (BadRequestException e) {
             // ok
@@ -107,7 +107,7 @@ public class QueryPathResolverTest extends AbstractQuerySpecTest {
         resolver.setAllowUnknownAttributes(true);
         List<String> jsonPath = Arrays.asList("doesNotExists");
 
-        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test");
+        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test", queryContext);
         Assert.assertEquals(jsonPath, spec.getAttributePath());
         Assert.assertEquals(Object.class, spec.getValueType());
     }
@@ -117,7 +117,7 @@ public class QueryPathResolverTest extends AbstractQuerySpecTest {
         ResourceInformation resourceInformation = resourceRegistry.getEntry(Schedule.class).getResourceInformation();
         List<String> jsonPath = Arrays.asList("description");
 
-        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JSON, "test");
+        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JSON, "test", queryContext);
         Assert.assertEquals(Arrays.asList("desc"), spec.getAttributePath());
         Assert.assertEquals(String.class, spec.getValueType());
     }
@@ -127,7 +127,7 @@ public class QueryPathResolverTest extends AbstractQuerySpecTest {
         ResourceInformation resourceInformation = resourceRegistry.getEntry(Schedule.class).getResourceInformation();
         List<String> jsonPath = Arrays.asList("desc");
 
-        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test");
+        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test", queryContext);
         Assert.assertEquals(Arrays.asList("description"), spec.getAttributePath());
         Assert.assertEquals(String.class, spec.getValueType());
     }
@@ -137,7 +137,7 @@ public class QueryPathResolverTest extends AbstractQuerySpecTest {
         ResourceInformation resourceInformation = resourceRegistry.getEntry(Schedule.class).getResourceInformation();
         List<String> jsonPath = Arrays.asList("desc");
 
-        resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JSON, "test");
+        resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JSON, "test", queryContext);
     }
 
     @Test
@@ -145,7 +145,7 @@ public class QueryPathResolverTest extends AbstractQuerySpecTest {
         ResourceInformation resourceInformation = resourceRegistry.getEntry(Task.class).getResourceInformation();
         List<String> jsonPath = Arrays.asList("project", "id");
 
-        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test");
+        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test", queryContext);
         Assert.assertEquals(Long.class, spec.getValueType());
         Assert.assertEquals(jsonPath, spec.getAttributePath());
     }
@@ -155,7 +155,7 @@ public class QueryPathResolverTest extends AbstractQuerySpecTest {
         List<String> jsonPath = Arrays.asList("project", "includedTask");
         ResourceInformation resourceInformation = resourceRegistry.getEntry(Task.class).getResourceInformation();
 
-        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test");
+        QueryPathSpec spec = resolver.resolve(resourceInformation, jsonPath, QueryPathResolver.NamingType.JAVA, "test", queryContext);
         Assert.assertEquals(Task.class, spec.getValueType());
         Assert.assertEquals(jsonPath, spec.getAttributePath());
     }

--- a/crnk-documentation/src/docs/asciidoc/resource.adoc
+++ b/crnk-documentation/src/docs/asciidoc/resource.adoc
@@ -636,3 +636,55 @@ to compute URLs.
 WARNING: Nesting is currently limited to a single level (and the possibility to have further relationships on the nested resource).
 
 
+## @JsonApiVersion
+
+WARNING: This feature is experimental
+
+Crnk supports versioning of resources and fields based on content negotiation.
+Any resource and field can carry a version range where it is available.
+Crnk will disregard any resource and field with a version range that does not intersect with the request version.
+The HTTP `Accept` header is used to pass along the desired version as part of general content negotiation.
+This has the benefit that URLs remain constant across versions, greatly simplifying usability and linking.
+For a more detailed discussion, see here[https://blog.ploeh.dk/2015/06/22/rest-implies-content-negotiation/].
+
+A versioned resource looks like:
+
+[source,java]
+.VersionedTask.java
+----
+include::../../../../crnk-test/src/main/java/io/crnk/test/mock/models/VersionedTask.java[tags=docs]
+----
+
+- The resource itself is available up to version 5.
+- The field `completed` is only available from version 1 to 3.
+- The field `newCompleted` introduces a new flavor of `completed` making use of `CompletionStatus` rather than
+  a boolean. Through the use of `@JsonProperty` it is mapped to `completed` on the REST layer whereas
+  the Java side has access to both the old and new field.
+
+Crnk makes use of integer-based version number to signal major versions with breaking changes. There is
+no need for minor versions in this scheme. But applications are free to use additional minor versions in other contexts.
+
+A request than carries an accept header like:
+
+----
+GET /api/versionedTask HTTP/1.1
+Accept: application/vnd.api+json; version=2
+----
+
+Alternatively, the version can be passed as URL parameter (easier to use from a browser:
+
+----
+GET /api/versionedTask?version=2 HTTP/1.1
+Accept: application/vnd.api+json
+----
+
+<<client,CrnkClient>> supports setting the request version through `CrnkClient.setVersion(...)`.
+
+Not supported is:
+
+- ID fields cannot be versioned.
+- for multiple classes to serve the same resource for different version ranges.
+  For example, it is not possible to introduce a class `VersionedTaskV2.java`.
+  For most use cases it should be sufficient to redefine fields. This may change in the future
+- Meta and link fields cannot be versioned, this may change in the future.
+

--- a/crnk-home/src/main/java/io/crnk/home/HomeModule.java
+++ b/crnk-home/src/main/java/io/crnk/home/HomeModule.java
@@ -165,13 +165,14 @@ public class HomeModule implements Module, ModuleExtensionAware<HomeModuleExtens
 				}
 			}
 
+			QueryContext queryContext = requestContext.getQueryContext();
 			ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
-			JsonPath jsonPath = new PathBuilder(resourceRegistry, moduleContext.getTypeParser()).build(path);
+			PathBuilder pathBuilder = new PathBuilder(resourceRegistry, moduleContext.getTypeParser());
+			JsonPath jsonPath = pathBuilder.build(path, queryContext);
 
 			// check no repository with that path
 			if (jsonPath == null) {
 				// check there are children to display
-				QueryContext queryContext = requestContext.getQueryContext();
 				String requestPath = requestContext.getPath();
 				List<String> pathList = list(requestPath, queryContext);
 				boolean accepted = path.equals("/") || !pathList.isEmpty();

--- a/crnk-integration-examples/spring-boot-example/src/test/java/io/crnk/example/springboot/simple/SpringBootSimpleExampleApplicationTests.java
+++ b/crnk-integration-examples/spring-boot-example/src/test/java/io/crnk/example/springboot/simple/SpringBootSimpleExampleApplicationTests.java
@@ -1,5 +1,14 @@
 package io.crnk.example.springboot.simple;
 
+import static com.jayway.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchema;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
+import javax.security.auth.message.config.AuthConfigFactory;
+
 import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.response.Response;
@@ -22,15 +31,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
-
-import javax.security.auth.message.config.AuthConfigFactory;
-import java.io.Serializable;
-import java.util.Map;
-import java.util.Set;
-
-import static com.jayway.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchema;
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.OK;
 
 /**
  * Shows two kinds of test cases: RestAssured and CrnkClient.
@@ -184,7 +184,7 @@ public class SpringBootSimpleExampleApplicationTests extends BaseTest {
 
     @Test
     public void testCreateTask() {
-        Map<String, Object> attributeMap = new ImmutableMap.Builder<String, Object>().put("my-name", "Getter Done")
+        Map<String, Object> attributeMap = new ImmutableMap.Builder<String, Object>().put("name", "Getter Done")
                 .put("description", "12345678901234567890").build();
 
         Map dataMap = ImmutableMap.of("data", ImmutableMap.of("type", "tasks", "attributes", attributeMap));
@@ -197,7 +197,7 @@ public class SpringBootSimpleExampleApplicationTests extends BaseTest {
 
     @Test
     public void testUpdateTask() {
-        Map<String, Object> attributeMap = new ImmutableMap.Builder<String, Object>().put("my-name", "Gotter Did")
+        Map<String, Object> attributeMap = new ImmutableMap.Builder<String, Object>().put("name", "Gotter Did")
                 .put("description", "12345678901234567890").build();
 
         Map dataMap = ImmutableMap.of("data", ImmutableMap.of("type", "tasks", "id", 1, "attributes", attributeMap));

--- a/crnk-meta/src/main/java/io/crnk/meta/internal/resource/ResourceMetaParitition.java
+++ b/crnk-meta/src/main/java/io/crnk/meta/internal/resource/ResourceMetaParitition.java
@@ -88,8 +88,7 @@ public class ResourceMetaParitition extends TypedMetaPartitionBase {
 				String id = getId(entry.getResourceInformation().getResourceType());
 				if (isMeta) {
 					return id + "$meta";
-				}
-				else {
+				} else {
 					return id + "$links";
 				}
 			}
@@ -179,6 +178,7 @@ public class ResourceMetaParitition extends TypedMetaPartitionBase {
 		resource.setName(getName(information));
 		resource.setResourceType(resourceType);
 		resource.setResourcePath(information.getResourcePath());
+		resource.setVersionRange(information.getVersionRange());
 		if (superMeta != null) {
 			resource.setSuperType(superMeta);
 			if (superMeta != null) {
@@ -217,8 +217,7 @@ public class ResourceMetaParitition extends TypedMetaPartitionBase {
 		RegistryEntry entry = resourceRegistry.getEntry(resourceType);
 		if (idPrefix != null) {
 			return idPrefix + resourceType.replace('/', '.');
-		}
-		else {
+		} else {
 			Class<?> resourceClass = entry.getResourceInformation().getResourceClass();
 			return resourceClass.getName();
 		}
@@ -230,8 +229,7 @@ public class ResourceMetaParitition extends TypedMetaPartitionBase {
 		for (int i = 0; i < resourceType.length(); i++) {
 			if (i == 0 || resourceType.charAt(i - 1) == '/') {
 				name.append(Character.toUpperCase(resourceType.charAt(i)));
-			}
-			else if (resourceType.charAt(i) != '/') {
+			} else if (resourceType.charAt(i) != '/') {
 				name.append(resourceType.charAt(i));
 			}
 		}
@@ -297,9 +295,11 @@ public class ResourceMetaParitition extends TypedMetaPartitionBase {
 		attr.setUnderlyingName(field.getUnderlyingName());
 
 		attr.setParent(resource, true);
+		attr.setId(resource.getId() + "." + field.getUnderlyingName());
 		attr.setName(field.getJsonName());
 		attr.setAssociation(field.getResourceFieldType() == ResourceFieldType.RELATIONSHIP);
 		attr.setFieldType(field.getResourceFieldType());
+		attr.setVersionRange(field.getVersionRange());
 		attr.setDerived(false);
 
 		attr.setLazy(field.getSerializeType() == SerializeType.LAZY);

--- a/crnk-meta/src/main/java/io/crnk/meta/model/resource/MetaResource.java
+++ b/crnk-meta/src/main/java/io/crnk/meta/model/resource/MetaResource.java
@@ -1,10 +1,11 @@
 package io.crnk.meta.model.resource;
 
+import io.crnk.core.engine.information.resource.VersionRange;
 import io.crnk.core.resource.annotations.JsonApiRelation;
 import io.crnk.core.resource.annotations.JsonApiResource;
 
 /**
- * A JSON API resource.
+ * A JSON:API resource.
  */
 @JsonApiResource(type = "metaResource", resourcePath = "meta/resource")
 public class MetaResource extends MetaResourceBase { // NOSONAR ignore exception hierarchy
@@ -15,6 +16,16 @@ public class MetaResource extends MetaResourceBase { // NOSONAR ignore exception
 
 	@JsonApiRelation
 	private MetaResourceRepository repository;
+
+	private VersionRange versionRange;
+
+	public VersionRange getVersionRange() {
+		return versionRange;
+	}
+
+	public void setVersionRange(VersionRange versionRange) {
+		this.versionRange = versionRange;
+	}
 
 	public String getResourceType() {
 		return resourceType;

--- a/crnk-meta/src/main/java/io/crnk/meta/model/resource/MetaResourceField.java
+++ b/crnk-meta/src/main/java/io/crnk/meta/model/resource/MetaResourceField.java
@@ -1,6 +1,7 @@
 package io.crnk.meta.model.resource;
 
 import io.crnk.core.engine.information.resource.ResourceFieldType;
+import io.crnk.core.engine.information.resource.VersionRange;
 import io.crnk.core.resource.annotations.JsonApiResource;
 import io.crnk.meta.model.MetaAttribute;
 
@@ -12,11 +13,21 @@ public class MetaResourceField extends MetaAttribute {
 
 	private ResourceFieldType fieldType;
 
+	private VersionRange versionRange;
+
 	public ResourceFieldType getFieldType() {
 		return fieldType;
 	}
 
 	public void setFieldType(ResourceFieldType fieldType) {
 		this.fieldType = fieldType;
+	}
+
+	public VersionRange getVersionRange() {
+		return versionRange;
+	}
+
+	public void setVersionRange(VersionRange versionRange) {
+		this.versionRange = versionRange;
 	}
 }

--- a/crnk-meta/src/test/java/io/crnk/meta/ResourceMetaProviderTest.java
+++ b/crnk-meta/src/test/java/io/crnk/meta/ResourceMetaProviderTest.java
@@ -37,6 +37,7 @@ import io.crnk.test.mock.models.Schedule;
 import io.crnk.test.mock.models.Task;
 import io.crnk.test.mock.models.TaskStatus;
 import io.crnk.test.mock.models.TaskSubType;
+import io.crnk.test.mock.models.VersionedTask;
 import io.crnk.test.mock.models.types.ProjectData;
 import io.crnk.test.mock.repository.ScheduleRepository;
 import org.junit.Assert;
@@ -46,39 +47,39 @@ import org.junit.Test;
 
 public class ResourceMetaProviderTest extends AbstractMetaTest {
 
-    private MetaLookupImpl lookup;
+	private MetaLookupImpl lookup;
 
-    private ResourceMetaProvider resourceProvider;
+	private ResourceMetaProvider resourceProvider;
 
-    @Before
-    public void setup() {
-        super.setup();
+	@Before
+	public void setup() {
+		super.setup();
 
-        resourceProvider = new ResourceMetaProvider();
+		resourceProvider = new ResourceMetaProvider();
 
-        lookup = new MetaLookupImpl();
-        lookup.setModuleContext(container.getModuleRegistry().getContext());
-        lookup.addProvider(resourceProvider);
-        lookup.initialize();
-    }
+		lookup = new MetaLookupImpl();
+		lookup.setModuleContext(container.getModuleRegistry().getContext());
+		lookup.addProvider(resourceProvider);
+		lookup.initialize();
+	}
 
-    @Test
-    public void testReadWriteMethods() {
-        MetaResource meta = resourceProvider.getMeta(Schedule.class);
+	@Test
+	public void testReadWriteMethods() {
+		MetaResource meta = resourceProvider.getMeta(Schedule.class);
 
-        MetaAttribute idAttr = meta.getAttribute("id");
-        Assert.assertEquals("getId", idAttr.getReadMethod().getName());
-        Assert.assertEquals("setId", idAttr.getWriteMethod().getName());
+		MetaAttribute idAttr = meta.getAttribute("id");
+		Assert.assertEquals("getId", idAttr.getReadMethod().getName());
+		Assert.assertEquals("setId", idAttr.getWriteMethod().getName());
 
-        Schedule schedule = new Schedule();
-        schedule.setTasks(new HashSet<>());
-        schedule.setId(13L);
-        Assert.assertEquals(13L, idAttr.getValue(schedule));
+		Schedule schedule = new Schedule();
+		schedule.setTasks(new HashSet<>());
+		schedule.setId(13L);
+		Assert.assertEquals(13L, idAttr.getValue(schedule));
 
-        idAttr.setValue(schedule, 14L);
-        Assert.assertEquals(14L, schedule.getId().longValue());
+		idAttr.setValue(schedule, 14L);
+		Assert.assertEquals(14L, schedule.getId().longValue());
 
-        // TODO meta ttribute & renaming
+		// TODO meta ttribute & renaming
 		/*
 		MetaAttribute listAttr = meta.getAttribute("taskSet");
 		Task task = new Task();
@@ -88,438 +89,460 @@ public class ResourceMetaProviderTest extends AbstractMetaTest {
 		listAttr.removeValue(schedule, task);
 		Assert.assertEquals(0, schedule.getTasks().size());
 		 */
-    }
-
-    @Test
-    public void getVersionAttribute() {
-        // TODO setup versioning concept in json api layer
-        MetaResource meta = resourceProvider.getMeta(Schedule.class);
-        Assert.assertNull(meta.getVersionAttribute());
-    }
-
-
-    @Test
-    public void checkUseOfJsonNaming() {
-        MetaResource meta = resourceProvider.getMeta(Schedule.class);
-        // this is the json name, not java (desc)!
-        MetaAttribute attr = meta.getAttribute("description");
-        Assert.assertNotNull(attr);
-    }
-
-    @Test
-    public void resolvePath() {
-        MetaResource meta = resourceProvider.getMeta(Schedule.class);
-
-        MetaAttributePath metaAttributes = meta.resolvePath(Arrays.asList("project", "name"));
-        Assert.assertEquals(2, metaAttributes.length());
-        Assert.assertEquals("project", metaAttributes.getElement(0).getName());
-        Assert.assertEquals("name", metaAttributes.getElement(1).getName());
-    }
-
-    @Test
-    public void resolvePathWithSubType() {
-        MetaResource meta = resourceProvider.getMeta(Task.class);
-
-        MetaAttributePath metaAttributes = meta.resolvePath(Arrays.asList("subTypeValue"), true);
-        Assert.assertEquals(1, metaAttributes.length());
-        Assert.assertEquals("subTypeValue", metaAttributes.getElement(0).getName());
-    }
-
-
-    @Test
-    public void getSubTypes() {
-        MetaResource meta = resourceProvider.getMeta(Task.class);
-
-        List<MetaDataObject> subTypes = meta.getSubTypes(true, false);
-        Assert.assertEquals(1, subTypes.size());
-        MetaDataObject subType = subTypes.iterator().next();
-        Assert.assertEquals(TaskSubType.class, subType.getImplementationClass());
-    }
-
-
-    @Test
-    public void getSubTypesOrSelf() {
-        MetaResource meta = resourceProvider.getMeta(Task.class);
-
-        List<MetaDataObject> subTypes = meta.getSubTypes(true, true);
-        Assert.assertEquals(2, subTypes.size());
-        Assert.assertTrue(subTypes.contains(meta));
-    }
-
-    @Test
-    public void testGetAnnotation() {
-        MetaResource meta = resourceProvider.getMeta(Schedule.class);
-        MetaAttribute idAttr = meta.getAttribute("id");
-        Assert.assertNotNull(idAttr.getAnnotation(JsonApiId.class));
-    }
-
-    @Test
-    public void testGetAnnotations() {
-        MetaResource meta = resourceProvider.getMeta(Schedule.class);
-        MetaAttribute idAttr = meta.getAttribute("id");
-        Assert.assertEquals(1, idAttr.getAnnotations().size());
-    }
-
-    @Test
-    public void testPreserveAttributeOrder() {
-        ResourceInformation resourceInformation = container.getEntry(Schedule.class).getResourceInformation();
-        List<ResourceField> fields = resourceInformation.getFields();
-        Assert.assertEquals("id", fields.get(0).getUnderlyingName());
-        Assert.assertEquals("name", fields.get(1).getUnderlyingName());
-        Assert.assertEquals("desc", fields.get(2).getUnderlyingName());
-        Assert.assertEquals("tasks", fields.get(3).getUnderlyingName());
-        Assert.assertEquals("project", fields.get(4).getUnderlyingName());
-        Assert.assertEquals("projects", fields.get(5).getUnderlyingName());
-        Assert.assertEquals("status", fields.get(6).getUnderlyingName());
-        Assert.assertEquals("delayed", fields.get(7).getUnderlyingName());
-        Assert.assertEquals("customData", fields.get(8).getUnderlyingName());
-
-        MetaResource meta = resourceProvider.getMeta(Schedule.class);
-        List<? extends MetaAttribute> attributes = meta.getAttributes();
-        Assert.assertEquals("id", attributes.get(0).getName());
-        Assert.assertEquals("name", attributes.get(1).getName());
-        Assert.assertEquals("description", attributes.get(2).getName());
-        Assert.assertEquals("taskSet", attributes.get(3).getName());
-        Assert.assertEquals("project", attributes.get(4).getName());
-        Assert.assertEquals("projects", attributes.get(5).getName());
-        Assert.assertEquals("status", attributes.get(6).getName());
-        Assert.assertEquals("delayed", attributes.get(7).getName());
-        Assert.assertEquals("customData", attributes.get(8).getName());
-    }
-
-    @Test
-    public void testUnderlyingNameForNestedObject() {
-        MetaDataObject meta = resourceProvider.getMeta(ProjectData.class);
-        MetaAttribute attribute = meta.getAttribute("due");
-        Assert.assertEquals("due", attribute.getName());
-        Assert.assertEquals("dueDate", attribute.getUnderlyingName());
-    }
-
-    @Test
-    public void testUnderlyingNameForResource() {
-        MetaResource meta = resourceProvider.getMeta(Schedule.class);
-        MetaAttribute attribute = meta.getAttribute("taskSet");
-        Assert.assertEquals("taskSet", attribute.getName());
-        Assert.assertEquals("tasks", attribute.getUnderlyingName());
-    }
-
-    @Test
-    public void testPrimaryKeyNotNullable() {
-        MetaResource meta = resourceProvider.getMeta(Schedule.class);
-        MetaKey primaryKey = meta.getPrimaryKey();
-        MetaAttribute idField = primaryKey.getElements().get(0);
-        Assert.assertFalse(idField.isNullable());
-
-        Assert.assertNotNull(idField.getAnnotation(JsonApiId.class));
-        Assert.assertEquals(1, idField.getAnnotations().size());
-    }
-
-    @Test
-    public void testRegularFieldNullable() {
-        MetaResource meta = resourceProvider.getMeta(Schedule.class);
-        MetaAttribute taskField = meta.getAttribute("project");
-        Assert.assertTrue(taskField.isNullable());
-    }
-
-    @Test
-    public void testPrimitiveFieldNotNullable() {
-        MetaResource meta = resourceProvider.getMeta(Schedule.class);
-        MetaAttribute taskField = meta.getAttribute("delayed");
-        Assert.assertFalse(taskField.isNullable());
-    }
-
-    @Test
-    public void testInheritanceOnResource() {
-        MetaResource meta = resourceProvider.getMeta(TaskSubType.class);
-
-        Assert.assertNotNull(meta.getAttribute("subTypeValue"));
-        Assert.assertNotNull(meta.getAttribute("name"));
-        Assert.assertNotNull(meta.getAttribute("id"));
-
-        MetaDataObject superType = meta.getSuperType();
-        Assert.assertEquals(MetaResource.class, superType.getClass());
-        Assert.assertFalse(superType.hasAttribute("subTypeValue"));
-        Assert.assertNotNull(superType.getAttribute("name"));
-        Assert.assertNotNull(superType.getAttribute("id"));
-
-        MetaKey primaryKey = meta.getPrimaryKey();
-        Assert.assertNotNull("id", primaryKey.getName());
-        Assert.assertEquals(1, primaryKey.getElements().size());
-        Assert.assertEquals("id", primaryKey.getElements().get(0).getName());
-        Assert.assertSame(primaryKey.getElements().get(0), meta.getAttribute("id"));
-        Assert.assertTrue(meta.getPrimaryKey().isUnique());
-
-        Assert.assertEquals(primaryKey.getElements().get(0), primaryKey.getUniqueElement());
-
-        Assert.assertEquals("12", primaryKey.toKeyString(12));
-    }
-
-    @Test
-    public void testResourceProperties() {
-        MetaResource meta = resourceProvider.getMeta(Schedule.class);
-
-        Assert.assertEquals("schedule", meta.getResourceType());
-        Assert.assertEquals("Schedule", meta.getName());
-        Assert.assertEquals("resources.schedule", meta.getId());
-
-        Assert.assertEquals(Schedule.class, meta.getImplementationClass());
-        Assert.assertEquals(Schedule.class, meta.getImplementationType());
-        Assert.assertNull(meta.getParent());
-        Assert.assertTrue(meta.getSubTypes().isEmpty());
-    }
-
-    @Test
-    public void testRenamedOppositeRelationship() {
-        MetaResource meta = resourceProvider.getMeta(Schedule.class);
-        MetaAttribute taskSetAttr = meta.getAttribute("taskSet");
-        Assert.assertEquals("taskSet", taskSetAttr.getName());
-        MetaAttribute oppositeAttribute = taskSetAttr.getOppositeAttribute();
-        Assert.assertNotNull(oppositeAttribute);
-        Assert.assertEquals("schedule", oppositeAttribute.getName());
-        Assert.assertSame(taskSetAttr, oppositeAttribute.getOppositeAttribute());
-    }
-
-    @Test
-    public void testLinksAttribute() {
-        MetaResource meta = resourceProvider.getMeta(Task.class);
-
-        MetaResourceField attr = (MetaResourceField) meta.getAttribute("linksInformation");
-        Assert.assertEquals("linksInformation", attr.getName());
-        Assert.assertEquals("resources.tasks.linksInformation", attr.getId());
-        Assert.assertFalse(attr.isLazy());
-        Assert.assertTrue(attr.getFieldType() == ResourceFieldType.LINKS_INFORMATION);
-        Assert.assertNull(attr.getOppositeAttribute());
-        Assert.assertEquals(Task.TaskLinks.class, attr.getType().getImplementationClass());
-    }
-
-    @Test
-    public void testMetaAttribute() {
-        MetaResource meta = resourceProvider.getMeta(Task.class);
-
-        MetaResourceField attr = (MetaResourceField) meta.getAttribute("metaInformation");
-        Assert.assertEquals("metaInformation", attr.getName());
-        Assert.assertEquals("resources.tasks.metaInformation", attr.getId());
-        Assert.assertFalse(attr.isLazy());
-        Assert.assertTrue(attr.getFieldType() == ResourceFieldType.META_INFORMATION);
-        Assert.assertNull(attr.getOppositeAttribute());
-        Assert.assertEquals(Task.TaskMeta.class, attr.getType().getImplementationClass());
-    }
-
-    @Test
-    public void testNestedObject() {
-        MetaResource meta = resourceProvider.getMeta(Project.class);
-        MetaAttribute data = meta.getAttribute("data");
-        MetaType type = data.getType();
-        Assert.assertEquals("resources.types.projectdata", type.getId());
-    }
-
-
-    @Test
-    public void testNestedAttributeRenaming() {
-        MetaResource meta = resourceProvider.getMeta(Project.class);
-        MetaAttribute data = meta.getAttribute("data");
-        MetaJsonObject type = (MetaJsonObject) data.getType();
-        Assert.assertEquals("resources.types.projectdata", type.getId());
-
-        Assert.assertFalse(type.hasAttribute("dueDate"));
-        Assert.assertNotNull(type.getAttribute("due"));
-
-    }
-
-
-    @Test
-    public void testSingleValuedAttribute() {
-        MetaResource meta = resourceProvider.getMeta(Task.class);
-
-        MetaResourceField attr = (MetaResourceField) meta.getAttribute("name");
-        Assert.assertEquals("name", attr.getName());
-        Assert.assertFalse(attr.isLazy());
-        Assert.assertFalse(attr.getFieldType() == ResourceFieldType.META_INFORMATION);
-        Assert.assertFalse(attr.getFieldType() == ResourceFieldType.LINKS_INFORMATION);
-        Assert.assertFalse(attr.isAssociation());
-
-        Assert.assertTrue(attr.isSortable());
-        Assert.assertTrue(attr.isFilterable());
-        Assert.assertTrue(attr.isInsertable());
-        Assert.assertTrue(attr.isUpdatable());
-    }
-
-    @Test
-    public void testArrayAttribute() {
-        MetaResource meta = resourceProvider.getMeta(Project.class);
-
-        MetaResourceField dataField = (MetaResourceField) meta.getAttribute("data");
-        Assert.assertEquals("data", dataField.getName());
-
-        MetaJsonObject projectData = (MetaJsonObject) dataField.getType();
-
-        MetaAttribute keywordField = projectData.getAttribute("keywords");
-
-        Assert.assertFalse(keywordField.isLazy());
-        Assert.assertFalse(keywordField.isAssociation());
-        Assert.assertTrue(keywordField.isInsertable());
-        Assert.assertTrue(keywordField.isUpdatable());
-
-        Assert.assertEquals(MetaArrayType.class, keywordField.getType().getClass());
-        Assert.assertTrue(keywordField.getType().getElementType() instanceof MetaPrimitiveType);
-
-        Assert.assertEquals("string$array", keywordField.getType().getName());
-        Assert.assertEquals("base.string$array", keywordField.getType().getId());
-
-        // FIXME support crnk annotations
-        // Assert.assertTrue(dataField.isSortable());
-        // Assert.assertTrue(dataField.isFilterable());
-    }
-
-    @Test
-    public void testMapAttribute() {
-        MetaResource meta = resourceProvider.getMeta(Project.class);
-
-        MetaResourceField dataField = (MetaResourceField) meta.getAttribute("data");
-        Assert.assertEquals("data", dataField.getName());
-
-        MetaJsonObject projectData = (MetaJsonObject) dataField.getType();
-
-        MetaAttribute keywordField = projectData.getAttribute("customData");
-
-        Assert.assertFalse(keywordField.isLazy());
-        Assert.assertFalse(keywordField.isAssociation());
-        Assert.assertTrue(keywordField.isInsertable());
-        Assert.assertTrue(keywordField.isUpdatable());
-
-        Assert.assertTrue(keywordField.getType() instanceof MetaMapType);
-        MetaMapType mapType = (MetaMapType) keywordField.getType();
-        Assert.assertTrue(keywordField.getType().getElementType() instanceof MetaPrimitiveType);
-        Assert.assertTrue(mapType.getKeyType() instanceof MetaPrimitiveType);
-
-        Assert.assertNotNull(mapType.asMap());
-        Assert.assertTrue(mapType.isMap());
-        Assert.assertFalse(mapType.isCollection());
-    }
-
-
-    @Test
-    public void testEnum() {
-        MetaResource meta = resourceProvider.getMeta(Task.class);
-        MetaResourceField statusField = (MetaResourceField) meta.getAttribute("status");
-        Assert.assertEquals(TaskStatus.class, statusField.getType().getImplementationClass());
-
-        MetaEnumType statusType = (MetaEnumType) statusField.getType();
-        Assert.assertEquals(3, statusType.getChildren().size());
-        Assert.assertEquals("OPEN", statusType.getChildren().get(0).getName());
-        Assert.assertEquals("INPROGRESS", statusType.getChildren().get(1).getName());
-        Assert.assertEquals("CLOSED", statusType.getChildren().get(2).getName());
-    }
-
-    @Test
-    public void testSingleValuedRelation() {
-        MetaResource meta = resourceProvider.getMeta(Task.class);
-
-        MetaResourceField attr = (MetaResourceField) meta.getAttribute("schedule");
-        Assert.assertEquals("schedule", attr.getName());
-        Assert.assertEquals("resources.tasks.schedule", attr.getId());
-        Assert.assertFalse(attr.isLazy());
-        Assert.assertFalse(attr.getFieldType() == ResourceFieldType.META_INFORMATION);
-        Assert.assertFalse(attr.getFieldType() == ResourceFieldType.LINKS_INFORMATION);
-        Assert.assertTrue(attr.isAssociation());
-        Assert.assertNotNull(attr.getOppositeAttribute());
-        Assert.assertNotNull("tasks", attr.getOppositeAttribute().getName());
-        Assert.assertEquals(Schedule.class, attr.getType().getImplementationClass());
-
-        Assert.assertTrue(attr.isSortable());
-        Assert.assertTrue(attr.isFilterable());
-        Assert.assertTrue(attr.isInsertable());
-        Assert.assertTrue(attr.isUpdatable());
-    }
-
-    @Test
-    public void testMultiValuedSetRelation() {
-        MetaResource meta = resourceProvider.getMeta(Schedule.class);
-
-        MetaResourceField attr = (MetaResourceField) meta.getAttribute("taskSet");
-        Assert.assertEquals("taskSet", attr.getName());
-        Assert.assertEquals("resources.schedule.taskSet", attr.getId());
-        Assert.assertTrue(attr.isLazy());
-        Assert.assertFalse(attr.getFieldType() == ResourceFieldType.META_INFORMATION);
-        Assert.assertFalse(attr.getFieldType() == ResourceFieldType.LINKS_INFORMATION);
-        Assert.assertTrue(attr.isAssociation());
-        Assert.assertFalse(attr.isOwner());
-        Assert.assertNotNull(attr.getOppositeAttribute());
-        Assert.assertTrue(attr.getOppositeAttribute().isOwner());
-        Assert.assertNotNull("taskSet", attr.getOppositeAttribute().getName());
-        Assert.assertEquals(Set.class, attr.getType().getImplementationClass());
-        Assert.assertEquals(Task.class, attr.getType().getElementType().getImplementationClass());
-        Assert.assertTrue(attr.getType().getClass().getName(), attr.getType() instanceof MetaSetType);
-
-        MetaSetType listType = (MetaSetType) attr.getType();
-        Assert.assertTrue(listType.newInstance() instanceof Set);
-        Assert.assertTrue(listType.isCollection());
-        Assert.assertFalse(listType.isMap());
-        Assert.assertNotNull(attr.getType().asCollection());
-    }
-
-    @Test
+	}
+
+	@Test
+	public void getVersionAttribute() {
+		// TODO setup versioning concept in json api layer
+		MetaResource meta = resourceProvider.getMeta(Schedule.class);
+		Assert.assertNull(meta.getVersionAttribute());
+	}
+
+
+	@Test
+	public void checkUseOfJsonNaming() {
+		MetaResource meta = resourceProvider.getMeta(Schedule.class);
+		// this is the json name, not java (desc)!
+		MetaAttribute attr = meta.getAttribute("description");
+		Assert.assertNotNull(attr);
+	}
+
+	@Test
+	public void resolvePath() {
+		MetaResource meta = resourceProvider.getMeta(Schedule.class);
+
+		MetaAttributePath metaAttributes = meta.resolvePath(Arrays.asList("project", "name"));
+		Assert.assertEquals(2, metaAttributes.length());
+		Assert.assertEquals("project", metaAttributes.getElement(0).getName());
+		Assert.assertEquals("name", metaAttributes.getElement(1).getName());
+	}
+
+	@Test
+	public void resolvePathWithSubType() {
+		MetaResource meta = resourceProvider.getMeta(Task.class);
+
+		MetaAttributePath metaAttributes = meta.resolvePath(Arrays.asList("subTypeValue"), true);
+		Assert.assertEquals(1, metaAttributes.length());
+		Assert.assertEquals("subTypeValue", metaAttributes.getElement(0).getName());
+	}
+
+
+	@Test
+	public void getSubTypes() {
+		MetaResource meta = resourceProvider.getMeta(Task.class);
+
+		List<MetaDataObject> subTypes = meta.getSubTypes(true, false);
+		Assert.assertEquals(1, subTypes.size());
+		MetaDataObject subType = subTypes.iterator().next();
+		Assert.assertEquals(TaskSubType.class, subType.getImplementationClass());
+	}
+
+
+	@Test
+	public void getSubTypesOrSelf() {
+		MetaResource meta = resourceProvider.getMeta(Task.class);
+
+		List<MetaDataObject> subTypes = meta.getSubTypes(true, true);
+		Assert.assertEquals(2, subTypes.size());
+		Assert.assertTrue(subTypes.contains(meta));
+	}
+
+	@Test
+	public void testGetAnnotation() {
+		MetaResource meta = resourceProvider.getMeta(Schedule.class);
+		MetaAttribute idAttr = meta.getAttribute("id");
+		Assert.assertNotNull(idAttr.getAnnotation(JsonApiId.class));
+	}
+
+	@Test
+	public void testGetAnnotations() {
+		MetaResource meta = resourceProvider.getMeta(Schedule.class);
+		MetaAttribute idAttr = meta.getAttribute("id");
+		Assert.assertEquals(1, idAttr.getAnnotations().size());
+	}
+
+	@Test
+	public void testPreserveAttributeOrder() {
+		ResourceInformation resourceInformation = container.getEntry(Schedule.class).getResourceInformation();
+		List<ResourceField> fields = resourceInformation.getFields();
+		Assert.assertEquals("id", fields.get(0).getUnderlyingName());
+		Assert.assertEquals("name", fields.get(1).getUnderlyingName());
+		Assert.assertEquals("desc", fields.get(2).getUnderlyingName());
+		Assert.assertEquals("tasks", fields.get(3).getUnderlyingName());
+		Assert.assertEquals("project", fields.get(4).getUnderlyingName());
+		Assert.assertEquals("projects", fields.get(5).getUnderlyingName());
+		Assert.assertEquals("status", fields.get(6).getUnderlyingName());
+		Assert.assertEquals("delayed", fields.get(7).getUnderlyingName());
+		Assert.assertEquals("customData", fields.get(8).getUnderlyingName());
+
+		MetaResource meta = resourceProvider.getMeta(Schedule.class);
+		List<? extends MetaAttribute> attributes = meta.getAttributes();
+		Assert.assertEquals("id", attributes.get(0).getName());
+		Assert.assertEquals("name", attributes.get(1).getName());
+		Assert.assertEquals("description", attributes.get(2).getName());
+		Assert.assertEquals("taskSet", attributes.get(3).getName());
+		Assert.assertEquals("project", attributes.get(4).getName());
+		Assert.assertEquals("projects", attributes.get(5).getName());
+		Assert.assertEquals("status", attributes.get(6).getName());
+		Assert.assertEquals("delayed", attributes.get(7).getName());
+		Assert.assertEquals("customData", attributes.get(8).getName());
+	}
+
+	@Test
+	public void testUnderlyingNameForNestedObject() {
+		MetaDataObject meta = resourceProvider.getMeta(ProjectData.class);
+		MetaAttribute attribute = meta.getAttribute("due");
+		Assert.assertEquals("due", attribute.getName());
+		Assert.assertEquals("dueDate", attribute.getUnderlyingName());
+	}
+
+	@Test
+	public void testUnderlyingNameForResource() {
+		MetaResource meta = resourceProvider.getMeta(Schedule.class);
+		MetaAttribute attribute = meta.getAttribute("taskSet");
+		Assert.assertEquals("taskSet", attribute.getName());
+		Assert.assertEquals("tasks", attribute.getUnderlyingName());
+	}
+
+	@Test
+	public void testPrimaryKeyNotNullable() {
+		MetaResource meta = resourceProvider.getMeta(Schedule.class);
+		MetaKey primaryKey = meta.getPrimaryKey();
+		MetaAttribute idField = primaryKey.getElements().get(0);
+		Assert.assertFalse(idField.isNullable());
+
+		Assert.assertNotNull(idField.getAnnotation(JsonApiId.class));
+		Assert.assertEquals(1, idField.getAnnotations().size());
+	}
+
+	@Test
+	public void testRegularFieldNullable() {
+		MetaResource meta = resourceProvider.getMeta(Schedule.class);
+		MetaAttribute taskField = meta.getAttribute("project");
+		Assert.assertTrue(taskField.isNullable());
+	}
+
+	@Test
+	public void testPrimitiveFieldNotNullable() {
+		MetaResource meta = resourceProvider.getMeta(Schedule.class);
+		MetaAttribute taskField = meta.getAttribute("delayed");
+		Assert.assertFalse(taskField.isNullable());
+	}
+
+	@Test
+	public void testInheritanceOnResource() {
+		MetaResource meta = resourceProvider.getMeta(TaskSubType.class);
+
+		Assert.assertNotNull(meta.getAttribute("subTypeValue"));
+		Assert.assertNotNull(meta.getAttribute("name"));
+		Assert.assertNotNull(meta.getAttribute("id"));
+
+		MetaDataObject superType = meta.getSuperType();
+		Assert.assertEquals(MetaResource.class, superType.getClass());
+		Assert.assertFalse(superType.hasAttribute("subTypeValue"));
+		Assert.assertNotNull(superType.getAttribute("name"));
+		Assert.assertNotNull(superType.getAttribute("id"));
+
+		MetaKey primaryKey = meta.getPrimaryKey();
+		Assert.assertNotNull("id", primaryKey.getName());
+		Assert.assertEquals(1, primaryKey.getElements().size());
+		Assert.assertEquals("id", primaryKey.getElements().get(0).getName());
+		Assert.assertSame(primaryKey.getElements().get(0), meta.getAttribute("id"));
+		Assert.assertTrue(meta.getPrimaryKey().isUnique());
+
+		Assert.assertEquals(primaryKey.getElements().get(0), primaryKey.getUniqueElement());
+
+		Assert.assertEquals("12", primaryKey.toKeyString(12));
+	}
+
+	@Test
+	public void testResourceProperties() {
+		MetaResource meta = resourceProvider.getMeta(Schedule.class);
+
+		Assert.assertEquals("schedule", meta.getResourceType());
+		Assert.assertEquals("Schedule", meta.getName());
+		Assert.assertEquals("resources.schedule", meta.getId());
+
+		Assert.assertEquals(Schedule.class, meta.getImplementationClass());
+		Assert.assertEquals(Schedule.class, meta.getImplementationType());
+		Assert.assertNull(meta.getParent());
+		Assert.assertTrue(meta.getSubTypes().isEmpty());
+	}
+
+	@Test
+	public void testRenamedOppositeRelationship() {
+		MetaResource meta = resourceProvider.getMeta(Schedule.class);
+		MetaAttribute taskSetAttr = meta.getAttribute("taskSet");
+		Assert.assertEquals("taskSet", taskSetAttr.getName());
+		MetaAttribute oppositeAttribute = taskSetAttr.getOppositeAttribute();
+		Assert.assertNotNull(oppositeAttribute);
+		Assert.assertEquals("schedule", oppositeAttribute.getName());
+		Assert.assertSame(taskSetAttr, oppositeAttribute.getOppositeAttribute());
+	}
+
+	@Test
+	public void testLinksAttribute() {
+		MetaResource meta = resourceProvider.getMeta(Task.class);
+
+		MetaResourceField attr = (MetaResourceField) meta.getAttribute("linksInformation");
+		Assert.assertEquals("linksInformation", attr.getName());
+		Assert.assertEquals("resources.tasks.linksInformation", attr.getId());
+		Assert.assertFalse(attr.isLazy());
+		Assert.assertTrue(attr.getFieldType() == ResourceFieldType.LINKS_INFORMATION);
+		Assert.assertNull(attr.getOppositeAttribute());
+		Assert.assertEquals(Task.TaskLinks.class, attr.getType().getImplementationClass());
+	}
+
+	@Test
+	public void testMetaAttribute() {
+		MetaResource meta = resourceProvider.getMeta(Task.class);
+
+		MetaResourceField attr = (MetaResourceField) meta.getAttribute("metaInformation");
+		Assert.assertEquals("metaInformation", attr.getName());
+		Assert.assertEquals("resources.tasks.metaInformation", attr.getId());
+		Assert.assertFalse(attr.isLazy());
+		Assert.assertTrue(attr.getFieldType() == ResourceFieldType.META_INFORMATION);
+		Assert.assertNull(attr.getOppositeAttribute());
+		Assert.assertEquals(Task.TaskMeta.class, attr.getType().getImplementationClass());
+	}
+
+	@Test
+	public void testNestedObject() {
+		MetaResource meta = resourceProvider.getMeta(Project.class);
+		MetaAttribute data = meta.getAttribute("data");
+		MetaType type = data.getType();
+		Assert.assertEquals("resources.types.projectdata", type.getId());
+	}
+
+
+	@Test
+	public void testNestedAttributeRenaming() {
+		MetaResource meta = resourceProvider.getMeta(Project.class);
+		MetaAttribute data = meta.getAttribute("data");
+		MetaJsonObject type = (MetaJsonObject) data.getType();
+		Assert.assertEquals("resources.types.projectdata", type.getId());
+
+		Assert.assertFalse(type.hasAttribute("dueDate"));
+		Assert.assertNotNull(type.getAttribute("due"));
+
+	}
+
+
+	@Test
+	public void testSingleValuedAttribute() {
+		MetaResource meta = resourceProvider.getMeta(Task.class);
+
+		MetaResourceField attr = (MetaResourceField) meta.getAttribute("name");
+		Assert.assertEquals("name", attr.getName());
+		Assert.assertFalse(attr.isLazy());
+		Assert.assertFalse(attr.getFieldType() == ResourceFieldType.META_INFORMATION);
+		Assert.assertFalse(attr.getFieldType() == ResourceFieldType.LINKS_INFORMATION);
+		Assert.assertFalse(attr.isAssociation());
+
+		Assert.assertTrue(attr.isSortable());
+		Assert.assertTrue(attr.isFilterable());
+		Assert.assertTrue(attr.isInsertable());
+		Assert.assertTrue(attr.isUpdatable());
+	}
+
+	@Test
+	public void testArrayAttribute() {
+		MetaResource meta = resourceProvider.getMeta(Project.class);
+
+		MetaResourceField dataField = (MetaResourceField) meta.getAttribute("data");
+		Assert.assertEquals("data", dataField.getName());
+
+		MetaJsonObject projectData = (MetaJsonObject) dataField.getType();
+
+		MetaAttribute keywordField = projectData.getAttribute("keywords");
+
+		Assert.assertFalse(keywordField.isLazy());
+		Assert.assertFalse(keywordField.isAssociation());
+		Assert.assertTrue(keywordField.isInsertable());
+		Assert.assertTrue(keywordField.isUpdatable());
+
+		Assert.assertEquals(MetaArrayType.class, keywordField.getType().getClass());
+		Assert.assertTrue(keywordField.getType().getElementType() instanceof MetaPrimitiveType);
+
+		Assert.assertEquals("string$array", keywordField.getType().getName());
+		Assert.assertEquals("base.string$array", keywordField.getType().getId());
+
+		// FIXME support crnk annotations
+		// Assert.assertTrue(dataField.isSortable());
+		// Assert.assertTrue(dataField.isFilterable());
+	}
+
+	@Test
+	public void testMapAttribute() {
+		MetaResource meta = resourceProvider.getMeta(Project.class);
+
+		MetaResourceField dataField = (MetaResourceField) meta.getAttribute("data");
+		Assert.assertEquals("data", dataField.getName());
+
+		MetaJsonObject projectData = (MetaJsonObject) dataField.getType();
+
+		MetaAttribute keywordField = projectData.getAttribute("customData");
+
+		Assert.assertFalse(keywordField.isLazy());
+		Assert.assertFalse(keywordField.isAssociation());
+		Assert.assertTrue(keywordField.isInsertable());
+		Assert.assertTrue(keywordField.isUpdatable());
+
+		Assert.assertTrue(keywordField.getType() instanceof MetaMapType);
+		MetaMapType mapType = (MetaMapType) keywordField.getType();
+		Assert.assertTrue(keywordField.getType().getElementType() instanceof MetaPrimitiveType);
+		Assert.assertTrue(mapType.getKeyType() instanceof MetaPrimitiveType);
+
+		Assert.assertNotNull(mapType.asMap());
+		Assert.assertTrue(mapType.isMap());
+		Assert.assertFalse(mapType.isCollection());
+	}
+
+
+	@Test
+	public void testEnum() {
+		MetaResource meta = resourceProvider.getMeta(Task.class);
+		MetaResourceField statusField = (MetaResourceField) meta.getAttribute("status");
+		Assert.assertEquals(TaskStatus.class, statusField.getType().getImplementationClass());
+
+		MetaEnumType statusType = (MetaEnumType) statusField.getType();
+		Assert.assertEquals(3, statusType.getChildren().size());
+		Assert.assertEquals("OPEN", statusType.getChildren().get(0).getName());
+		Assert.assertEquals("INPROGRESS", statusType.getChildren().get(1).getName());
+		Assert.assertEquals("CLOSED", statusType.getChildren().get(2).getName());
+	}
+
+	@Test
+	public void testSingleValuedRelation() {
+		MetaResource meta = resourceProvider.getMeta(Task.class);
+
+		MetaResourceField attr = (MetaResourceField) meta.getAttribute("schedule");
+		Assert.assertEquals("schedule", attr.getName());
+		Assert.assertEquals("resources.tasks.schedule", attr.getId());
+		Assert.assertFalse(attr.isLazy());
+		Assert.assertFalse(attr.getFieldType() == ResourceFieldType.META_INFORMATION);
+		Assert.assertFalse(attr.getFieldType() == ResourceFieldType.LINKS_INFORMATION);
+		Assert.assertTrue(attr.isAssociation());
+		Assert.assertNotNull(attr.getOppositeAttribute());
+		Assert.assertNotNull("tasks", attr.getOppositeAttribute().getName());
+		Assert.assertEquals(Schedule.class, attr.getType().getImplementationClass());
+
+		Assert.assertTrue(attr.isSortable());
+		Assert.assertTrue(attr.isFilterable());
+		Assert.assertTrue(attr.isInsertable());
+		Assert.assertTrue(attr.isUpdatable());
+	}
+
+	@Test
+	public void testMultiValuedSetRelation() {
+		MetaResource meta = resourceProvider.getMeta(Schedule.class);
+
+		MetaResourceField attr = (MetaResourceField) meta.getAttribute("taskSet");
+		Assert.assertEquals("taskSet", attr.getName());
+		Assert.assertEquals("resources.schedule.tasks", attr.getId());
+		Assert.assertTrue(attr.isLazy());
+		Assert.assertFalse(attr.getFieldType() == ResourceFieldType.META_INFORMATION);
+		Assert.assertFalse(attr.getFieldType() == ResourceFieldType.LINKS_INFORMATION);
+		Assert.assertTrue(attr.isAssociation());
+		Assert.assertFalse(attr.isOwner());
+		Assert.assertNotNull(attr.getOppositeAttribute());
+		Assert.assertTrue(attr.getOppositeAttribute().isOwner());
+		Assert.assertNotNull("taskSet", attr.getOppositeAttribute().getName());
+		Assert.assertEquals(Set.class, attr.getType().getImplementationClass());
+		Assert.assertEquals(Task.class, attr.getType().getElementType().getImplementationClass());
+		Assert.assertTrue(attr.getType().getClass().getName(), attr.getType() instanceof MetaSetType);
+
+		MetaSetType listType = (MetaSetType) attr.getType();
+		Assert.assertTrue(listType.newInstance() instanceof Set);
+		Assert.assertTrue(listType.isCollection());
+		Assert.assertFalse(listType.isMap());
+		Assert.assertNotNull(attr.getType().asCollection());
+	}
+
+	@Test
 	@Ignore
-    public void testMultiValuedListRelation() {
-        MetaResource meta = resourceProvider.getMeta(Task.class);
+	public void testMultiValuedListRelation() {
+		MetaResource meta = resourceProvider.getMeta(Task.class);
 
-        MetaResourceField attr = (MetaResourceField) meta.getAttribute("projects");
-        Assert.assertFalse(attr.getFieldType() == ResourceFieldType.META_INFORMATION);
-        Assert.assertFalse(attr.getFieldType() == ResourceFieldType.LINKS_INFORMATION);
-        Assert.assertTrue(attr.isAssociation());
-        Assert.assertTrue(attr.isOwner());
-        Assert.assertEquals(ResourceList.class, attr.getType().getImplementationClass());
-        Assert.assertEquals(Project.class, attr.getType().getElementType().getImplementationClass());
-        Assert.assertTrue(attr.getType() instanceof MetaListType);
+		MetaResourceField attr = (MetaResourceField) meta.getAttribute("projects");
+		Assert.assertFalse(attr.getFieldType() == ResourceFieldType.META_INFORMATION);
+		Assert.assertFalse(attr.getFieldType() == ResourceFieldType.LINKS_INFORMATION);
+		Assert.assertTrue(attr.isAssociation());
+		Assert.assertTrue(attr.isOwner());
+		Assert.assertEquals(ResourceList.class, attr.getType().getImplementationClass());
+		Assert.assertEquals(Project.class, attr.getType().getElementType().getImplementationClass());
+		Assert.assertTrue(attr.getType() instanceof MetaListType);
 
-        MetaListType listType = (MetaListType) attr.getType();
-        Assert.assertTrue(listType.newInstance() instanceof List);
-        Assert.assertTrue(listType.isCollection());
-        Assert.assertFalse(listType.isMap());
-        Assert.assertNotNull(attr.getType().asCollection());
-    }
-
-
-    @Test
-    public void testRepository() {
-        MetaResource resourceMeta = resourceProvider.getMeta(Schedule.class);
-        MetaResourceRepository meta = (MetaResourceRepository) lookup.getMetaById().get(resourceMeta.getId() + "$repository");
-        Assert.assertEquals(resourceMeta, meta.getResourceType());
-        Assert.assertTrue(meta.isExposed());
-        Assert.assertNotNull(meta.getListLinksType());
-        Assert.assertNotNull(meta.getListMetaType());
-        Assert.assertEquals(ScheduleRepository.ScheduleListLinks.class, meta.getListLinksType().getImplementationClass());
-        Assert.assertEquals(ScheduleRepository.ScheduleListMeta.class, meta.getListMetaType().getImplementationClass());
-
-        List<MetaElement> children = new ArrayList<>(meta.getChildren());
-        Collections.sort(children, Comparator.comparing(MetaElement::getName));
-        Assert.assertEquals(9, children.size());
-
-        MetaResourceAction repositoryActionMeta = (MetaResourceAction) children.get(1);
-        Assert.assertEquals("repositoryAction", repositoryActionMeta.getName());
-        Assert.assertEquals(MetaRepositoryActionType.REPOSITORY, repositoryActionMeta.getActionType());
-        MetaResourceAction resourceActionMeta = (MetaResourceAction) children.get(8);
-        Assert.assertEquals("resourceAction", resourceActionMeta.getName());
-        Assert.assertEquals(MetaRepositoryActionType.RESOURCE, resourceActionMeta.getActionType());
-
-    }
-
-    @Test
-    public void testDynamicResources() {
-        for (int i = 0; i < 2; i++) {
-            MetaResource meta = (MetaResource) lookup.getMetaById().get("resources.dynamic" + i);
-            Assert.assertNotNull(meta);
-
-            MetaAttribute parentAttr = meta.getAttribute("parent");
-            Assert.assertNotNull(meta.getAttribute("id"));
-            Assert.assertNotNull(meta.getAttribute("value"));
-            Assert.assertNotNull(parentAttr);
-            Assert.assertNotNull(meta.getAttribute("children"));
-
-            Assert.assertEquals("children", parentAttr.getOppositeAttribute().getName());
-            Assert.assertEquals("dynamic" + i, meta.getResourceType());
-        }
-    }
+		MetaListType listType = (MetaListType) attr.getType();
+		Assert.assertTrue(listType.newInstance() instanceof List);
+		Assert.assertTrue(listType.isCollection());
+		Assert.assertFalse(listType.isMap());
+		Assert.assertNotNull(attr.getType().asCollection());
+	}
 
 
+	@Test
+	public void testRepository() {
+		MetaResource resourceMeta = resourceProvider.getMeta(Schedule.class);
+		MetaResourceRepository meta = (MetaResourceRepository) lookup.getMetaById().get(resourceMeta.getId() + "$repository");
+		Assert.assertEquals(resourceMeta, meta.getResourceType());
+		Assert.assertTrue(meta.isExposed());
+		Assert.assertNotNull(meta.getListLinksType());
+		Assert.assertNotNull(meta.getListMetaType());
+		Assert.assertEquals(ScheduleRepository.ScheduleListLinks.class, meta.getListLinksType().getImplementationClass());
+		Assert.assertEquals(ScheduleRepository.ScheduleListMeta.class, meta.getListMetaType().getImplementationClass());
+
+		List<MetaElement> children = new ArrayList<>(meta.getChildren());
+		Collections.sort(children, Comparator.comparing(MetaElement::getName));
+		Assert.assertEquals(9, children.size());
+
+		MetaResourceAction repositoryActionMeta = (MetaResourceAction) children.get(1);
+		Assert.assertEquals("repositoryAction", repositoryActionMeta.getName());
+		Assert.assertEquals(MetaRepositoryActionType.REPOSITORY, repositoryActionMeta.getActionType());
+		MetaResourceAction resourceActionMeta = (MetaResourceAction) children.get(8);
+		Assert.assertEquals("resourceAction", resourceActionMeta.getName());
+		Assert.assertEquals(MetaRepositoryActionType.RESOURCE, resourceActionMeta.getActionType());
+
+	}
+
+	@Test
+	public void testDynamicResources() {
+		for (int i = 0; i < 2; i++) {
+			MetaResource meta = (MetaResource) lookup.getMetaById().get("resources.dynamic" + i);
+			Assert.assertNotNull(meta);
+
+			MetaAttribute parentAttr = meta.getAttribute("parent");
+			Assert.assertNotNull(meta.getAttribute("id"));
+			Assert.assertNotNull(meta.getAttribute("value"));
+			Assert.assertNotNull(parentAttr);
+			Assert.assertNotNull(meta.getAttribute("children"));
+
+			Assert.assertEquals("children", parentAttr.getOppositeAttribute().getName());
+			Assert.assertEquals("dynamic" + i, meta.getResourceType());
+		}
+	}
+
+	@Test
+	public void testVersioning() {
+		MetaResource resourceMeta = resourceProvider.getMeta(VersionedTask.class);
+		Assert.assertEquals(0, resourceMeta.getVersionRange().getMin());
+		Assert.assertEquals(5, resourceMeta.getVersionRange().getMax());
+
+		List<MetaResourceField> fields = (List<MetaResourceField>) resourceMeta.getAttributes();
+		Assert.assertEquals(4, fields.size());
+
+		MetaResourceField idField = fields.get(0);
+		MetaResourceField nameField = fields.get(1);
+		MetaResourceField completedField = fields.get(2);
+		MetaResourceField newCompletedField = fields.get(3);
+		Assert.assertEquals("id", idField.getName());
+		Assert.assertEquals("name", nameField.getName());
+		Assert.assertEquals("completed", completedField.getName());
+		Assert.assertEquals("completed", newCompletedField.getName());
+
+		Assert.assertEquals(1, completedField.getVersionRange().getMin());
+		Assert.assertEquals(3, completedField.getVersionRange().getMax());
+		Assert.assertEquals(5, newCompletedField.getVersionRange().getMin());
+		Assert.assertEquals(Integer.MAX_VALUE, newCompletedField.getVersionRange().getMax());
+	}
 }

--- a/crnk-monitor/crnk-monitor-brave4/src/main/java/io/crnk/monitor/brave/internal/BraveUtil.java
+++ b/crnk-monitor/crnk-monitor-brave4/src/main/java/io/crnk/monitor/brave/internal/BraveUtil.java
@@ -44,7 +44,7 @@ public class BraveUtil {
                     return objectMapper;
                 }
             });
-            Map<String, Set<String>> parameters = serializer.serialize(querySpec);
+            Map<String, Set<String>> parameters = serializer.serialize(querySpec, request.getQueryAdapter().getQueryContext());
             for (Map.Entry<String, Set<String>> entry : parameters.entrySet()) {
                 if (builder.length() > 1) {
                     builder.append("&");

--- a/crnk-operations/src/main/java/io/crnk/operations/client/OperationsCall.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/client/OperationsCall.java
@@ -84,7 +84,7 @@ public class OperationsCall {
 	protected <T> T fromResource(Document document, Class<T> clazz) {
 		CrnkClient crnk = client.getCrnk();
 		ClientDocumentMapper documentMapper = crnk.getDocumentMapper();
-		return (T) documentMapper.fromDocument(document, false);
+		return (T) documentMapper.fromDocument(document, false, crnk.getQueryContext());
 	}
 
 	public void execute() {

--- a/crnk-operations/src/main/java/io/crnk/operations/server/OperationFilterContext.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/server/OperationFilterContext.java
@@ -1,5 +1,6 @@
 package io.crnk.operations.server;
 
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.module.discovery.ServiceDiscovery;
 import io.crnk.operations.server.order.OrderedOperation;
 
@@ -7,7 +8,9 @@ import java.util.List;
 
 public interface OperationFilterContext {
 
-	List<OrderedOperation> getOrderedOperations();
+    List<OrderedOperation> getOrderedOperations();
 
-	ServiceDiscovery getServiceDiscovery();
+    ServiceDiscovery getServiceDiscovery();
+
+    QueryContext getQueryContext();
 }

--- a/crnk-operations/src/main/java/io/crnk/operations/server/OperationsModule.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/server/OperationsModule.java
@@ -1,15 +1,5 @@
 package io.crnk.operations.server;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collectors;
-
 import io.crnk.core.engine.dispatcher.RequestDispatcher;
 import io.crnk.core.engine.dispatcher.Response;
 import io.crnk.core.engine.document.Document;
@@ -45,401 +35,419 @@ import io.crnk.operations.server.order.DependencyOrderStrategy;
 import io.crnk.operations.server.order.OperationOrderStrategy;
 import io.crnk.operations.server.order.OrderedOperation;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
 public class OperationsModule implements Module {
 
-	private OperationOrderStrategy orderStrategy = new DependencyOrderStrategy();
-
-	private List<io.crnk.operations.server.OperationFilter> filters = new CopyOnWriteArrayList<>();
-
-	private ModuleContext moduleContext;
-
-	private boolean resumeOnError = false;
-
-	private boolean includeChangedRelationships = true;
-
-	private boolean displayOperationResponseOnSuccess = true;
-
-	private JsonApiRequestProcessorHelper helper;
-
-	public static OperationsModule create() {
-		return new OperationsModule();
-	}
-
-	// protected for CDI
-	protected OperationsModule() {
-	}
-
-	public void addFilter(io.crnk.operations.server.OperationFilter filter) {
-		this.filters.add(filter);
-	}
-
-	public void removeFilter(io.crnk.operations.server.OperationFilter filter) {
-		this.filters.remove(filter);
-	}
-
-	public OperationOrderStrategy getOrderStrategy() {
-		return orderStrategy;
-	}
-
-	public void setOrderStrategy(OperationOrderStrategy orderStrategy) {
-		this.orderStrategy = orderStrategy;
-	}
-
-	public List<io.crnk.operations.server.OperationFilter> getFilters() {
-		return filters;
-	}
-
-	@Override
-	public String getModuleName() {
-		return "operations";
-	}
-
-	@Override
-	public void setupModule(ModuleContext context) {
-		this.moduleContext = context;
-		this.helper = new JsonApiRequestProcessorHelper(context);
-		context.addHttpRequestProcessor(new io.crnk.operations.server.OperationsRequestProcessor(this, context));
-	}
-
-	/**
-	 * Applies the given set of operations.
-	 *
-	 * @return responses
-	 */
-	public List<OperationResponse> apply(List<Operation> operations, QueryContext queryContext) {
-		checkAccess(operations, queryContext);
-		enrichTypeIdInformation(operations);
-
-		List<OrderedOperation> orderedOperations = orderStrategy.order(operations);
-
-		DefaultOperationFilterChain chain = new DefaultOperationFilterChain();
-		return chain.doFilter(new DefaultOperationFilterContext(orderedOperations));
-	}
-
-	/**
-	 * This is not strictly necessary, but allows to catch security issues early before accessing the individual repositories
-	 */
-	private void checkAccess(List<Operation> operations, QueryContext queryContext) {
-		for (Operation operation : operations) {
-			checkAccess(operation, queryContext);
-		}
-	}
-
-	private void checkAccess(Operation operation, QueryContext queryContext) {
-		HttpMethod httpMethod = HttpMethod.valueOf(operation.getOp());
-
-		String path = OperationParameterUtils.parsePath(operation.getPath());
-		JsonPath jsonPath = (new PathBuilder(moduleContext.getResourceRegistry(), moduleContext.getTypeParser())).build(path);
-		if (jsonPath == null) {
-			throw new RepositoryNotFoundException(path);
-		}
-
-		RegistryEntry entry = jsonPath.getRootEntry();
-		ResourceInformation resourceInformation = entry.getResourceInformation();
-
-		ResourceFilterDirectory filterDirectory = moduleContext.getResourceFilterDirectory();
-		FilterBehavior filterBehavior = filterDirectory.get(resourceInformation, httpMethod, queryContext);
-		if (filterBehavior == FilterBehavior.FORBIDDEN) {
-			throw new ForbiddenException(resourceInformation, httpMethod);
-		}
-		if (filterBehavior == FilterBehavior.UNAUTHORIZED) {
-			throw new UnauthorizedException(resourceInformation, httpMethod);
-		}
-	}
-
-	private void enrichTypeIdInformation(List<Operation> operations) {
-		ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
-		for (Operation operation : operations) {
-			if (operation.getOp().equalsIgnoreCase(HttpMethod.DELETE.toString())) {
-				String path = OperationParameterUtils.parsePath(operation.getPath());
-				JsonPath jsonPath = (new PathBuilder(resourceRegistry, moduleContext.getTypeParser())).build(path);
-
-				RegistryEntry entry = jsonPath.getRootEntry();
-				String idString = entry.getResourceInformation().toIdString(jsonPath.getId());
-
-				Resource resource = new Resource();
-				resource.setType(jsonPath.getRootEntry().getResourceInformation().getResourceType());
-				resource.setId(idString);
-				operation.setValue(resource);
-			}
-		}
-	}
-
-	protected void fillinIgnoredOperations(OperationResponse[] responses) {
-		for (int i = 0; i < responses.length; i++) {
-			if (responses[i] == null) {
-				OperationResponse operationResponse = new OperationResponse();
-				operationResponse.setStatus(HttpStatus.PRECONDITION_FAILED_412);
-				responses[i] = operationResponse;
-			}
-		}
-	}
-
-
-	protected PathBuilder getPathBuilder() {
-		ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
-		TypeParser typeParser = moduleContext.getTypeParser();
-		return new PathBuilder(resourceRegistry, typeParser);
-	}
-
-	protected List<OperationResponse> executeOperations(List<OrderedOperation> orderedOperations) {
-		OperationResponse[] responses = new OperationResponse[orderedOperations.size()];
-		boolean successful = true;
-
-		int index = 0;
-
-		String bulkMethod = null;
-		String bulkType = null;
-		List<OrderedOperation> bulk = new ArrayList<>();
-
-		PathBuilder pathBuilder = getPathBuilder();
-
-
-		while (index < orderedOperations.size()) {
-			OrderedOperation orderedOperation = orderedOperations.get(index);
-			index++;
-
-			Operation operation = orderedOperation.getOperation();
-			String method = operation.getOp();
-			JsonPath path = pathBuilder.build(operation.getPath());
-			orderedOperation.setPath(path);
-			if (path == null) {
-				throw new BadRequestException("invalid path: " + operation.getPath());
-			}
-			String type = path.getRootEntry().getResourceInformation().getResourceType();
-
-			if (!method.equals(bulkMethod) || !type.equals(bulkType)) {
-				if (!bulk.isEmpty()) {
-					boolean success = bulkExecuteOperations(bulk, responses);
-					if (!success) {
-						successful = false;
-						if (!resumeOnError) {
-							break;
-						}
-					}
-					bulk.clear();
-				}
-				bulkMethod = method;
-				bulkType = type;
-			}
-
-			bulk.add(orderedOperation);
-		}
-
-		if (!bulk.isEmpty()) {
-			boolean success = bulkExecuteOperations(bulk, responses);
-			if (!success) {
-				successful = false;
-			}
-		}
-
-		if (orderedOperations.size() > 1 && ((!successful && resumeOnError) || (successful && displayOperationResponseOnSuccess))) {
-			fetchUpToDateResponses(orderedOperations, responses);
-		}
-
-		fillinIgnoredOperations(responses);
-		return Arrays.asList(responses);
-	}
-
-	private String getType(Operation operation) {
-		return operation.getValue().getType();
-	}
-
-	private boolean legacySetup;
-
-	private boolean bulkExecuteOperations(List<OrderedOperation> operations, OperationResponse[] responses) {
-		RequestDispatcher requestDispatcher = moduleContext.getRequestDispatcher();
-
-		OrderedOperation firstOperation = operations.get(0);
-
-		RegistryEntry rootEntry = firstOperation.getPath().getRootEntry();
-
-		if (supportsBulk(rootEntry)) {
-			String method = firstOperation.getOperation().getOp();
-
-			JsonPath repositoryPath = new ResourcePath(rootEntry, null);
-
-			PreconditionUtil.verifyEquals(HttpMethod.POST.toString(), method, "experimental bulk support is currently limited to POST");
-
-			Document requestBody = new Document();
-			requestBody.setData(Nullable.of(operations.stream().map(it -> it.getOperation().getValue()).collect(Collectors.toList())));
-
-
-			Map<String, Set<String>> parameters = new HashMap<>();
-			Response response = requestDispatcher.dispatchRequest(repositoryPath.toString(), method, parameters, requestBody);
-
-			boolean success = response.getHttpStatus() < 400;
-			for (int i = 0; i < operations.size(); i++) {
-				OrderedOperation orderedOperation = operations.get(i);
-				OperationResponse operationResponse = new OperationResponse();
-				operationResponse.setStatus(response.getHttpStatus());
-				if (displayOperationResponseOnSuccess || !success) {
-					if (success) {
-						List<Resource> collectionData = response.getDocument().getCollectionData().get();
-						Resource responseResourceBody = collectionData.get(0);
-						operationResponse.setData(Nullable.of(responseResourceBody));
-					}
-					copyDocument(operationResponse, response.getDocument(), false);
-				}
-				responses[orderedOperation.getOrdinal()] = operationResponse;
-			}
-			return success;
-		}
-		else {
-			boolean successful = true;
-			for (OrderedOperation orderedOperation : operations) {
-				Operation operation = orderedOperation.getOperation();
-				String path = OperationParameterUtils.parsePath(operation.getPath());
-				Map<String, Set<String>> parameters = OperationParameterUtils.parseParameters(operation.getPath());
-				String method = operation.getOp();
-				Document requestBody = new Document();
-				requestBody.setData(Nullable.of(operation.getValue()));
-
-				Response response = requestDispatcher.dispatchRequest(path, method, parameters, requestBody);
-				boolean success = response.getHttpStatus() < 400;
-
-				OperationResponse operationResponse = new OperationResponse();
-				operationResponse.setStatus(response.getHttpStatus());
-				if (displayOperationResponseOnSuccess || !success) {
-					copyDocument(operationResponse, response.getDocument(), true);
-				}
-				responses[orderedOperation.getOrdinal()] = operationResponse;
-
-				successful = successful && operationResponse.getStatus() < 400;
-				if (!successful && !resumeOnError) {
-					return false;
-				}
-			}
-			return successful;
-		}
-
-	}
-
-	private boolean supportsBulk(RegistryEntry rootEntry) {
-		Object implementation = rootEntry.getResourceRepository().getImplementation();
-		boolean supported = implementation instanceof BulkResourceRepository;
-		if (!supported) {
-			Object wrapped = implementation;
-			while (wrapped instanceof Wrapper) {
-				wrapped = ((Wrapper) wrapped).getWrappedObject();
-				PreconditionUtil.verify(!(wrapped instanceof BulkResourceRepository),
-						"non-bulk wrapper " + implementation + " wraps bulk repository " + wrapped + ", fix wrappers to support bulk operations to avoid performance issues");
-			}
-		}
-		return supported;
-	}
-
-	protected void fetchUpToDateResponses(List<OrderedOperation> orderedOperations, OperationResponse[] responses) {
-		RequestDispatcher requestDispatcher = moduleContext.getRequestDispatcher();
-		ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
-
-		// get current set of resources after all the updates have been applied
-		for (OrderedOperation orderedOperation : orderedOperations) {
-			Operation operation = orderedOperation.getOperation();
-			OperationResponse operationResponse = responses[orderedOperation.getOrdinal()];
-
-			boolean isPost = operation.getOp().equalsIgnoreCase(HttpMethod.POST.toString());
-			boolean isPatch = operation.getOp().equalsIgnoreCase(HttpMethod.PATCH.toString());
-			boolean success = operationResponse.getStatus() < 400;
-			if (success && (isPost || isPatch)) {
-				Resource resource = operationResponse.getSingleData().get();
-
-				ResourceInformation resourceInformation = resourceRegistry.getBaseResourceInformation(resource.getType());
-				String path = resourceRegistry.getResourcePath(resourceInformation, resource.getId());
-				String method = HttpMethod.GET.toString();
-
-				Map<String, Set<String>> parameters = new HashMap<>();
-				if (includeChangedRelationships) {
-					parameters.put("include", getLoadedRelationshipNames(resource));
-				}
-
-				Response response =
-						requestDispatcher.dispatchRequest(path, method, parameters, null);
-				copyDocument(operationResponse, response.getDocument(), true);
-				operationResponse.setIncluded(null);
-			}
-		}
-	}
-
-	private Set<String> getLoadedRelationshipNames(Resource resourceBody) {
-		Set<String> result = new HashSet<>();
-		for (Map.Entry<String, Relationship> entry : resourceBody.getRelationships().entrySet()) {
-			if (entry.getValue() != null && entry.getValue().getData() != null) {
-				result.add(entry.getKey());
-			}
-		}
-		return result;
-	}
-
-	private void copyDocument(OperationResponse operationResponse, Document document, boolean copyData) {
-		if (document != null) {
-			if (copyData) {
-				operationResponse.setData(document.getData());
-			}
-			operationResponse.setMeta(document.getMeta());
-			operationResponse.setLinks(document.getLinks());
-			operationResponse.setErrors(document.getErrors());
-			operationResponse.setIncluded(document.getIncluded());
-		}
-	}
-
-	public boolean isResumeOnError() {
-		return resumeOnError;
-	}
-
-	public void setResumeOnError(boolean resumeOnError) {
-		this.resumeOnError = resumeOnError;
-	}
-
-	public boolean isIncludeChangedRelationships() {
-		return includeChangedRelationships;
-	}
-
-	public void setIncludeChangedRelationships(boolean includeChangedRelationships) {
-		this.includeChangedRelationships = includeChangedRelationships;
-	}
-
-	public boolean isDisplayOperationResponseOnSuccess() {
-		return displayOperationResponseOnSuccess;
-	}
-
-	public void setDisplayOperationResponseOnSuccess(boolean displayOperationResponseOnSuccess) {
-		this.displayOperationResponseOnSuccess = displayOperationResponseOnSuccess;
-	}
-
-	protected class DefaultOperationFilterContext implements OperationFilterContext {
-
-		private List<OrderedOperation> orderedOperations;
-
-		DefaultOperationFilterContext(List<OrderedOperation> orderedOperations) {
-			this.orderedOperations = orderedOperations;
-		}
-
-		public List<OrderedOperation> getOrderedOperations() {
-			return orderedOperations;
-		}
-
-		@Override
-		public ServiceDiscovery getServiceDiscovery() {
-			return moduleContext.getServiceDiscovery();
-		}
-	}
-
-	protected class DefaultOperationFilterChain implements OperationFilterChain {
-
-		protected int filterIndex = 0;
-
-		@Override
-		public List<OperationResponse> doFilter(OperationFilterContext context) {
-			List<OperationFilter> filters = getFilters();
-			if (filterIndex == filters.size()) {
-				return executeOperations(context.getOrderedOperations());
-			}
-			else {
-				OperationFilter filter = filters.get(filterIndex);
-				filterIndex++;
-				return filter.filter(context, this);
-			}
-		}
-	}
+    private OperationOrderStrategy orderStrategy = new DependencyOrderStrategy();
+
+    private List<io.crnk.operations.server.OperationFilter> filters = new CopyOnWriteArrayList<>();
+
+    private ModuleContext moduleContext;
+
+    private boolean resumeOnError = false;
+
+    private boolean includeChangedRelationships = true;
+
+    private boolean displayOperationResponseOnSuccess = true;
+
+    private JsonApiRequestProcessorHelper helper;
+
+    public static OperationsModule create() {
+        return new OperationsModule();
+    }
+
+    // protected for CDI
+    protected OperationsModule() {
+    }
+
+    public void addFilter(io.crnk.operations.server.OperationFilter filter) {
+        this.filters.add(filter);
+    }
+
+    public void removeFilter(io.crnk.operations.server.OperationFilter filter) {
+        this.filters.remove(filter);
+    }
+
+    public OperationOrderStrategy getOrderStrategy() {
+        return orderStrategy;
+    }
+
+    public void setOrderStrategy(OperationOrderStrategy orderStrategy) {
+        this.orderStrategy = orderStrategy;
+    }
+
+    public List<io.crnk.operations.server.OperationFilter> getFilters() {
+        return filters;
+    }
+
+    @Override
+    public String getModuleName() {
+        return "operations";
+    }
+
+    @Override
+    public void setupModule(ModuleContext context) {
+        this.moduleContext = context;
+        this.helper = new JsonApiRequestProcessorHelper(context);
+        context.addHttpRequestProcessor(new io.crnk.operations.server.OperationsRequestProcessor(this, context));
+    }
+
+    /**
+     * Applies the given set of operations.
+     *
+     * @return responses
+     */
+    public List<OperationResponse> apply(List<Operation> operations, QueryContext queryContext) {
+        checkAccess(operations, queryContext);
+        enrichTypeIdInformation(operations, queryContext);
+
+        List<OrderedOperation> orderedOperations = orderStrategy.order(operations);
+
+        DefaultOperationFilterChain chain = new DefaultOperationFilterChain();
+        return chain.doFilter(new DefaultOperationFilterContext(orderedOperations, queryContext));
+    }
+
+    /**
+     * This is not strictly necessary, but allows to catch security issues early before accessing the individual repositories
+     */
+    private void checkAccess(List<Operation> operations, QueryContext queryContext) {
+        for (Operation operation : operations) {
+            checkAccess(operation, queryContext);
+        }
+    }
+
+    private void checkAccess(Operation operation, QueryContext queryContext) {
+        HttpMethod httpMethod = HttpMethod.valueOf(operation.getOp());
+
+        String path = OperationParameterUtils.parsePath(operation.getPath());
+        PathBuilder pathBuilder = new PathBuilder(moduleContext.getResourceRegistry(), moduleContext.getTypeParser());
+        JsonPath jsonPath = pathBuilder.build(path, queryContext);
+        if (jsonPath == null) {
+            throw new RepositoryNotFoundException(path);
+        }
+
+        RegistryEntry entry = jsonPath.getRootEntry();
+        ResourceInformation resourceInformation = entry.getResourceInformation();
+
+        ResourceFilterDirectory filterDirectory = moduleContext.getResourceFilterDirectory();
+        FilterBehavior filterBehavior = filterDirectory.get(resourceInformation, httpMethod, queryContext);
+        if (filterBehavior == FilterBehavior.FORBIDDEN) {
+            throw new ForbiddenException(resourceInformation, httpMethod);
+        }
+        if (filterBehavior == FilterBehavior.UNAUTHORIZED) {
+            throw new UnauthorizedException(resourceInformation, httpMethod);
+        }
+    }
+
+    private void enrichTypeIdInformation(List<Operation> operations, QueryContext queryContext) {
+        ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
+        for (Operation operation : operations) {
+            if (operation.getOp().equalsIgnoreCase(HttpMethod.DELETE.toString())) {
+                String path = OperationParameterUtils.parsePath(operation.getPath());
+                PathBuilder pathBuilder = new PathBuilder(resourceRegistry, moduleContext.getTypeParser());
+                JsonPath jsonPath = pathBuilder.build(path, queryContext);
+
+                RegistryEntry entry = jsonPath.getRootEntry();
+                String idString = entry.getResourceInformation().toIdString(jsonPath.getId());
+
+                Resource resource = new Resource();
+                resource.setType(jsonPath.getRootEntry().getResourceInformation().getResourceType());
+                resource.setId(idString);
+                operation.setValue(resource);
+            }
+        }
+    }
+
+    protected void fillinIgnoredOperations(OperationResponse[] responses) {
+        for (int i = 0; i < responses.length; i++) {
+            if (responses[i] == null) {
+                OperationResponse operationResponse = new OperationResponse();
+                operationResponse.setStatus(HttpStatus.PRECONDITION_FAILED_412);
+                responses[i] = operationResponse;
+            }
+        }
+    }
+
+
+    protected PathBuilder getPathBuilder() {
+        ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
+        TypeParser typeParser = moduleContext.getTypeParser();
+        return new PathBuilder(resourceRegistry, typeParser);
+    }
+
+    protected List<OperationResponse> executeOperations(List<OrderedOperation> orderedOperations, QueryContext queryContext) {
+        OperationResponse[] responses = new OperationResponse[orderedOperations.size()];
+        boolean successful = true;
+
+        int index = 0;
+
+        String bulkMethod = null;
+        String bulkType = null;
+        List<OrderedOperation> bulk = new ArrayList<>();
+
+        PathBuilder pathBuilder = getPathBuilder();
+
+
+        while (index < orderedOperations.size()) {
+            OrderedOperation orderedOperation = orderedOperations.get(index);
+            index++;
+
+            Operation operation = orderedOperation.getOperation();
+            String method = operation.getOp();
+            JsonPath path = pathBuilder.build(operation.getPath(), queryContext);
+            orderedOperation.setPath(path);
+            if (path == null) {
+                throw new BadRequestException("invalid path: " + operation.getPath());
+            }
+            String type = path.getRootEntry().getResourceInformation().getResourceType();
+
+            if (!method.equals(bulkMethod) || !type.equals(bulkType)) {
+                if (!bulk.isEmpty()) {
+                    boolean success = bulkExecuteOperations(bulk, responses);
+                    if (!success) {
+                        successful = false;
+                        if (!resumeOnError) {
+                            break;
+                        }
+                    }
+                    bulk.clear();
+                }
+                bulkMethod = method;
+                bulkType = type;
+            }
+
+            bulk.add(orderedOperation);
+        }
+
+        if (!bulk.isEmpty()) {
+            boolean success = bulkExecuteOperations(bulk, responses);
+            if (!success) {
+                successful = false;
+            }
+        }
+
+        if (orderedOperations.size() > 1 && ((!successful && resumeOnError) || (successful && displayOperationResponseOnSuccess))) {
+            fetchUpToDateResponses(orderedOperations, responses);
+        }
+
+        fillinIgnoredOperations(responses);
+        return Arrays.asList(responses);
+    }
+
+    private String getType(Operation operation) {
+        return operation.getValue().getType();
+    }
+
+    private boolean legacySetup;
+
+    private boolean bulkExecuteOperations(List<OrderedOperation> operations, OperationResponse[] responses) {
+        RequestDispatcher requestDispatcher = moduleContext.getRequestDispatcher();
+
+        OrderedOperation firstOperation = operations.get(0);
+
+        RegistryEntry rootEntry = firstOperation.getPath().getRootEntry();
+
+        if (supportsBulk(rootEntry)) {
+            String method = firstOperation.getOperation().getOp();
+
+            JsonPath repositoryPath = new ResourcePath(rootEntry, null);
+
+            PreconditionUtil.verifyEquals(HttpMethod.POST.toString(), method, "experimental bulk support is currently limited to POST");
+
+            Document requestBody = new Document();
+            requestBody.setData(Nullable.of(operations.stream().map(it -> it.getOperation().getValue()).collect(Collectors.toList())));
+
+
+            Map<String, Set<String>> parameters = new HashMap<>();
+            Response response = requestDispatcher.dispatchRequest(repositoryPath.toString(), method, parameters, requestBody);
+
+            boolean success = response.getHttpStatus() < 400;
+            for (int i = 0; i < operations.size(); i++) {
+                OrderedOperation orderedOperation = operations.get(i);
+                OperationResponse operationResponse = new OperationResponse();
+                operationResponse.setStatus(response.getHttpStatus());
+                if (displayOperationResponseOnSuccess || !success) {
+                    if (success) {
+                        List<Resource> collectionData = response.getDocument().getCollectionData().get();
+                        Resource responseResourceBody = collectionData.get(0);
+                        operationResponse.setData(Nullable.of(responseResourceBody));
+                    }
+                    copyDocument(operationResponse, response.getDocument(), false);
+                }
+                responses[orderedOperation.getOrdinal()] = operationResponse;
+            }
+            return success;
+        } else {
+            boolean successful = true;
+            for (OrderedOperation orderedOperation : operations) {
+                Operation operation = orderedOperation.getOperation();
+                String path = OperationParameterUtils.parsePath(operation.getPath());
+                Map<String, Set<String>> parameters = OperationParameterUtils.parseParameters(operation.getPath());
+                String method = operation.getOp();
+                Document requestBody = new Document();
+                requestBody.setData(Nullable.of(operation.getValue()));
+
+                Response response = requestDispatcher.dispatchRequest(path, method, parameters, requestBody);
+                boolean success = response.getHttpStatus() < 400;
+
+                OperationResponse operationResponse = new OperationResponse();
+                operationResponse.setStatus(response.getHttpStatus());
+                if (displayOperationResponseOnSuccess || !success) {
+                    copyDocument(operationResponse, response.getDocument(), true);
+                }
+                responses[orderedOperation.getOrdinal()] = operationResponse;
+
+                successful = successful && operationResponse.getStatus() < 400;
+                if (!successful && !resumeOnError) {
+                    return false;
+                }
+            }
+            return successful;
+        }
+
+    }
+
+    private boolean supportsBulk(RegistryEntry rootEntry) {
+        Object implementation = rootEntry.getResourceRepository().getImplementation();
+        boolean supported = implementation instanceof BulkResourceRepository;
+        if (!supported) {
+            Object wrapped = implementation;
+            while (wrapped instanceof Wrapper) {
+                wrapped = ((Wrapper) wrapped).getWrappedObject();
+                PreconditionUtil.verify(!(wrapped instanceof BulkResourceRepository),
+                        "non-bulk wrapper " + implementation + " wraps bulk repository " + wrapped + ", fix wrappers to support bulk operations to avoid performance issues");
+            }
+        }
+        return supported;
+    }
+
+    protected void fetchUpToDateResponses(List<OrderedOperation> orderedOperations, OperationResponse[] responses) {
+        RequestDispatcher requestDispatcher = moduleContext.getRequestDispatcher();
+        ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
+
+        // get current set of resources after all the updates have been applied
+        for (OrderedOperation orderedOperation : orderedOperations) {
+            Operation operation = orderedOperation.getOperation();
+            OperationResponse operationResponse = responses[orderedOperation.getOrdinal()];
+
+            boolean isPost = operation.getOp().equalsIgnoreCase(HttpMethod.POST.toString());
+            boolean isPatch = operation.getOp().equalsIgnoreCase(HttpMethod.PATCH.toString());
+            boolean success = operationResponse.getStatus() < 400;
+            if (success && (isPost || isPatch)) {
+                Resource resource = operationResponse.getSingleData().get();
+
+                ResourceInformation resourceInformation = resourceRegistry.getBaseResourceInformation(resource.getType());
+                String path = resourceRegistry.getResourcePath(resourceInformation, resource.getId());
+                String method = HttpMethod.GET.toString();
+
+                Map<String, Set<String>> parameters = new HashMap<>();
+                if (includeChangedRelationships) {
+                    parameters.put("include", getLoadedRelationshipNames(resource));
+                }
+
+                Response response =
+                        requestDispatcher.dispatchRequest(path, method, parameters, null);
+                copyDocument(operationResponse, response.getDocument(), true);
+                operationResponse.setIncluded(null);
+            }
+        }
+    }
+
+    private Set<String> getLoadedRelationshipNames(Resource resourceBody) {
+        Set<String> result = new HashSet<>();
+        for (Map.Entry<String, Relationship> entry : resourceBody.getRelationships().entrySet()) {
+            if (entry.getValue() != null && entry.getValue().getData() != null) {
+                result.add(entry.getKey());
+            }
+        }
+        return result;
+    }
+
+    private void copyDocument(OperationResponse operationResponse, Document document, boolean copyData) {
+        if (document != null) {
+            if (copyData) {
+                operationResponse.setData(document.getData());
+            }
+            operationResponse.setMeta(document.getMeta());
+            operationResponse.setLinks(document.getLinks());
+            operationResponse.setErrors(document.getErrors());
+            operationResponse.setIncluded(document.getIncluded());
+        }
+    }
+
+    public boolean isResumeOnError() {
+        return resumeOnError;
+    }
+
+    public void setResumeOnError(boolean resumeOnError) {
+        this.resumeOnError = resumeOnError;
+    }
+
+    public boolean isIncludeChangedRelationships() {
+        return includeChangedRelationships;
+    }
+
+    public void setIncludeChangedRelationships(boolean includeChangedRelationships) {
+        this.includeChangedRelationships = includeChangedRelationships;
+    }
+
+    public boolean isDisplayOperationResponseOnSuccess() {
+        return displayOperationResponseOnSuccess;
+    }
+
+    public void setDisplayOperationResponseOnSuccess(boolean displayOperationResponseOnSuccess) {
+        this.displayOperationResponseOnSuccess = displayOperationResponseOnSuccess;
+    }
+
+    protected class DefaultOperationFilterContext implements OperationFilterContext {
+
+        private final QueryContext queryContext;
+
+        private List<OrderedOperation> orderedOperations;
+
+        DefaultOperationFilterContext(List<OrderedOperation> orderedOperations, QueryContext queryContext) {
+            this.orderedOperations = orderedOperations;
+            this.queryContext = queryContext;
+        }
+
+        public List<OrderedOperation> getOrderedOperations() {
+            return orderedOperations;
+        }
+
+        @Override
+        public ServiceDiscovery getServiceDiscovery() {
+            return moduleContext.getServiceDiscovery();
+        }
+
+        @Override
+        public QueryContext getQueryContext() {
+            return queryContext;
+        }
+    }
+
+    protected class DefaultOperationFilterChain implements OperationFilterChain {
+
+        protected int filterIndex = 0;
+
+        @Override
+        public List<OperationResponse> doFilter(OperationFilterContext context) {
+            List<OperationFilter> filters = getFilters();
+            if (filterIndex == filters.size()) {
+                return executeOperations(context.getOrderedOperations(), context.getQueryContext());
+            } else {
+                OperationFilter filter = filters.get(filterIndex);
+                filterIndex++;
+                return filter.filter(context, this);
+            }
+        }
+    }
 }

--- a/crnk-security/src/main/java/io/crnk/security/SecurityModule.java
+++ b/crnk-security/src/main/java/io/crnk/security/SecurityModule.java
@@ -187,10 +187,11 @@ public class SecurityModule implements Module {
     @Override
     public void setupModule(ModuleContext context) {
         this.moduleContext = context;
-        context.addRepositoryFilter(new SecurityRepositoryFilter(this));
-        context.addResourceFilter(new SecurityResourceFilter(this, context));
 
         if (config != null) {
+            context.addRepositoryFilter(new SecurityRepositoryFilter(this));
+            context.addResourceFilter(new SecurityResourceFilter(this, context));
+
             if (config.isExposeRepositories()) {
                 context.addRepository(new RolePermissionRepository(this));
                 context.addRepository(new CallerPermissionRepository(this));

--- a/crnk-setup/crnk-setup-servlet/src/test/java/io/crnk/servlet/ServletModuleTest.java
+++ b/crnk-setup/crnk-setup-servlet/src/test/java/io/crnk/servlet/ServletModuleTest.java
@@ -21,7 +21,7 @@ public class ServletModuleTest {
 	@Test
 	public void testName() {
 		ImmediateResultFactory resultFactory = new ImmediateResultFactory();
-		HttpRequestContextProvider provider = new HttpRequestContextProvider(() -> resultFactory);
+		HttpRequestContextProvider provider = new HttpRequestContextProvider(() -> resultFactory, null);
 		ServletModule module = new ServletModule(provider);
 		Assert.assertEquals("servlet", module.getModuleName());
 	}
@@ -29,10 +29,10 @@ public class ServletModuleTest {
 	@Test
 	public void testSecurityProviderInstalled() {
 		ImmediateResultFactory resultFactory = new ImmediateResultFactory();
-		HttpRequestContextProvider provider = new HttpRequestContextProvider(() -> resultFactory);
-		ServletModule module = new ServletModule(provider);
 
 		CrnkBoot boot = new CrnkBoot();
+		HttpRequestContextProvider provider = new HttpRequestContextProvider(() -> resultFactory, boot.getModuleRegistry());
+		ServletModule module = new ServletModule(provider);
 		boot.addModule(module);
 		boot.boot();
 

--- a/crnk-setup/crnk-setup-spring-boot2/src/main/java/io/crnk/spring/setup/boot/monitor/CrnkWebMvcTagsProvider.java
+++ b/crnk-setup/crnk-setup-spring-boot2/src/main/java/io/crnk/spring/setup/boot/monitor/CrnkWebMvcTagsProvider.java
@@ -9,8 +9,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import io.crnk.core.boot.CrnkBoot;
+import io.crnk.core.engine.http.HttpRequestContext;
 import io.crnk.core.engine.internal.dispatcher.path.JsonPath;
 import io.crnk.core.engine.internal.dispatcher.path.PathBuilder;
+import io.crnk.core.engine.internal.http.HttpRequestContextBaseAdapter;
 import io.crnk.core.engine.internal.utils.UrlUtils;
 import io.crnk.core.engine.parser.TypeParser;
 import io.crnk.servlet.internal.ServletRequestContext;
@@ -71,13 +73,16 @@ public class CrnkWebMvcTagsProvider extends DefaultWebMvcTagsProvider {
 	private Tag uri(final HttpServletRequest request) {
 		if (matchesPrefix(request)) {
 			ServletContext servletContext = request.getServletContext();
-			ServletRequestContext context = new ServletRequestContext(servletContext, request, null, boot.getWebPathPrefix());
+			HttpRequestContext context = new HttpRequestContextBaseAdapter(new ServletRequestContext(servletContext, request, null, boot.getWebPathPrefix()));
+			context.getQueryContext().initializeDefaults(boot.getResourceRegistry());
+
 			String path = context.getPath();
+
 
 			TypeParser typeParser = boot.getModuleRegistry().getTypeParser();
 			PathBuilder pathBuilder = new PathBuilder(boot.getResourceRegistry(), typeParser);
 
-			JsonPath jsonPath = pathBuilder.build(path);
+			JsonPath jsonPath = pathBuilder.build(path, context.getQueryContext());
 			if (jsonPath != null) {
 				URL baseUrl;
 				try {

--- a/crnk-test/src/main/java/io/crnk/test/mock/TestModule.java
+++ b/crnk-test/src/main/java/io/crnk/test/mock/TestModule.java
@@ -5,6 +5,7 @@ import io.crnk.core.repository.InMemoryResourceRepository;
 import io.crnk.test.mock.models.BulkTask;
 import io.crnk.test.mock.models.RelocatedTask;
 import io.crnk.test.mock.models.ResourceIdentifierBasedRelationshipResource;
+import io.crnk.test.mock.models.VersionedTask;
 import io.crnk.test.mock.repository.BulkInMemoryRepository;
 import io.crnk.test.mock.repository.HistoricTaskRepository;
 import io.crnk.test.mock.repository.PrimitiveAttributeRepository;
@@ -27,92 +28,94 @@ import io.crnk.test.mock.repository.nested.RelatedRepository;
 
 public class TestModule implements Module {
 
-	private static ManyNestedRepository manyNestedRepository = new ManyNestedRepository();
+    private static ManyNestedRepository manyNestedRepository = new ManyNestedRepository();
 
-	private static OneNestedRepository oneNestedRepository = new OneNestedRepository();
+    private static OneNestedRepository oneNestedRepository = new OneNestedRepository();
 
-	private static RelatedRepository relatedRepository = new RelatedRepository();
+    private static RelatedRepository relatedRepository = new RelatedRepository();
 
-	private static ParentRepository parentRepository = new ParentRepository();
+    private static ParentRepository parentRepository = new ParentRepository();
 
-	private static NestedManyRelationshipRepository nestedManyRelationshipRepository = new NestedManyRelationshipRepository();
+    private static NestedManyRelationshipRepository nestedManyRelationshipRepository = new NestedManyRelationshipRepository();
 
-	private static NestedOneRelationshipRepository nestedOneRelationshipRepository = new NestedOneRelationshipRepository();
+    private static NestedOneRelationshipRepository nestedOneRelationshipRepository = new NestedOneRelationshipRepository();
 
-	private ProjectRepository projects = new ProjectRepository();
+    private ProjectRepository projects = new ProjectRepository();
 
-	private TaskRepository tasks = new TaskRepository();
+    private TaskRepository tasks = new TaskRepository();
 
-	private boolean extended = true;
+    private boolean extended = true;
 
-	private BulkInMemoryRepository<BulkTask, Object> bulkTasks = new BulkInMemoryRepository<>(BulkTask.class);
+    private BulkInMemoryRepository<BulkTask, Object> bulkTasks = new BulkInMemoryRepository<>(BulkTask.class);
 
-	@Override
-	public String getModuleName() {
-		return "test";
-	}
+    @Override
+    public String getModuleName() {
+        return "test";
+    }
 
-	@Override
-	public void setupModule(ModuleContext context) {
-		context.addRepository(tasks);
-		context.addRepository(projects);
-		context.addRepository(new ScheduleRepositoryImpl());
-		context.addRepository(new TaskSubtypeRepository());
-		context.addRepository(new ProjectToTaskRepository());
-		context.addRepository(new TaskToProjectRepository());
-		context.addRepository(new PrimitiveAttributeRepository());
-		context.addRepository(new RelationIdTestRepository());
-		context.addRepository(new RenamedIdRepository());
-		context.addRepository(new ScheduleStatusRepositoryImpl());
-		context.addRepository(new ReadOnlyTaskRepository());
-		context.addRepository(new HistoricTaskRepository());
-		context.addRepository(new InMemoryResourceRepository<>(RelocatedTask.class));
-		if (extended) {
-			context.addRepository(new InMemoryResourceRepository<>(ResourceIdentifierBasedRelationshipResource.class));
-			context.addRepository(bulkTasks);
-		}
+    @Override
+    public void setupModule(ModuleContext context) {
+        context.addRepository(tasks);
+        context.addRepository(projects);
+        context.addRepository(new ScheduleRepositoryImpl());
+        context.addRepository(new TaskSubtypeRepository());
+        context.addRepository(new ProjectToTaskRepository());
+        context.addRepository(new TaskToProjectRepository());
+        context.addRepository(new PrimitiveAttributeRepository());
+        context.addRepository(new RelationIdTestRepository());
+        context.addRepository(new RenamedIdRepository());
+        context.addRepository(new ScheduleStatusRepositoryImpl());
+        context.addRepository(new ReadOnlyTaskRepository());
+        context.addRepository(new HistoricTaskRepository());
+        context.addRepository(new InMemoryResourceRepository<>(RelocatedTask.class));
+        if (extended) {
+            context.addRepository(new InMemoryResourceRepository<>(ResourceIdentifierBasedRelationshipResource.class));
+            context.addRepository(bulkTasks);
 
-		context.addRepository(manyNestedRepository);
-		context.addRepository(oneNestedRepository);
-		context.addRepository(relatedRepository);
-		context.addRepository(parentRepository);
-		context.addRepository(nestedManyRelationshipRepository);
-		context.addRepository(nestedOneRelationshipRepository);
+            context.addRepository(new InMemoryResourceRepository<>(VersionedTask.class));
+        }
 
-		context.addNamingStrategy(new TestNamingStrategy());
-		context.addExceptionMapper(new TestExceptionMapper());
-	}
+        context.addRepository(manyNestedRepository);
+        context.addRepository(oneNestedRepository);
+        context.addRepository(relatedRepository);
+        context.addRepository(parentRepository);
+        context.addRepository(nestedManyRelationshipRepository);
+        context.addRepository(nestedOneRelationshipRepository);
 
-	/**
-	 * if true will expose the full set of repositories. Some omitted to not over complicate e.g. schema generation
-	 */
-	public TestModule setExtended(boolean extended) {
-		this.extended = extended;
-		return this;
-	}
+        context.addNamingStrategy(new TestNamingStrategy());
+        context.addExceptionMapper(new TestExceptionMapper());
+    }
 
-	public ProjectRepository getProjects() {
-		return projects;
-	}
+    /**
+     * if true will expose the full set of repositories. Some omitted to not over complicate e.g. schema generation
+     */
+    public TestModule setExtended(boolean extended) {
+        this.extended = extended;
+        return this;
+    }
 
-	public TaskRepository getTasks() {
-		return tasks;
-	}
+    public ProjectRepository getProjects() {
+        return projects;
+    }
 
-	public BulkInMemoryRepository<BulkTask, Object> getBulkTasks() {
-		return bulkTasks;
-	}
+    public TaskRepository getTasks() {
+        return tasks;
+    }
 
-	public static void clear() {
-		TaskRepository.clear();
-		ProjectRepository.clear();
-		TaskToProjectRepository.clear();
-		ProjectToTaskRepository.clear();
-		ScheduleRepositoryImpl.clear();
-		RelationIdTestRepository.clear();
+    public BulkInMemoryRepository<BulkTask, Object> getBulkTasks() {
+        return bulkTasks;
+    }
 
-		manyNestedRepository.clear();
-		relatedRepository.clear();
-		parentRepository.clear();
-	}
+    public static void clear() {
+        TaskRepository.clear();
+        ProjectRepository.clear();
+        TaskToProjectRepository.clear();
+        ProjectToTaskRepository.clear();
+        ScheduleRepositoryImpl.clear();
+        RelationIdTestRepository.clear();
+
+        manyNestedRepository.clear();
+        relatedRepository.clear();
+        parentRepository.clear();
+    }
 }

--- a/crnk-test/src/main/java/io/crnk/test/mock/models/VersionedTask.java
+++ b/crnk-test/src/main/java/io/crnk/test/mock/models/VersionedTask.java
@@ -1,0 +1,67 @@
+package io.crnk.test.mock.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.crnk.core.resource.annotations.JsonApiId;
+import io.crnk.core.resource.annotations.JsonApiResource;
+import io.crnk.core.resource.annotations.JsonApiVersion;
+
+// tags::docs[]
+@JsonApiResource(type = "versionedTask")
+@JsonApiVersion(max = 5)
+public class VersionedTask {
+
+    public enum CompletionStatus {
+        DONE,
+        OPEN,
+        IN_PROGRESS
+    }
+
+    @JsonApiId
+    private Long id;
+
+    private String name;
+
+    @JsonApiVersion(min = 1, max = 3)
+    private boolean completed;
+
+    @JsonApiVersion(min = 5)
+    @JsonProperty("completed")
+    private CompletionStatus newCompleted;
+
+// end::docs[]
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public void setCompleted(boolean completed) {
+        this.completed = completed;
+    }
+
+    public CompletionStatus getNewCompleted() {
+        return newCompleted;
+    }
+
+    public void setNewCompleted(CompletionStatus newCompleted) {
+        this.newCompleted = newCompleted;
+    }
+
+    // tags::docs[]
+}
+// end::docs[]

--- a/crnk-ui/src/main/java/io/crnk/ui/UIModule.java
+++ b/crnk-ui/src/main/java/io/crnk/ui/UIModule.java
@@ -111,7 +111,7 @@ public class UIModule implements Module {
 				servicesSupplier = () -> Arrays.asList(new PresentationService("local", null, initMetaModule()));
 			}
 
-			presentationManager = new PresentationManager(servicesSupplier);
+			presentationManager = new PresentationManager(servicesSupplier, context.getModuleRegistry().getHttpRequestContextProvider());
 			config.getPresentationElementFactories().forEach(it -> presentationManager.registerFactory(it));
 
 			explorerRepository = new ExplorerRepository(presentationManager);

--- a/crnk-ui/src/main/java/io/crnk/ui/presentation/PresentationEnvironment.java
+++ b/crnk-ui/src/main/java/io/crnk/ui/presentation/PresentationEnvironment.java
@@ -25,8 +25,18 @@ public class PresentationEnvironment {
 
 	private PresentationService service;
 
+	private int requestVersion;
+
 	public PresentationElement createElement(PresentationEnvironment env) {
 		return manager.createElement(env);
+	}
+
+	public int getRequestVersion() {
+		return requestVersion;
+	}
+
+	public void setRequestVersion(int requestVersion) {
+		this.requestVersion = requestVersion;
 	}
 
 	public MetaElement getElement() {
@@ -99,6 +109,7 @@ public class PresentationEnvironment {
 		duplicate.setAcceptedTypes(acceptedTypes);
 		duplicate.setManager(manager);
 		duplicate.setService(service);
+		duplicate.setRequestVersion(requestVersion);
 		return duplicate;
 	}
 }

--- a/crnk-ui/src/main/java/io/crnk/ui/presentation/factory/DefaultFormFactory.java
+++ b/crnk-ui/src/main/java/io/crnk/ui/presentation/factory/DefaultFormFactory.java
@@ -9,6 +9,7 @@ import io.crnk.meta.model.MetaAttribute;
 import io.crnk.meta.model.MetaDataObject;
 import io.crnk.meta.model.MetaType;
 import io.crnk.meta.model.resource.MetaResource;
+import io.crnk.meta.model.resource.MetaResourceField;
 import io.crnk.ui.presentation.PresentationEnvironment;
 import io.crnk.ui.presentation.PresentationType;
 import io.crnk.ui.presentation.element.FormContainerElement;
@@ -37,7 +38,7 @@ public class DefaultFormFactory implements PresentationElementFactory {
 	private void buildElement(PresentationEnvironment env, FormElements elements, ArrayDeque<MetaAttribute> attributePath) {
 		MetaAttribute lastAttribute = attributePath.getLast();
 		MetaType type = lastAttribute.getType();
-		if (isIgnored(attributePath)) {
+		if (isIgnored(attributePath, env)) {
 			return;
 		}
 
@@ -52,8 +53,7 @@ public class DefaultFormFactory implements PresentationElementFactory {
 					buildElement(env, elements, nestedPath);
 				}
 			}
-		}
-		else {
+		} else {
 			PresentationEnvironment elementEnv = env.clone();
 			elementEnv.setAttributePath(attributePath);
 			elementEnv.setAcceptedTypes(Arrays.asList(PresentationType.FORM_ELEMENT, PresentationType.DISPLAY));
@@ -80,8 +80,8 @@ public class DefaultFormFactory implements PresentationElementFactory {
 		}
 	}
 
-	private boolean isIgnored(ArrayDeque<MetaAttribute> attributePath) {
-		return attributePath.getLast().isVersion();
+	private boolean isIgnored(ArrayDeque<MetaAttribute> attributePath, PresentationEnvironment env) {
+		MetaAttribute last = attributePath.getLast();
+		return last.isVersion() || last instanceof MetaResourceField && !((MetaResourceField) last).getVersionRange().contains(env.getRequestVersion());
 	}
-
 }

--- a/crnk-ui/src/main/java/io/crnk/ui/presentation/factory/DefaultTableElementFactory.java
+++ b/crnk-ui/src/main/java/io/crnk/ui/presentation/factory/DefaultTableElementFactory.java
@@ -9,6 +9,7 @@ import io.crnk.meta.model.MetaAttribute;
 import io.crnk.meta.model.MetaDataObject;
 import io.crnk.meta.model.MetaType;
 import io.crnk.meta.model.resource.MetaResource;
+import io.crnk.meta.model.resource.MetaResourceField;
 import io.crnk.ui.presentation.PresentationEnvironment;
 import io.crnk.ui.presentation.PresentationType;
 import io.crnk.ui.presentation.element.DataTableElement;
@@ -45,11 +46,11 @@ public class DefaultTableElementFactory implements PresentationElementFactory {
 			ArrayDeque<MetaAttribute> attributePath) {
 		MetaAttribute lastAttribute = attributePath.getLast();
 		MetaType type = lastAttribute.getType();
-		if(type == null){
+		if (type == null) {
 			return; // TODO support e.g. from other services
 		}
 
-		if (isIgnored(attributePath) || type.isCollection()) {
+		if (isIgnored(attributePath, env) || type.isCollection()) {
 			return;
 		}
 
@@ -64,8 +65,7 @@ public class DefaultTableElementFactory implements PresentationElementFactory {
 					buildColumn(env, columns, resource, filtersEnabled, sortingEnabled, nestedPath);
 				}
 			}
-		}
-		else {
+		} else {
 			PresentationEnvironment cellEnv = env.clone();
 			cellEnv.setAttributePath(attributePath);
 			cellEnv.setAcceptedTypes(Arrays.asList(PresentationType.CELL, PresentationType.DISPLAY));
@@ -98,8 +98,8 @@ public class DefaultTableElementFactory implements PresentationElementFactory {
 
 	}
 
-	private boolean isIgnored(ArrayDeque<MetaAttribute> attributePath) {
-		return attributePath.getLast().isVersion();
+	private boolean isIgnored(ArrayDeque<MetaAttribute> attributePath, PresentationEnvironment env) {
+		MetaAttribute last = attributePath.getLast();
+		return last.isVersion() || last instanceof MetaResourceField && !((MetaResourceField) last).getVersionRange().contains(env.getRequestVersion());
 	}
-
 }

--- a/crnk-ui/src/test/java/io/crnk/ui/EditorRepositoryTest.java
+++ b/crnk-ui/src/test/java/io/crnk/ui/EditorRepositoryTest.java
@@ -4,6 +4,11 @@ package io.crnk.ui;
 import java.util.Arrays;
 
 import io.crnk.core.boot.CrnkBoot;
+import io.crnk.core.engine.http.HttpRequestContextBase;
+import io.crnk.core.engine.http.HttpRequestContextProvider;
+import io.crnk.core.engine.internal.http.HttpRequestContextBaseAdapter;
+import io.crnk.core.engine.query.QueryContext;
+import io.crnk.core.exception.ResourceNotFoundException;
 import io.crnk.core.module.SimpleModule;
 import io.crnk.core.queryspec.PathSpec;
 import io.crnk.core.queryspec.QuerySpec;
@@ -24,11 +29,14 @@ import io.crnk.ui.presentation.repository.EditorRepository;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class EditorRepositoryTest {
 
 
 	private UIModule uiModule;
+
+	private QueryContext queryContext;
 
 	@Before
 	public void setup() {
@@ -44,6 +52,10 @@ public class EditorRepositoryTest {
 		boot.addModule(new TestModule());
 		boot.boot();
 
+		HttpRequestContextProvider httpRequestContextProvider = boot.getModuleRegistry().getHttpRequestContextProvider();
+		httpRequestContextProvider.onRequestStarted(new HttpRequestContextBaseAdapter(Mockito.mock(HttpRequestContextBase.class)));
+		queryContext = httpRequestContextProvider.getRequestContext().getQueryContext();
+		queryContext.setRequestVersion(2);
 	}
 
 	@Test
@@ -113,4 +125,41 @@ public class EditorRepositoryTest {
 
 	}
 
+
+	@Test(expected = ResourceNotFoundException.class)
+	public void checkResourceVersionOutOfRange() {
+		queryContext.setRequestVersion(0);
+
+		EditorRepository repository = uiModule.getEditorRepository();
+		repository.findOne("local-presentationProject", new QuerySpec(EditorElement.class));
+	}
+
+	@Test
+	public void checkResourceVersionInRange() {
+		queryContext.setRequestVersion(1);
+
+		EditorRepository repository = uiModule.getEditorRepository();
+		EditorElement editor = repository.findOne("local-presentationProject", new QuerySpec(EditorElement.class));
+		Assert.assertNotNull(editor);
+	}
+
+	@Test
+	public void checkFieldVersionOutOfRange() {
+		queryContext.setRequestVersion(1);
+		EditorRepository repository = uiModule.getEditorRepository();
+		EditorElement editor = repository.findOne("local-presentationProject", new QuerySpec(EditorElement.class));
+
+		FormElements elements = editor.getForm().getElements();
+		Assert.assertEquals(Arrays.asList("id", "name", "tasks"), elements.getElementIds());
+	}
+
+	@Test
+	public void checkFieldVersionInRange() {
+		queryContext.setRequestVersion(2);
+		EditorRepository repository = uiModule.getEditorRepository();
+		EditorElement editor = repository.findOne("local-presentationProject", new QuerySpec(EditorElement.class));
+
+		FormElements elements = editor.getForm().getElements();
+		Assert.assertEquals(Arrays.asList("id", "name", "description", "tasks"), elements.getElementIds());
+	}
 }

--- a/crnk-ui/src/test/java/io/crnk/ui/PresentationProject.java
+++ b/crnk-ui/src/test/java/io/crnk/ui/PresentationProject.java
@@ -5,10 +5,12 @@ import java.util.List;
 import io.crnk.core.resource.annotations.JsonApiId;
 import io.crnk.core.resource.annotations.JsonApiRelation;
 import io.crnk.core.resource.annotations.JsonApiResource;
+import io.crnk.core.resource.annotations.JsonApiVersion;
 import io.crnk.ui.presentation.annotation.PresentationFullTextSearchable;
 import io.crnk.ui.presentation.annotation.PresentationLabel;
 
 @JsonApiResource(type = "presentationProject")
+@JsonApiVersion(min = 1)
 public class PresentationProject {
 
 	@JsonApiId
@@ -18,6 +20,7 @@ public class PresentationProject {
 	@PresentationLabel
 	private String name;
 
+	@JsonApiVersion(min = 2)
 	private String description;
 
 	@JsonApiRelation(mappedBy = "project")

--- a/crnk-ui/src/test/java/io/crnk/ui/UIModuleTest.java
+++ b/crnk-ui/src/test/java/io/crnk/ui/UIModuleTest.java
@@ -10,6 +10,7 @@ import io.crnk.core.engine.http.HttpRequestProcessor;
 import io.crnk.core.engine.http.HttpResponse;
 import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.module.Module;
+import io.crnk.core.module.ModuleRegistry;
 import io.crnk.home.HomeModule;
 import io.crnk.test.mock.ClassTestUtils;
 import io.crnk.ui.internal.UIHttpRequestProcessor;
@@ -33,8 +34,12 @@ public class UIModuleTest {
 	@Test
 	public void setup() {
 		UIModule module = UIModule.create(new UIModuleConfig());
+
+		ModuleRegistry moduleRegistry = Mockito.mock(ModuleRegistry.class);
 		Module.ModuleContext context = Mockito.mock(Module.ModuleContext.class);
+		Mockito.when(context.getModuleRegistry()).thenReturn(moduleRegistry);
 		module.setupModule(context);
+
 		Mockito.verify(context, Mockito.times(1)).addHttpRequestProcessor(Mockito.any(HttpRequestProcessor.class));
 	}
 
@@ -68,7 +73,9 @@ public class UIModuleTest {
 		config.setBrowserEnabled(false);
 		UIModule module = new UIModule(config);
 
+		ModuleRegistry moduleRegistry = Mockito.mock(ModuleRegistry.class);
 		Module.ModuleContext context = Mockito.mock(Module.ModuleContext.class);
+		Mockito.when(context.getModuleRegistry()).thenReturn(moduleRegistry);
 		module.setupModule(context);
 
 		Mockito.verify(context, Mockito.times(0)).addHttpRequestProcessor(Mockito.any(HttpRequestProcessor.class));
@@ -80,7 +87,9 @@ public class UIModuleTest {
 		config.setPresentationModelEnabled(false);
 		UIModule module = new UIModule(config);
 
+		ModuleRegistry moduleRegistry = Mockito.mock(ModuleRegistry.class);
 		Module.ModuleContext context = Mockito.mock(Module.ModuleContext.class);
+		Mockito.when(context.getModuleRegistry()).thenReturn(moduleRegistry);
 		module.setupModule(context);
 
 		Mockito.verify(context, Mockito.times(0)).addRepository(Mockito.any());

--- a/crnk-validation/src/main/java/io/crnk/validation/internal/ConstraintViolationExceptionMapper.java
+++ b/crnk-validation/src/main/java/io/crnk/validation/internal/ConstraintViolationExceptionMapper.java
@@ -5,6 +5,8 @@ import io.crnk.core.engine.document.ErrorDataBuilder;
 import io.crnk.core.engine.error.ErrorResponse;
 import io.crnk.core.engine.error.ExceptionMapper;
 import io.crnk.core.engine.error.ExceptionMapperHelper;
+import io.crnk.core.engine.http.HttpRequestContext;
+import io.crnk.core.engine.http.HttpRequestContextProvider;
 import io.crnk.core.engine.http.HttpStatus;
 import io.crnk.core.engine.information.resource.ResourceField;
 import io.crnk.core.engine.information.resource.ResourceFieldAccessor;
@@ -13,6 +15,7 @@ import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.utils.ExceptionUtil;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.engine.internal.utils.PropertyUtils;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.RegistryEntry;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.module.Module.ModuleContext;
@@ -173,9 +176,13 @@ public class ConstraintViolationExceptionMapper implements ExceptionMapper<Const
 
 		StringBuilder message = new StringBuilder();
 
+		HttpRequestContextProvider httpRequestContextProvider = context.getModuleRegistry().getHttpRequestContextProvider();
+		HttpRequestContext requestContext = httpRequestContextProvider.getRequestContext();
+		QueryContext queryContext = requestContext.getQueryContext();
+
 		Iterable<ErrorData> errors = errorResponse.getErrors();
 		for (ErrorData error : errors) {
-			ConstraintViolationImpl violation = ConstraintViolationImpl.fromError(context.getResourceRegistry(), error);
+			ConstraintViolationImpl violation = ConstraintViolationImpl.fromError(context.getResourceRegistry(), error, queryContext);
 			violations.add(violation);
 
 			// TODO cleanup message handling

--- a/crnk-validation/src/test/java/io/crnk/validation/internal/ConstraintViolationImplTest.java
+++ b/crnk-validation/src/test/java/io/crnk/validation/internal/ConstraintViolationImplTest.java
@@ -3,6 +3,7 @@ package io.crnk.validation.internal;
 import io.crnk.core.boot.CrnkBoot;
 import io.crnk.core.engine.document.ErrorData;
 import io.crnk.core.engine.document.ErrorDataBuilder;
+import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.ResourceRegistry;
 import io.crnk.core.module.SimpleModule;
 import io.crnk.validation.ValidationModule;
@@ -27,6 +28,7 @@ public class ConstraintViolationImplTest {
     private CrnkBoot boot;
 
     private ConstraintViolationImpl violation;
+    private QueryContext queryContext = new QueryContext().setRequestVersion(0);
 
     @Before
     public void setup() {
@@ -48,7 +50,7 @@ public class ConstraintViolationImplTest {
 
         ResourceRegistry resourceRegistry = boot.getResourceRegistry();
 
-        violation = ConstraintViolationImpl.fromError(resourceRegistry, errorData);
+        violation = ConstraintViolationImpl.fromError(resourceRegistry, errorData, queryContext);
     }
 
     @Test


### PR DESCRIPTION
Based on accept header content negotiation rather than having the version in URLs to allow for proper linking.

- @JsonApiVersion(min=1,max=3) introduced. Applicable to resources and fields.
- Accept header used to request specified version: Accept=application/json;version=3.
- version url parameter can be used instead of Accept header for ease of use in browser.
- fields and resources are hidden from request if their version range does not match the request version.
- CrnkClient.setVersion(...) introduced.
- Internally version is carried along in QueryContext.requestVersion.
- Implementation is based on already existing ResourceFilter mechanism (and in that regard quite straightforward).
- crnk-meta extended by version range information
- presentation model honors version ranges when serving explorers and editors