### PR TITLE
OpenApi generation complex test gold file incorrect after logical mer…

### DIFF
--- a/crnk-gen/crnk-gen-openapi/src/test/resources/gold/complex.yaml
+++ b/crnk-gen/crnk-gen-openapi/src/test/resources/gold/complex.yaml
@@ -1500,6 +1500,10 @@ components:
       required:
       - type
       type: object
+    NoAccessTaskPostResources:
+      items:
+        $ref: '#/components/schemas/NoAccessTaskPostResource'
+      type: array
     NoAccessTaskResourceAttributes:
       properties:
         attributes:


### PR DESCRIPTION
…ge between adding Bulk Post support and making MetaResourcePartition respect the access properties of JsonApiResource , causing tests to fail

Closes https://github.com/crnk-project/crnk-framework/issues/653