### PR TITLE
QuerySpecs creation with targetResourceType or targetResource Class

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/queryspec/QuerySpec.java
+++ b/crnk-core/src/main/java/io/crnk/core/queryspec/QuerySpec.java
@@ -273,13 +273,13 @@ public class QuerySpec {
     }
 
     public void setNestedSpecs(Collection<QuerySpec> specs) {
-    	this.typeRelatedSpecs.clear();;
+    	this.typeRelatedSpecs.clear();
         this.classRelatedSpecs.clear();
         for (QuerySpec spec : specs) {
-            if (spec.getResourceClass() != null) {
-                classRelatedSpecs.put(spec.getResourceClass(), spec);
-            } else {
+	    if (spec.getResourceType() != null) {
                 typeRelatedSpecs.put(spec.getResourceType(), spec);
+            } else {
+                classRelatedSpecs.put(spec.getResourceClass(), spec);
             }
         }
     }

--- a/crnk-core/src/main/java/io/crnk/core/queryspec/QuerySpec.java
+++ b/crnk-core/src/main/java/io/crnk/core/queryspec/QuerySpec.java
@@ -278,7 +278,8 @@ public class QuerySpec {
         for (QuerySpec spec : specs) {
 	    if (spec.getResourceType() != null) {
                 typeRelatedSpecs.put(spec.getResourceType(), spec);
-            } else {
+            } 
+        if (spec.getResourceClass() != null) {
                 classRelatedSpecs.put(spec.getResourceClass(), spec);
             }
         }

--- a/crnk-core/src/main/java/io/crnk/core/queryspec/QuerySpec.java
+++ b/crnk-core/src/main/java/io/crnk/core/queryspec/QuerySpec.java
@@ -6,6 +6,7 @@ import io.crnk.core.engine.internal.utils.CompareUtils;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
 import io.crnk.core.queryspec.pagingspec.OffsetLimitPagingSpec;
 import io.crnk.core.queryspec.pagingspec.PagingSpec;
+import io.crnk.core.resource.annotations.JsonApiResource;
 import io.crnk.core.resource.list.DefaultResourceList;
 import io.crnk.core.resource.list.ResourceList;
 import io.crnk.core.resource.meta.DefaultPagedMetaInformation;
@@ -45,7 +46,14 @@ public class QuerySpec {
         if (resourceClass != Resource.class) {
             this.resourceClass = resourceClass;
         }
-        this.resourceType = resourceType;
+        if (resourceType == null) {
+			JsonApiResource annotation = resourceClass.getAnnotation(JsonApiResource.class);
+			if (annotation != null) {
+				this.resourceType = annotation.type();
+			}
+		} else {
+			this.resourceType = resourceType;
+		}
         this.pagingSpec = new OffsetLimitPagingSpec();
     }
 

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/QuerySpecTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/QuerySpecTest.java
@@ -72,38 +72,38 @@ public class QuerySpecTest {
         Assert.assertEquals("QuerySpec[resourceType=projects, paging=OffsetLimitPagingSpec[offset=0]]", spec.toString());
 
         spec = new QuerySpec(Project.class);
-        Assert.assertEquals("QuerySpec[resourceClass=io.crnk.core.mock.models.Project, paging=OffsetLimitPagingSpec[offset=0]]",
+        Assert.assertEquals("QuerySpec[resourceClass=io.crnk.core.mock.models.Project, resourceType=projects, paging=OffsetLimitPagingSpec[offset=0]]",
                 spec.toString());
 
         spec.addFilter(new FilterSpec(Arrays.asList("filterAttr"), FilterOperator.EQ, "test"));
         Assert.assertEquals(
-                "QuerySpec[resourceClass=io.crnk.core.mock.models.Project, paging=OffsetLimitPagingSpec[offset=0], "
+                "QuerySpec[resourceClass=io.crnk.core.mock.models.Project, resourceType=projects, paging=OffsetLimitPagingSpec[offset=0], "
                         + "filters=[filterAttr EQ test]]",
                 spec.toString());
 
         spec.addSort(new SortSpec(Arrays.asList("sortAttr"), Direction.ASC));
         Assert.assertEquals(
-                "QuerySpec[resourceClass=io.crnk.core.mock.models.Project, paging=OffsetLimitPagingSpec[offset=0], "
+                "QuerySpec[resourceClass=io.crnk.core.mock.models.Project, resourceType=projects, paging=OffsetLimitPagingSpec[offset=0], "
                         + "filters=[filterAttr EQ test], sort=[sortAttr ASC]]",
                 spec.toString());
 
         spec.includeField(Arrays.asList("includedField"));
         Assert.assertEquals(
-                "QuerySpec[resourceClass=io.crnk.core.mock.models.Project, paging=OffsetLimitPagingSpec[offset=0], "
+                "QuerySpec[resourceClass=io.crnk.core.mock.models.Project, resourceType=projects, paging=OffsetLimitPagingSpec[offset=0], "
                         + "filters=[filterAttr EQ test], sort=[sortAttr ASC], "
                         + "includedFields=[includedField]]",
                 spec.toString());
 
         spec.includeRelation(Arrays.asList("includedRelation"));
         Assert.assertEquals(
-                "QuerySpec[resourceClass=io.crnk.core.mock.models.Project, paging=OffsetLimitPagingSpec[offset=0], "
+                "QuerySpec[resourceClass=io.crnk.core.mock.models.Project, resourceType=projects, paging=OffsetLimitPagingSpec[offset=0], "
                         + "filters=[filterAttr EQ test], sort=[sortAttr ASC], "
                         + "includedFields=[includedField], includedRelations=[includedRelation]]",
                 spec.toString());
 
         spec.setPaging(new OffsetLimitPagingSpec(12L, 13L));
         Assert.assertEquals(
-                "QuerySpec[resourceClass=io.crnk.core.mock.models.Project, paging=OffsetLimitPagingSpec[offset=12, limit=13], "
+                "QuerySpec[resourceClass=io.crnk.core.mock.models.Project, resourceType=projects, paging=OffsetLimitPagingSpec[offset=12, limit=13], "
                         + "filters=[filterAttr EQ test], "
                         + "sort=[sortAttr ASC], includedFields=[includedField], includedRelations=[includedRelation]]",
                 spec.toString());

--- a/crnk-ui/package-lock.json
+++ b/crnk-ui/package-lock.json
@@ -4955,7 +4955,6 @@
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"are-we-there-yet": "1.1.4",
 				"console-control-strings": "1.1.0",
@@ -8393,7 +8392,6 @@
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
 			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"string-width": "1.0.2"
 			},
@@ -8403,7 +8401,6 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -8413,7 +8410,6 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",


### PR DESCRIPTION
Hi @remmeier 
This PR should solve #636 
I've split relatedSpecs between resourceType and resourceClass as you proposed.
I've used a Set to return the relatedSpecs in order to remove duplicates Specs (those who are both related to a resourceType and a resourceClass).
Let me know if it is what you were looking for.
Thx
JB