### PR TITLE
crnk-operations bulk find-one

### DIFF
--- a/crnk-documentation/src/docs/asciidoc/operations.adoc
+++ b/crnk-documentation/src/docs/asciidoc/operations.adoc
@@ -169,10 +169,9 @@ to have `application/json-patch+json`, otherwise the `OperationsModule` will ign
 
 The current limitations of the implementation are:
 
-- So far does not support bulk `GET` operations.
 - Does so far not support bulk update of relationships.
 
-With support for `POST`, `PATCH` and `DELETE` operations the most important building blocks should be in place.
+With support for `GET` (find-one only), `POST`, `PATCH` and `DELETE` operations the most important building blocks should be in place.
 The limitations are expected to be addressed at some point as well, contributions welcomed.
 
 There is experimental support for <<resource_bulk_repository,BulkResourceRepository>>. If multiple changes to the

--- a/crnk-operations/src/main/java/io/crnk/operations/client/OperationsCall.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/client/OperationsCall.java
@@ -57,6 +57,16 @@ public class OperationsCall {
 		queuedOperations.add(queuedOperation);
 	}
 
+	public void add(HttpMethod method, String path) {
+		Operation operation = new Operation();
+		operation.setOp(method.toString());
+		operation.setPath(path);
+
+		QueuedOperation queuedOperation = new QueuedOperation();
+		queuedOperation.operation = operation;
+		queuedOperations.add(queuedOperation);
+	}
+
 	protected String computePath(HttpMethod method, Resource resource) {
 		if (method == HttpMethod.POST) {
 			return resource.getType();

--- a/crnk-operations/src/main/java/io/crnk/operations/server/OperationsModule.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/server/OperationsModule.java
@@ -151,7 +151,7 @@ public class OperationsModule implements Module {
     private void enrichTypeIdInformation(List<Operation> operations, QueryContext queryContext) {
         ResourceRegistry resourceRegistry = moduleContext.getResourceRegistry();
         for (Operation operation : operations) {
-            if (operation.getOp().equalsIgnoreCase(HttpMethod.DELETE.toString())) {
+            if (Arrays.asList(HttpMethod.DELETE.toString(), HttpMethod.GET.toString()).contains(operation.getOp())) {
                 String path = OperationParameterUtils.parsePath(operation.getPath());
                 PathBuilder pathBuilder = new PathBuilder(resourceRegistry, moduleContext.getTypeParser());
                 JsonPath jsonPath = pathBuilder.build(path, queryContext);
@@ -203,12 +203,13 @@ public class OperationsModule implements Module {
 
             Operation operation = orderedOperation.getOperation();
             String method = operation.getOp();
-            JsonPath path = pathBuilder.build(operation.getPath(), queryContext);
-            orderedOperation.setPath(path);
-            if (path == null) {
+            String path = OperationParameterUtils.parsePath(operation.getPath());
+            JsonPath jsonPath = pathBuilder.build(path, queryContext);
+            orderedOperation.setPath(jsonPath);
+            if (jsonPath == null) {
                 throw new BadRequestException("invalid path: " + operation.getPath());
             }
-            String type = path.getRootEntry().getResourceInformation().getResourceType();
+            String type = jsonPath.getRootEntry().getResourceInformation().getResourceType();
 
             if (!method.equals(bulkMethod) || !type.equals(bulkType)) {
                 if (!bulk.isEmpty()) {

--- a/crnk-operations/src/test/java/io/crnk/operations/OperationsDeleteTest.java
+++ b/crnk-operations/src/test/java/io/crnk/operations/OperationsDeleteTest.java
@@ -88,6 +88,33 @@ public class OperationsDeleteTest extends AbstractOperationsTest {
   }
 
   @Test
+  public void checkDeleteByPath() {
+    ResourceRepository<PersonEntity, UUID> personRepo = client.getRepositoryForType(PersonEntity.class);
+
+    PersonEntity person1 = newPerson("1");
+    PersonEntity person2 = newPerson("2");
+
+    OperationsClient operationsClient = new OperationsClient(client);
+    OperationsCall call = operationsClient.createCall();
+    call.add(HttpMethod.POST, person1);
+    call.add(HttpMethod.POST, person2);
+    call.execute();
+
+    QuerySpec querySpecBeforeDelete = new QuerySpec(PersonEntity.class);
+    ResourceList<PersonEntity> personsBeforeDelete = personRepo.findAll(querySpecBeforeDelete);
+    Assert.assertEquals(2, personsBeforeDelete.size());
+
+    call = operationsClient.createCall();
+    call.add(HttpMethod.DELETE, "person/" + person1.getId());
+    call.add(HttpMethod.DELETE, "person/" + person2.getId());
+    call.execute();
+
+    QuerySpec querySpecAfterDelete = new QuerySpec(PersonEntity.class);
+    ResourceList<PersonEntity> personsAfterDelete = personRepo.findAll(querySpecAfterDelete);
+    Assert.assertEquals(0, personsAfterDelete.size());
+  }
+
+  @Test
   public void checkExperimentalBulkDelete() {
     Task task1 = newTask("1");
     Task task2 = newTask("2");

--- a/crnk-operations/src/test/java/io/crnk/operations/OperationsGetTest.java
+++ b/crnk-operations/src/test/java/io/crnk/operations/OperationsGetTest.java
@@ -1,0 +1,80 @@
+package io.crnk.operations;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.UUID;
+
+import javax.persistence.EntityManager;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crnk.core.engine.http.HttpMethod;
+import io.crnk.core.repository.ResourceRepository;
+import io.crnk.operations.client.OperationsCall;
+import io.crnk.operations.client.OperationsClient;
+import io.crnk.operations.model.MovieEntity;
+import io.crnk.operations.model.PersonEntity;
+import io.crnk.spring.jpa.SpringTransactionRunner;
+
+public class OperationsGetTest extends AbstractOperationsTest {
+
+  protected ResourceRepository<MovieEntity, UUID> movieRepo;
+
+  PersonEntity person1;
+  PersonEntity person2;
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    movieRepo = client.getRepositoryForType(MovieEntity.class);
+
+    SpringTransactionRunner transactionRunner = context.getBean(SpringTransactionRunner.class);
+    transactionRunner.doInTransaction(() -> {
+      EntityManager em = context.getBean(EntityManagerProducer.class).getEntityManager();
+
+      person1 = newPerson("P1");
+      em.persist(person1);
+
+      person2 = newPerson("P2");
+      em.persist(person2);
+
+      MovieEntity movie = newMovie("test");
+      em.persist(movie);
+
+      movie.setDirectors(new HashSet<>(Arrays.asList(person1, person2)));
+
+      return null;
+    });
+  }
+
+  @Test
+  public void checkGet() {
+    OperationsClient operationsClient = new OperationsClient(client);
+    OperationsCall call = operationsClient.createCall();
+    call.add(HttpMethod.GET, "person/" + person1.getId());
+    call.add(HttpMethod.GET, "person/" + person2.getId());
+    call.execute();
+
+    Assert.assertEquals("P1", call.getResponse(0).getSingleData().get().getAttributes().get("name").asText());
+    Assert.assertEquals("P2", call.getResponse(1).getSingleData().get().getAttributes().get("name").asText());
+  }
+
+  @Test
+  public void checkGetWithIncludeParam() {
+    OperationsClient operationsClient = new OperationsClient(client);
+    OperationsCall call = operationsClient.createCall();
+    call.add(HttpMethod.GET, "person/" + person1.getId() + "?include=directedMovies");
+    call.add(HttpMethod.GET, "person/" + person2.getId() + "?include=directedMovies");
+    call.execute();
+
+    // directedMovies should have been included:
+    Assert.assertEquals(1, call.getResponse(0).getSingleData().get().getRelationships().get("directedMovies")
+        .getCollectionData().get().size());
+    Assert.assertEquals(1, call.getResponse(1).getSingleData().get().getRelationships().get("directedMovies")
+        .getCollectionData().get().size());
+  }
+
+}


### PR DESCRIPTION
The thing preventing bulk GETs from working was that in OperationsModule the query string wasn't stripped from the path before passing it into the PathBuilder. I fixed this, and also used the existing "enrichTypeIdInformation" method so GET operations don't need to provide the operation's "value" field.

To test this using OperationsCall I added another "add" method which takes the URL path instead of the target resource. This method can be used for GET or DELETE calls which only need a path.

Fixes #662 
