### PR TITLE
Fix incorrect serialization of nested filtering with AND operator

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/queryspec/internal/JsonFilterSpecMapper.java
+++ b/crnk-core/src/main/java/io/crnk/core/queryspec/internal/JsonFilterSpecMapper.java
@@ -101,7 +101,7 @@ public class JsonFilterSpecMapper {
 	}
 
 	public JsonNode serialize(List<FilterSpec> filterSpecs) {
-		return serialize(filterSpecs, FilterOperator.AND);
+		return serialize(filterSpecs, null);
 	}
 
 	private JsonNode serialize(List<FilterSpec> filterSpecs, FilterOperator operator) {
@@ -109,7 +109,12 @@ public class JsonFilterSpecMapper {
 
 		ObjectMapper objectMapper = context.getObjectMapper();
 
-		if (operator == FilterOperator.AND) {
+		// Operators nesting multiple filters: serialize to JSON array
+		if (operator == FilterOperator.AND || operator == FilterOperator.OR) {
+			ArrayNode arrayNode = objectMapper.createArrayNode();
+			filterSpecs.forEach(it -> arrayNode.add(serializeFilter(it)));
+			return arrayNode;
+		} else {
 			ObjectNode objectNode = objectMapper.createObjectNode();
 			for (FilterSpec filterSpec : filterSpecs) {
 				PathSpec path = filterSpec.getPath();
@@ -133,11 +138,6 @@ public class JsonFilterSpecMapper {
 				}
 			}
 			return objectNode;
-		}
-		else {
-			ArrayNode arrayNode = objectMapper.createArrayNode();
-			filterSpecs.stream().forEach(it -> arrayNode.add(serializeFilter(it)));
-			return arrayNode;
 		}
 	}
 

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/JsonFilterSpecMapperTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/JsonFilterSpecMapperTest.java
@@ -2,6 +2,7 @@ package io.crnk.core.queryspec.mapper;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -228,6 +229,32 @@ public class JsonFilterSpecMapperTest {
 		JsonNode serializedJsonNode = mapper.serialize(filterSpecs);
 		checkNodeEquals(jsonNode, serializedJsonNode);
 		Assert.assertFalse(mapper.isNested(filterSpecs));
+	}
+
+	@Test
+	public void filterTwoAttributesOfSameRelationUsingAnd() {
+		final FilterSpec filterSpec = FilterSpec.and(
+				new FilterSpec(PathSpec.of("project.name"), FilterOperator.EQ, "test"),
+				new FilterSpec(PathSpec.of("project.description"), FilterOperator.EQ, "test test")
+		);
+
+		final List<FilterSpec> serializedFilterSpecs = Collections.singletonList(filterSpec);
+		final JsonNode jsonNode = mapper.serialize(serializedFilterSpecs);
+
+		Assert.assertEquals("{\"AND\":[{\"project\":{\"name\":\"test\"}},{\"project\":{\"description\":\"test test\"}}]}", jsonNode.toString());
+	}
+
+	@Test
+	public void filterTwoAttributesOfSameRelationUsingOr() {
+		final FilterSpec filterSpec = FilterSpec.or(
+				new FilterSpec(PathSpec.of("project.name"), FilterOperator.EQ, "test"),
+				new FilterSpec(PathSpec.of("project.description"), FilterOperator.EQ, "test test")
+		);
+
+		final List<FilterSpec> serializedFilterSpecs = Collections.singletonList(filterSpec);
+		final JsonNode jsonNode = mapper.serialize(serializedFilterSpecs);
+
+		Assert.assertEquals("{\"OR\":[{\"project\":{\"name\":\"test\"}},{\"project\":{\"description\":\"test test\"}}]}", jsonNode.toString());
 	}
 
 	private void checkNodeEquals(JsonNode expected, JsonNode actual) throws JsonProcessingException {


### PR DESCRIPTION
Fixes issue #680.

Filters nested under an AND operator are now correctly serialized as a JSON array.