### PR TITLE
Fix incorrect serialization of nested filtering with AND operator

### DIFF
--- a/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/JsonFilterSpecMapperTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/JsonFilterSpecMapperTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -257,6 +258,32 @@ public class JsonFilterSpecMapperTest {
         checkNodeEquals(jsonNode, serializedJsonNode);
         Assert.assertFalse(mapper.isNested(filterSpecs));
     }
+
+	@Test
+	public void filterTwoAttributesOfSameRelationUsingAnd() {
+		final FilterSpec filterSpec = FilterSpec.and(
+				new FilterSpec(PathSpec.of("project.name"), FilterOperator.EQ, "test"),
+				new FilterSpec(PathSpec.of("project.description"), FilterOperator.EQ, "test test")
+		);
+
+		final List<FilterSpec> serializedFilterSpecs = Collections.singletonList(filterSpec);
+		final JsonNode jsonNode = mapper.serialize(resourceInformation, serializedFilterSpecs, queryContext);
+
+		Assert.assertEquals("{\"AND\":[{\"project\":{\"name\":\"test\"}},{\"project\":{\"description\":\"test test\"}}]}", jsonNode.toString());
+	}
+
+	@Test
+	public void filterTwoAttributesOfSameRelationUsingOr() {
+		final FilterSpec filterSpec = FilterSpec.or(
+				new FilterSpec(PathSpec.of("project.name"), FilterOperator.EQ, "test"),
+				new FilterSpec(PathSpec.of("project.description"), FilterOperator.EQ, "test test")
+		);
+
+		final List<FilterSpec> serializedFilterSpecs = Collections.singletonList(filterSpec);
+		final JsonNode jsonNode = mapper.serialize(resourceInformation, serializedFilterSpecs, queryContext);
+
+		Assert.assertEquals("{\"OR\":[{\"project\":{\"name\":\"test\"}},{\"project\":{\"description\":\"test test\"}}]}", jsonNode.toString());
+	}
 
     private void checkNodeEquals(JsonNode expected, JsonNode actual) throws JsonProcessingException {
         String strExpected = objectMapper.writeValueAsString(expected);


### PR DESCRIPTION
Fixes issue #680.

Filters nested under an AND operator are now correctly serialized as a JSON array.