### PR TITLE
Fix transformation of java map to typescript

### DIFF
--- a/crnk-gen/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/model/writer/TSWriter.java
+++ b/crnk-gen/crnk-gen-typescript/src/main/java/io/crnk/gen/typescript/model/writer/TSWriter.java
@@ -180,8 +180,16 @@ public class TSWriter implements TSVisitor {
 
 	@Override
 	public void visit(TSIndexSignatureType element) {
-		builder.append("[key: ");
-		visitReference(element.getKeyType());
+		builder.append("[key");
+		TSType keyType = element.getKeyType();
+		if (keyType instanceof TSEnumType) {
+			builder.append(" in ");
+		} else if (keyType instanceof TSPrimitiveType && ("string".equals(keyType.getName()) || "number".equals(keyType.getName()))) {
+			builder.append(": ");
+		} else {
+			throw new UnsupportedOperationException();
+		}
+		visitReference(keyType);
 		builder.append("]: ");
 		visitReference(element.getValueType());
 	}

--- a/crnk-gen/crnk-gen-typescript/src/test/java/io/crnk/gen/typescript/model/TSWriterTest.java
+++ b/crnk-gen/crnk-gen-typescript/src/test/java/io/crnk/gen/typescript/model/TSWriterTest.java
@@ -5,142 +5,174 @@ import io.crnk.gen.typescript.model.writer.TSWriter;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 
 public class TSWriterTest {
 
-    private TSWriter writer;
+	private TSWriter writer;
 
-    private TSCodeStyle codeStyle;
+	private TSCodeStyle codeStyle;
 
-    @Before
-    public void setup() {
-        codeStyle = new TSCodeStyle();
-        writer = new TSWriter(codeStyle);
-    }
+	@Before
+	public void setup() {
+		codeStyle = new TSCodeStyle();
+		writer = new TSWriter(codeStyle);
+	}
 
-    @Test
-    public void writeArray() {
-        TSArrayType arrayType = new TSArrayType(TSPrimitiveType.STRING);
-        arrayType.accept(writer);
-        Assert.assertEquals("Array<string>", writer.toString());
-    }
+	@Test
+	public void writeArray() {
+		TSArrayType arrayType = new TSArrayType(TSPrimitiveType.STRING);
+		arrayType.accept(writer);
+		Assert.assertEquals("Array<string>", writer.toString());
+	}
 
-    @Test
-    public void writeClassWithSuperType() {
-        TSClassType classSuperType = new TSClassType();
-        classSuperType.setName("Base");
+	@Test
+	public void writeClassWithSuperType() {
+		TSClassType classSuperType = new TSClassType();
+		classSuperType.setName("Base");
 
-        TSClassType classType = new TSClassType();
-        classType.setName("Child");
-        classType.setSuperType(classSuperType);
+		TSClassType classType = new TSClassType();
+		classType.setName("Child");
+		classType.setSuperType(classSuperType);
 
-        classType.accept(writer);
-        Assert.assertEquals("\nclass Child extends Base {\n}", writer.toString());
-    }
+		classType.accept(writer);
+		Assert.assertEquals("\nclass Child extends Base {\n}", writer.toString());
+	}
 
-    @Test
-    public void writeEnum() {
-        TSEnumType enumType = new TSEnumType();
-        enumType.setName("TestEnum");
-        enumType.getLiterals().add(new TSEnumLiteral("TEST_LITERAL_1"));
-        enumType.getLiterals().add(new TSEnumLiteral("TEST_LITERAL_2"));
+	@Test
+	public void writeEnum() {
+		TSEnumType enumType = new TSEnumType();
+		enumType.setName("TestEnum");
+		enumType.getLiterals().add(new TSEnumLiteral("TEST_LITERAL_1"));
+		enumType.getLiterals().add(new TSEnumLiteral("TEST_LITERAL_2"));
 
-        enumType.accept(writer);
-        Assert.assertEquals("\nenum TestEnum {\n" +
-                "\tTEST_LITERAL_1 = 'TEST_LITERAL_1',\n" +
-                "\tTEST_LITERAL_2 = 'TEST_LITERAL_2',\n" +
-                "}", writer.toString());
-    }
+		enumType.accept(writer);
+		Assert.assertEquals("\nenum TestEnum {\n" +
+				"\tTEST_LITERAL_1 = 'TEST_LITERAL_1',\n" +
+				"\tTEST_LITERAL_2 = 'TEST_LITERAL_2',\n" +
+				"}", writer.toString());
+	}
 
-    @Test
-    public void writeEnumLegacy() {
-        codeStyle.setStringEnums(false);
-        TSEnumType enumType = new TSEnumType();
-        enumType.setName("TestEnum");
-        enumType.getLiterals().add(new TSEnumLiteral("TEST_LITERAL_1"));
-        enumType.getLiterals().add(new TSEnumLiteral("TEST_LITERAL_2"));
+	@Test
+	public void writeEnumLegacy() {
+		codeStyle.setStringEnums(false);
+		TSEnumType enumType = new TSEnumType();
+		enumType.setName("TestEnum");
+		enumType.getLiterals().add(new TSEnumLiteral("TEST_LITERAL_1"));
+		enumType.getLiterals().add(new TSEnumLiteral("TEST_LITERAL_2"));
 
-        enumType.accept(writer);
-        Assert.assertEquals("\ntype TestEnum = 'TEST_LITERAL_1' | 'TEST_LITERAL_2';", writer.toString());
-    }
+		enumType.accept(writer);
+		Assert.assertEquals("\ntype TestEnum = 'TEST_LITERAL_1' | 'TEST_LITERAL_2';", writer.toString());
+	}
 
-    @Test
-    public void writePrimitiveType() {
-        TSPrimitiveType.STRING.accept(writer);
-        Assert.assertEquals("string", writer.toString());
-    }
+	@Test
+	public void writePrimitiveType() {
+		TSPrimitiveType.STRING.accept(writer);
+		Assert.assertEquals("string", writer.toString());
+	}
 
-    @Test
-    public void writeAnyType() {
-        TSAny.INSTANCE.accept(writer);
-        Assert.assertEquals("any", writer.toString());
-    }
+	@Test
+	public void writeAnyType() {
+		TSAny.INSTANCE.accept(writer);
+		Assert.assertEquals("any", writer.toString());
+	}
 
-    @Test
-    public void writeClassWithImplements() {
-        TSInterfaceType interfaceType = new TSInterfaceType();
-        interfaceType.setName("SomeInterface");
+	@Test
+	public void writeClassWithImplements() {
+		TSInterfaceType interfaceType = new TSInterfaceType();
+		interfaceType.setName("SomeInterface");
 
-        TSClassType classType = new TSClassType();
-        classType.setName("SomeClass");
-        classType.addImplementedInterface(interfaceType);
+		TSClassType classType = new TSClassType();
+		classType.setName("SomeClass");
+		classType.addImplementedInterface(interfaceType);
 
-        classType.accept(writer);
-        Assert.assertEquals("\nclass SomeClass implements SomeInterface {\n}", writer.toString());
-    }
+		classType.accept(writer);
+		Assert.assertEquals("\nclass SomeClass implements SomeInterface {\n}", writer.toString());
+	}
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void writeMemberNotSupported() {
-        // must visit subtypes directly
-        TSMember member = Mockito.mock(TSMember.class);
-        writer.visit(member);
-    }
+	@Test
+	public void writeMemberNotSupported() {
+		// must visit subtypes directly
+		TSMember member = Mockito.mock(TSMember.class);
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> writer.visit(member));
+	}
 
-    @Test
-    public void writeClassWithIndex() {
-        TSIndexSignatureType indexSignature = new TSIndexSignatureType();
-        indexSignature.setKeyType(TSPrimitiveType.STRING);
-        indexSignature.setValueType(TSPrimitiveType.NUMBER);
+	@Test
+	public void writeClassWithIndex() {
+		TSIndexSignatureType indexSignature = new TSIndexSignatureType();
+		indexSignature.setKeyType(TSPrimitiveType.STRING);
+		indexSignature.setValueType(TSPrimitiveType.NUMBER);
 
-        TSClassType classType = new TSClassType();
-        classType.setName("Child");
-        classType.setIndexSignature(indexSignature);
+		TSClassType classType = new TSClassType();
+		classType.setName("Child");
+		classType.setIndexSignature(indexSignature);
 
-        classType.accept(writer);
-        Assert.assertEquals("\nclass Child {\n"
-                + "\t[key: string]: number;\n"
-                + "}", writer.toString());
-    }
+		classType.accept(writer);
+		Assert.assertEquals("\nclass Child {\n"
+				+ "\t[key: string]: number;\n"
+				+ "}", writer.toString());
+	}
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void writeParameterizedType() {
-        TSParameterizedType type = new TSParameterizedType(null);
-        type.accept(writer);
-    }
+	@Test
+	public void writeClassWithEnumIndex() {
+		TSIndexSignatureType indexSignature = new TSIndexSignatureType();
+		TSEnumType enumKeyType = new TSEnumType();
+		enumKeyType.setName("SampleEnum");
+		indexSignature.setKeyType(enumKeyType);
+		indexSignature.setValueType(TSPrimitiveType.NUMBER);
 
-    @Test
-    public void writeExport() {
-        TSExport export = new TSExport();
+		TSClassType classType = new TSClassType();
+		classType.setName("Child");
+		classType.setIndexSignature(indexSignature);
 
-        export.setAny(false);
-        export.setPath("@test");
-        export.addTypeName("a");
-        export.addTypeName("b");
+		classType.accept(writer);
+		Assert.assertEquals("\nclass Child {\n"
+				+ "\t[key in SampleEnum]: number;\n"
+				+ "}", writer.toString());
+	}
 
-        export.accept(writer);
-        Assert.assertEquals("export {a, b} from '@test';", writer.toString().trim());
-    }
+	@Test
+	public void writeClassWithInvalidAnyIndex() {
+		TSIndexSignatureType indexSignature = new TSIndexSignatureType();
+		indexSignature.setKeyType(TSAny.INSTANCE);
+		indexSignature.setValueType(TSPrimitiveType.NUMBER);
 
-    @Test
-    public void writeAnyExport() {
-        TSExport export = new TSExport();
+		TSClassType classType = new TSClassType();
+		classType.setName("Child");
+		classType.setIndexSignature(indexSignature);
 
-        export.setAny(true);
-        export.setPath("@test");
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> classType.accept(writer));
+	}
 
-        export.accept(writer);
-        Assert.assertEquals("export * from '@test';", writer.toString().trim());
-    }
+	@Test
+	public void writeParameterizedType() {
+		TSParameterizedType type = new TSParameterizedType(null);
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> type.accept(writer));
+	}
+
+	@Test
+	public void writeExport() {
+		TSExport export = new TSExport();
+
+		export.setAny(false);
+		export.setPath("@test");
+		export.addTypeName("a");
+		export.addTypeName("b");
+
+		export.accept(writer);
+		Assert.assertEquals("export {a, b} from '@test';", writer.toString().trim());
+	}
+
+	@Test
+	public void writeAnyExport() {
+		TSExport export = new TSExport();
+
+		export.setAny(true);
+		export.setPath("@test");
+
+		export.accept(writer);
+		Assert.assertEquals("export * from '@test';", writer.toString().trim());
+	}
 
 }

--- a/crnk-gen/crnk-gen-typescript/src/test/resources/expected_primitive_plain_json.ts
+++ b/crnk-gen/crnk-gen-typescript/src/test/resources/expected_primitive_plain_json.ts
@@ -3,7 +3,7 @@ import {
 	OneResult,
 	Resource
 } from './crnk';
-import {ScheduleStatus} from './schedule.status';
+import {TaskStatus} from './task.status';
 
 export interface PrimitiveAttribute extends Resource {
 	stringValue?: string;
@@ -26,8 +26,8 @@ export interface PrimitiveAttribute extends Resource {
 	uuidValue?: string;
 	dateValue?: any;
 	objectValue?: any;
-	mapValueWithEnumKey?: { [key: ScheduleStatus]: string };
-	mapValueWithListValue?: { [key: string]: Array<string> };
+	mapValueWithEnumKey?: { [key in TaskStatus]: string };
+	mapValueWithListValue?: { [key: number]: Array<string> };
 	mapValueWithSetValue?: { [key: string]: Array<string> };
 }
 export interface PrimitiveAttributeResult extends OneResult {

--- a/crnk-test/src/main/java/io/crnk/test/mock/models/PrimitiveAttributeResource.java
+++ b/crnk-test/src/main/java/io/crnk/test/mock/models/PrimitiveAttributeResource.java
@@ -58,9 +58,9 @@ public class PrimitiveAttributeResource {
 
 	private Object objectValue;
 
-	private Map<ScheduleStatus, String> mapValueWithEnumKey;
+	private Map<TaskStatus, String> mapValueWithEnumKey;
 
-	private Map<String, List<String>> mapValueWithListValue;
+	private Map<Long, List<String>> mapValueWithListValue;
 
 	private Map<String, Set<String>> mapValueWithSetValue;
 
@@ -80,19 +80,19 @@ public class PrimitiveAttributeResource {
 		this.mapValueWithSetValue = mapValueWithSetValue;
 	}
 
-	public Map<ScheduleStatus, String> getMapValueWithEnumKey() {
+	public Map<TaskStatus, String> getMapValueWithEnumKey() {
 		return mapValueWithEnumKey;
 	}
 
-	public void setMapValueWithEnumKey(Map<ScheduleStatus, String> mapValueWithEnumKey) {
+	public void setMapValueWithEnumKey(Map<TaskStatus, String> mapValueWithEnumKey) {
 		this.mapValueWithEnumKey = mapValueWithEnumKey;
 	}
 
-	public Map<String, List<String>> getMapValueWithListValue() {
+	public Map<Long, List<String>> getMapValueWithListValue() {
 		return mapValueWithListValue;
 	}
 
-	public void setMapValueWithListValue(Map<String, List<String>> mapValueWithListValue) {
+	public void setMapValueWithListValue(Map<Long, List<String>> mapValueWithListValue) {
 		this.mapValueWithListValue = mapValueWithListValue;
 	}
 


### PR DESCRIPTION
Add distinction between string/number, enum and everything else when transforming java map into typescript.

Created unit tests for the new conditions.

Fix for issue [708](https://github.com/crnk-project/crnk-framework/issues/708)