### PR TITLE
JAX-RS integrations webpath prefix handling

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/utils/UrlUtils.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/utils/UrlUtils.java
@@ -13,9 +13,25 @@ public class UrlUtils {
 		}
 	}
 
+	public static String addTrailingSlash(String url) {
+		if (url != null && !url.endsWith("/")) {
+			return url + "/";
+		} else {
+			return url;
+		}
+	}
+
 	public static String removeLeadingSlash(String url) {
 		if (url != null && url.startsWith("/")) {
 			return url.substring(1);
+		} else {
+			return url;
+		}
+	}
+
+	public static String addLeadingSlash(String url) {
+		if (url != null && !url.startsWith("/")) {
+			return "/" + url;
 		} else {
 			return url;
 		}

--- a/crnk-setup/crnk-setup-rs/src/main/java/io/crnk/rs/CrnkFilter.java
+++ b/crnk-setup/crnk-setup-rs/src/main/java/io/crnk/rs/CrnkFilter.java
@@ -1,6 +1,7 @@
 package io.crnk.rs;
 
 import io.crnk.core.engine.dispatcher.RequestDispatcher;
+import io.crnk.core.engine.internal.utils.UrlUtils;
 import io.crnk.rs.type.JsonApiMediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,7 +12,6 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.core.Response;
-import java.io.IOException;
 
 /**
  * Handles JSON API requests.
@@ -42,6 +42,12 @@ public class CrnkFilter implements ContainerRequestFilter {
 
 	@Override
 	public void filter(ContainerRequestContext requestContext) {
+		if (feature.getWebPathPrefix() != null) {
+			String path = UrlUtils.removeLeadingSlash(requestContext.getUriInfo().getPath());
+			if (!path.startsWith(UrlUtils.addTrailingSlash(feature.getWebPathPrefix()))) {
+				return;
+			}
+		}
 		try {
 			LOGGER.debug("CrnkFilter entered");
 			JaxrsRequestContext context = new JaxrsRequestContext(requestContext, feature);

--- a/crnk-setup/crnk-setup-rs/src/main/java/io/crnk/rs/JaxrsRequestContext.java
+++ b/crnk-setup/crnk-setup-rs/src/main/java/io/crnk/rs/JaxrsRequestContext.java
@@ -75,7 +75,12 @@ public class JaxrsRequestContext extends DefaultHttpRequestContextBase {
 
 	@Override
 	public String getBaseUrl() {
-		return UrlUtils.removeTrailingSlash(requestContext.getUriInfo().getBaseUri().toString());
+		String baseUrl = requestContext.getUriInfo().getBaseUri().toString();
+		if (feature.getWebPathPrefix() == null) {
+			return UrlUtils.removeTrailingSlash(baseUrl);
+		} else {
+			return UrlUtils.concat(baseUrl, feature.getWebPathPrefix());
+		}
 	}
 
 	@Override
@@ -137,7 +142,7 @@ public class JaxrsRequestContext extends DefaultHttpRequestContextBase {
 	}
 
 	private String buildPath(UriInfo uriInfo) {
-		String basePath = uriInfo.getPath();
+		String basePath = UrlUtils.removeLeadingSlash(uriInfo.getPath());
 		String webPathPrefix = feature.getWebPathPrefix();
 		String path;
 		if (webPathPrefix != null && basePath.startsWith(webPathPrefix)) {

--- a/crnk-setup/crnk-setup-rs/src/test/java/io/crnk/rs/CrnkFilterTest.java
+++ b/crnk-setup/crnk-setup-rs/src/test/java/io/crnk/rs/CrnkFilterTest.java
@@ -6,6 +6,8 @@ import org.mockito.Mockito;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
 import java.io.IOException;
 
 public class CrnkFilterTest {
@@ -39,6 +41,68 @@ public class CrnkFilterTest {
 		} catch (WebApplicationException e) {
 			Assert.assertEquals("test", e.getMessage());
 			Assert.assertNull(e.getCause());
+		}
+	}
+
+	@Test
+	public void checkWebPathPrefixNullFilter() throws IOException {
+		CrnkFeature feature = Mockito.mock(CrnkFeature.class);
+		Mockito.when(feature.getWebPathPrefix()).thenReturn(null);
+		Mockito.when(feature.getBoot()).thenThrow(new WebApplicationException("test"));
+
+		CrnkFilter filter = new CrnkFilter(feature);
+		UriInfo uriInfo = Mockito.mock(UriInfo.class);
+		Mockito.when(uriInfo.getPath()).thenReturn("/tasks");
+		Mockito.when(uriInfo.getQueryParameters()).thenReturn(Mockito.mock(MultivaluedMap.class));
+
+		ContainerRequestContext requestContext = Mockito.mock(ContainerRequestContext.class);
+		Mockito.when(requestContext.getUriInfo()).thenReturn(uriInfo);
+		try {
+			filter.filter(requestContext);
+			Assert.fail();
+		} catch (WebApplicationException e) {
+			Assert.assertEquals("test", e.getMessage());
+		}
+	}
+
+	@Test
+	public void checkWebPathPrefixCorrectFilter() throws IOException {
+		CrnkFeature feature = Mockito.mock(CrnkFeature.class);
+		Mockito.when(feature.getWebPathPrefix()).thenReturn("api");
+		Mockito.when(feature.getBoot()).thenThrow(new WebApplicationException("test"));
+
+		CrnkFilter filter = new CrnkFilter(feature);
+		UriInfo uriInfo = Mockito.mock(UriInfo.class);
+		Mockito.when(uriInfo.getPath()).thenReturn("/api/tasks");
+		Mockito.when(uriInfo.getQueryParameters()).thenReturn(Mockito.mock(MultivaluedMap.class));
+
+		ContainerRequestContext requestContext = Mockito.mock(ContainerRequestContext.class);
+		Mockito.when(requestContext.getUriInfo()).thenReturn(uriInfo);
+		try {
+			filter.filter(requestContext);
+			Assert.fail();
+		} catch (WebApplicationException e) {
+			Assert.assertEquals("test", e.getMessage());
+		}
+	}
+
+	@Test
+	public void checkWebPathPrefixWrongNoFilter() throws IOException {
+		CrnkFeature feature = Mockito.mock(CrnkFeature.class);
+		Mockito.when(feature.getWebPathPrefix()).thenReturn("api");
+		Mockito.when(feature.getBoot()).thenThrow(new WebApplicationException("test"));
+
+		CrnkFilter filter = new CrnkFilter(feature);
+		UriInfo uriInfo = Mockito.mock(UriInfo.class);
+		Mockito.when(uriInfo.getPath()).thenReturn("/api2/tasks");
+		Mockito.when(uriInfo.getQueryParameters()).thenReturn(Mockito.mock(MultivaluedMap.class));
+
+		ContainerRequestContext requestContext = Mockito.mock(ContainerRequestContext.class);
+		Mockito.when(requestContext.getUriInfo()).thenReturn(uriInfo);
+		try {
+			filter.filter(requestContext);
+		} catch (WebApplicationException e) {
+			Assert.fail();
 		}
 	}
 }

--- a/crnk-setup/crnk-setup-rs/src/test/java/io/crnk/rs/JaxrsRequestContextTest.java
+++ b/crnk-setup/crnk-setup-rs/src/test/java/io/crnk/rs/JaxrsRequestContextTest.java
@@ -1,6 +1,7 @@
 package io.crnk.rs;
 
 import java.io.ByteArrayInputStream;
+import java.net.URI;
 import java.util.Arrays;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Configuration;
@@ -12,6 +13,7 @@ import io.crnk.core.engine.http.HttpResponse;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 
 public class JaxrsRequestContextTest {
@@ -60,5 +62,19 @@ public class JaxrsRequestContextTest {
 		Assert.assertTrue(Arrays.equals(copy1, body));
 	}
 
+	@Test
+	public void testGetBaseBath() {
+		Mockito.when(feature.getWebPathPrefix()).thenReturn(null);
+		Mockito.when(uriInfo.getBaseUri()).thenReturn(URI.create("/base"));
 
+		Assert.assertEquals("/base", context.getBaseUrl());;
+	}
+
+	@Test
+	public void testGetBaseBathWithWebpathPrefix() {
+		Mockito.when(feature.getWebPathPrefix()).thenReturn("/api");
+		Mockito.when(uriInfo.getBaseUri()).thenReturn(URI.create("/base"));
+
+		Assert.assertEquals("/base/api", context.getBaseUrl());;
+	}
 }

--- a/crnk-setup/crnk-setup-rs/src/test/java/io/crnk/rs/controller/ControllerTest.java
+++ b/crnk-setup/crnk-setup-rs/src/test/java/io/crnk/rs/controller/ControllerTest.java
@@ -89,7 +89,7 @@ public abstract class ControllerTest extends JerseyTestBase {
 
 	}
 
-	private String getPrefixForPath() {
+	protected String getPrefixForPath() {
 		String prefix = getPrefix();
 		return prefix != null ? prefix + PathBuilder.SEPARATOR : "";
 	}

--- a/crnk-setup/crnk-setup-rs/src/test/java/io/crnk/rs/controller/ControllerWithPrefixTest.java
+++ b/crnk-setup/crnk-setup-rs/src/test/java/io/crnk/rs/controller/ControllerWithPrefixTest.java
@@ -1,14 +1,20 @@
 package io.crnk.rs.controller;
 
 import io.crnk.core.boot.CrnkProperties;
+import io.crnk.core.engine.http.HttpStatus;
 import io.crnk.rs.CrnkFeature;
 import io.crnk.test.mock.TestModule;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.jetty.JettyTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import static io.crnk.rs.type.JsonApiMediaType.APPLICATION_JSON_API_TYPE;
 
 public class ControllerWithPrefixTest extends ControllerTest {
 
@@ -27,6 +33,16 @@ public class ControllerWithPrefixTest extends ControllerTest {
 	@Override
 	protected String getPrefix() {
 		return PREFIX;
+	}
+
+	@Test
+	public void onCallWithoutWebpathPrefix() {
+		//Getting task of id = 10000, simulates error and is throwing an exception we want to check.
+		Response errorResponse = target("tasks")
+				.request(APPLICATION_JSON_API_TYPE)
+				.get();
+
+		assertThat(errorResponse.getStatus()).isEqualTo(HttpStatus.NOT_FOUND_404);
 	}
 
 	@ApplicationPath("/")


### PR DESCRIPTION
Goes with #707.

I kept all the changes inside the jax-rs-setup. Tried to add some tests too, although the CrnkFilterTest ones seem kinda bad. The biggest problem is the leading/trailing slash handling. The uriInfo.getPath() returns a leading slash on Wildfly and no leading slash on Glassfish.