### PR TITLE
Fix OpenAPI generator type field and relationships issues

### DIFF
--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/OASResource.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/OASResource.java
@@ -22,6 +22,7 @@ import io.crnk.gen.openapi.internal.responses.ResourceReferenceResponse;
 import io.crnk.gen.openapi.internal.responses.ResourceReferencesResponse;
 import io.crnk.gen.openapi.internal.responses.ResourceResponse;
 import io.crnk.gen.openapi.internal.responses.ResourcesResponse;
+import io.crnk.gen.openapi.internal.schemas.AbstractSchemaGenerator;
 import io.crnk.gen.openapi.internal.schemas.PatchResource;
 import io.crnk.gen.openapi.internal.schemas.PostResource;
 import io.crnk.gen.openapi.internal.schemas.PostResourceData;
@@ -29,11 +30,15 @@ import io.crnk.gen.openapi.internal.schemas.PostResourceReference;
 import io.crnk.gen.openapi.internal.schemas.PostResources;
 import io.crnk.gen.openapi.internal.schemas.ResourceAttribute;
 import io.crnk.gen.openapi.internal.schemas.ResourceAttributes;
+import io.crnk.gen.openapi.internal.schemas.ResourceLinks;
 import io.crnk.gen.openapi.internal.schemas.ResourcePatchAttributes;
+import io.crnk.gen.openapi.internal.schemas.ResourcePatchRelationships;
 import io.crnk.gen.openapi.internal.schemas.ResourcePostAttributes;
+import io.crnk.gen.openapi.internal.schemas.ResourcePostRelationships;
 import io.crnk.gen.openapi.internal.schemas.ResourceReference;
 import io.crnk.gen.openapi.internal.schemas.ResourceReferenceResponseSchema;
 import io.crnk.gen.openapi.internal.schemas.ResourceReferencesResponseSchema;
+import io.crnk.gen.openapi.internal.schemas.ResourceRelationships;
 import io.crnk.gen.openapi.internal.schemas.ResourceResponseSchema;
 import io.crnk.gen.openapi.internal.schemas.ResourceSchema;
 import io.crnk.gen.openapi.internal.schemas.ResourcesResponseSchema;
@@ -52,152 +57,162 @@ import java.util.stream.Stream;
 
 public class OASResource {
 
-  private MetaResource metaResource;
+	private final MetaResource metaResource;
 
-  private Map<String, Parameter> componentParameters;
+	private Map<String, Parameter> componentParameters;
 
-  private Map<String, Schema> componentSchemas;
+	private Map<String, Schema> componentSchemas;
 
-  private Map<String, ApiResponse> componentResponses;
+	private Map<String, ApiResponse> componentResponses;
 
-  private List<OASOperation> operations;
+	private List<OASOperation> operations;
 
-  OASResource(MetaResource metaResource) {
-    this.metaResource = metaResource;
-    initializeComponentParameters();
-    initializeComponentSchemas();
-    initializeComponentResponses();
-    initializeOperations();
-  }
+	OASResource(MetaResource metaResource) {
+		this.metaResource = metaResource;
+		initializeComponentParameters();
+		initializeComponentSchemas();
+		initializeComponentResponses();
+		initializeOperations();
+	}
 
-  private void initializeComponentParameters() {
-    if (componentParameters != null) {
-      return;
-    }
-    componentParameters = new HashMap<>();
-    componentParameters.put(new PrimaryKey(metaResource).getName(), new PrimaryKey(metaResource).parameter());
-    componentParameters.put(new Fields(metaResource).getName(), new Fields(metaResource).parameter());
-    componentParameters.put(new Include(metaResource).getName(), new Include(metaResource).parameter());
-    componentParameters.put(new Sort(metaResource).getName(), new Sort(metaResource).parameter());
-  }
+	private void initializeComponentParameters() {
+		if (componentParameters != null) {
+			return;
+		}
+		componentParameters = new HashMap<>();
+		componentParameters.put(new PrimaryKey(metaResource).getName(), new PrimaryKey(metaResource).parameter());
+		componentParameters.put(new Fields(metaResource).getName(), new Fields(metaResource).parameter());
+		componentParameters.put(new Include(metaResource).getName(), new Include(metaResource).parameter());
+		componentParameters.put(new Sort(metaResource).getName(), new Sort(metaResource).parameter());
+	}
 
-  private void initializeComponentSchemas() {
-    if (componentSchemas != null) {
-      return;
-    }
-    componentSchemas = OASUtils.attributes(metaResource, true)
-        .map(e -> new ResourceAttribute(metaResource, e))
-        .collect(Collectors.toMap(ResourceAttribute::getName, ResourceAttribute::schema));
+	private void initializeComponentSchemas() {
+		if (componentSchemas != null) {
+			return;
+		}
 
-    componentSchemas.put(new PostResourceReference(metaResource).getName(), new PostResourceReference(metaResource).schema());
-    componentSchemas.put(new ResourceReference(metaResource).getName(), new ResourceReference(metaResource).schema());
-    componentSchemas.put(new ResourceAttributes(metaResource).getName(), new ResourceAttributes(metaResource).schema());
-    componentSchemas.put(new ResourcePostAttributes(metaResource).getName(), new ResourcePostAttributes(metaResource).schema());
-    componentSchemas.put(new ResourcePatchAttributes(metaResource).getName(), new ResourcePatchAttributes(metaResource).schema());
-    componentSchemas.put(new ResourceSchema(metaResource).getName(), new ResourceSchema(metaResource).schema());
-    componentSchemas.put(new PatchResource(metaResource).getName(), new PatchResource(metaResource).schema());
-    componentSchemas.put(new PostResourceData(metaResource).getName(), new PostResourceData(metaResource).schema());
-    componentSchemas.put(new PostResource(metaResource).getName(), new PostResource(metaResource).schema());
-    componentSchemas.put(new PostResources(metaResource).getName(), new PostResources(metaResource).schema());
-    componentSchemas.put(new ResourceResponseSchema(metaResource).getName(), new ResourceResponseSchema(metaResource).schema());
-    componentSchemas.put(new ResourcesResponseSchema(metaResource).getName(), new ResourcesResponseSchema(metaResource).schema());
-    componentSchemas.put(new ResourceReferenceResponseSchema(metaResource).getName(), new ResourceReferenceResponseSchema(metaResource).schema());
-    componentSchemas.put(new ResourceReferencesResponseSchema(metaResource).getName(), new ResourceReferencesResponseSchema(metaResource).schema());
-  }
+		Stream<ResourceAttribute> baseAttributeSchemas = OASUtils.attributes(metaResource, true)
+				.map(e -> new ResourceAttribute(metaResource, e));
 
-  private void initializeComponentResponses() {
-    if (componentResponses != null) {
-      return;
-    }
-    componentResponses = new HashMap<>();
-    componentResponses.put(new ResourceResponse(metaResource).getName(), new ResourceResponse(metaResource).response());
-    componentResponses.put(new ResourcesResponse(metaResource).getName(), new ResourcesResponse(metaResource).response());
-    componentResponses.put(new ResourceReferenceResponse(metaResource).getName(), new ResourceReferenceResponse(metaResource).response());
-    componentResponses.put(new ResourceReferencesResponse(metaResource).getName(), new ResourceReferencesResponse(metaResource).response());
-  }
+		Stream<AbstractSchemaGenerator> resourceSchemas = Stream.of(
+				new PostResourceReference(metaResource),
+				new ResourceReference(metaResource),
+				new ResourceAttributes(metaResource),
+				new ResourceRelationships(metaResource),
+				new ResourceLinks(metaResource),
+				new ResourcePostAttributes(metaResource),
+				new ResourcePostRelationships(metaResource),
+				new ResourcePatchAttributes(metaResource),
+				new ResourcePatchRelationships(metaResource),
+				new ResourceSchema(metaResource),
+				new PatchResource(metaResource),
+				new PostResourceData(metaResource),
+				new PostResource(metaResource),
+				new PostResources(metaResource),
+				new ResourceResponseSchema(metaResource),
+				new ResourcesResponseSchema(metaResource),
+				new ResourceReferenceResponseSchema(metaResource),
+				new ResourceReferencesResponseSchema(metaResource)
+		);
 
-  private void initializeOperations() {
-    if (operations != null) {
-      return;
-    }
-    operations = Stream.of(
-        resourceOperations().stream(),
-        resourcesOperations().stream(),
-        nestedOperations().stream(),
-        relationshipsOperations().stream()
-    )
-        .reduce(Stream::concat)
-        .orElseGet(Stream::empty)
-        .filter(OASOperation::isEnabled)
-        .collect(Collectors.toList());
-  }
+		componentSchemas = Stream.concat(baseAttributeSchemas, resourceSchemas)
+				.filter(AbstractSchemaGenerator::isIncluded)
+				.collect(Collectors.toMap(AbstractSchemaGenerator::getName, AbstractSchemaGenerator::schema));
+	}
 
-  private List<OASOperation> resourceOperations() {
-    List<OASOperation> operations = new ArrayList<>();
-    operations.add(new ResourceGet(metaResource));
-    operations.add(new ResourcePatch(metaResource));
-    operations.add(new ResourceDelete(metaResource));
-    return operations;
-  }
+	private void initializeComponentResponses() {
+		if (componentResponses != null) {
+			return;
+		}
+		componentResponses = new HashMap<>();
+		componentResponses.put(new ResourceResponse(metaResource).getName(), new ResourceResponse(metaResource).response());
+		componentResponses.put(new ResourcesResponse(metaResource).getName(), new ResourcesResponse(metaResource).response());
+		componentResponses.put(new ResourceReferenceResponse(metaResource).getName(), new ResourceReferenceResponse(metaResource).response());
+		componentResponses.put(new ResourceReferencesResponse(metaResource).getName(), new ResourceReferencesResponse(metaResource).response());
+	}
 
-  private List<OASOperation> resourcesOperations() {
-    List<OASOperation> operations = new ArrayList<>();
-    operations.add(new ResourcesGet(metaResource));
-    operations.add(new ResourcesPost(metaResource));
-    return operations;
-  }
+	private void initializeOperations() {
+		if (operations != null) {
+			return;
+		}
+		operations = Stream.of(
+				resourceOperations().stream(),
+				resourcesOperations().stream(),
+				nestedOperations().stream(),
+				relationshipsOperations().stream()
+		)
+				.reduce(Stream::concat)
+				.orElseGet(Stream::empty)
+				.filter(OASOperation::isEnabled)
+				.collect(Collectors.toList());
+	}
 
-  private List<OASOperation> nestedOperations() {
-    MetaResource relatedMetaResource;
-    List<OASOperation> operations = new ArrayList<>();
-    for (MetaResourceField metaResourceField :
-        OASUtils.associationAttributes(metaResource, false)
-            .collect(Collectors.toList())) {
-      relatedMetaResource = (MetaResource) metaResourceField.getType().getElementType();
-      operations.add(new NestedGet(metaResource, metaResourceField, relatedMetaResource));
-      operations.add(new NestedDelete(metaResource, metaResourceField, relatedMetaResource));
-      operations.add(new NestedPatch(metaResource, metaResourceField, relatedMetaResource));
-      operations.add(new NestedPost(metaResource, metaResourceField, relatedMetaResource));
-    }
-    return operations;
-  }
+	private List<OASOperation> resourceOperations() {
+		List<OASOperation> operations = new ArrayList<>();
+		operations.add(new ResourceGet(metaResource));
+		operations.add(new ResourcePatch(metaResource));
+		operations.add(new ResourceDelete(metaResource));
+		return operations;
+	}
 
-  private List<OASOperation> relationshipsOperations() {
-    MetaResource relatedMetaResource;
-    List<OASOperation> operations = new ArrayList<>();
-    for (MetaResourceField metaResourceField :
-        OASUtils.associationAttributes(metaResource, false)
-            .collect(Collectors.toList())) {
-      relatedMetaResource = (MetaResource) metaResourceField.getType().getElementType();
-      operations.add(new RelationshipGet(metaResource, metaResourceField, relatedMetaResource));
-      operations.add(new RelationshipDelete(metaResource, metaResourceField, relatedMetaResource));
-      operations.add(new RelationshipPatch(metaResource, metaResourceField, relatedMetaResource));
-      operations.add(new RelationshipPost(metaResource, metaResourceField, relatedMetaResource));
-    }
-    return operations;
-  }
+	private List<OASOperation> resourcesOperations() {
+		List<OASOperation> operations = new ArrayList<>();
+		operations.add(new ResourcesGet(metaResource));
+		operations.add(new ResourcesPost(metaResource));
+		return operations;
+	}
 
-  Map<String, Parameter> getComponentParameters() {
-    return componentParameters;
-  }
+	private List<OASOperation> nestedOperations() {
+		MetaResource relatedMetaResource;
+		List<OASOperation> operations = new ArrayList<>();
+		for (MetaResourceField metaResourceField :
+				OASUtils.associationAttributes(metaResource, false)
+						.collect(Collectors.toList())) {
+			relatedMetaResource = (MetaResource) metaResourceField.getType().getElementType();
+			operations.add(new NestedGet(metaResource, metaResourceField, relatedMetaResource));
+			operations.add(new NestedDelete(metaResource, metaResourceField, relatedMetaResource));
+			operations.add(new NestedPatch(metaResource, metaResourceField, relatedMetaResource));
+			operations.add(new NestedPost(metaResource, metaResourceField, relatedMetaResource));
+		}
+		return operations;
+	}
 
-  Map<String, Schema> getComponentSchemas() {
-    return componentSchemas;
-  }
+	private List<OASOperation> relationshipsOperations() {
+		MetaResource relatedMetaResource;
+		List<OASOperation> operations = new ArrayList<>();
+		for (MetaResourceField metaResourceField :
+				OASUtils.associationAttributes(metaResource, false)
+						.collect(Collectors.toList())) {
+			relatedMetaResource = (MetaResource) metaResourceField.getType().getElementType();
+			operations.add(new RelationshipGet(metaResource, metaResourceField, relatedMetaResource));
+			operations.add(new RelationshipDelete(metaResource, metaResourceField, relatedMetaResource));
+			operations.add(new RelationshipPatch(metaResource, metaResourceField, relatedMetaResource));
+			operations.add(new RelationshipPost(metaResource, metaResourceField, relatedMetaResource));
+		}
+		return operations;
+	}
 
-  Map<String, ApiResponse> getComponentResponses() {
-    return componentResponses;
-  }
+	Map<String, Parameter> getComponentParameters() {
+		return componentParameters;
+	}
 
-  List<OASOperation> getOperations() {
-    return operations;
-  }
+	Map<String, Schema> getComponentSchemas() {
+		return componentSchemas;
+	}
 
-  String getResourceName() {
-    return metaResource.getName();
-  }
+	Map<String, ApiResponse> getComponentResponses() {
+		return componentResponses;
+	}
 
-  public String getResourceType() {
-    return metaResource.getResourceType();
-  }
+	List<OASOperation> getOperations() {
+		return operations;
+	}
+
+	String getResourceName() {
+		return metaResource.getName();
+	}
+
+	public String getResourceType() {
+		return metaResource.getResourceType();
+	}
 }

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/OASUtils.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/OASUtils.java
@@ -1,6 +1,7 @@
 package io.crnk.gen.openapi.internal;
 
 import io.crnk.core.engine.information.resource.ResourceFieldType;
+import io.crnk.gen.openapi.internal.schemas.AbstractSchemaGenerator;
 import io.crnk.gen.openapi.internal.schemas.ResourceReference;
 import io.crnk.meta.model.MetaArrayType;
 import io.crnk.meta.model.MetaAttribute;
@@ -28,150 +29,176 @@ import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.media.UUIDSchema;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.apache.commons.lang3.Validate.notNull;
 
 public class OASUtils {
 
-  public static Stream<MetaResourceField> attributes(MetaResource metaResource, boolean includePrimaryKey) {
-    return metaResource.getChildren().stream()
-        .filter(not(MetaPrimaryKey.class::isInstance))
-        .map(MetaResourceField.class::cast)
-        .filter(it -> it.getFieldType() != ResourceFieldType.META_INFORMATION && it.getFieldType() != ResourceFieldType.LINKS_INFORMATION)
-        .filter(e -> !e.isPrimaryKeyAttribute() || includePrimaryKey);
-  }
-
-  static Stream<MetaResourceField> associationAttributes(MetaResource metaResource, boolean includePrimaryKey) {
-    return attributes(metaResource, includePrimaryKey).filter(MetaAttribute::isAssociation);
-  }
-
-  public static Stream<MetaResourceField> filterAttributes(MetaResource metaResource, boolean includePrimaryKey) {
-    return attributes(metaResource, includePrimaryKey).filter(MetaAttribute::isFilterable);
-  }
-
-  public static Stream<MetaResourceField> patchAttributes(MetaResource metaResource, boolean includePrimaryKey) {
-    return attributes(metaResource, includePrimaryKey).filter(MetaAttribute::isUpdatable);
-  }
-
-  public static Stream<MetaResourceField> postAttributes(MetaResource metaResource, boolean includePrimaryKey) {
-    return attributes(metaResource, includePrimaryKey).filter(MetaAttribute::isInsertable);
-  }
-
-  public static Stream<MetaResourceField> sortAttributes(MetaResource metaResource, boolean includePrimaryKey) {
-    return attributes(metaResource, includePrimaryKey).filter(MetaAttribute::isSortable);
-  }
-
-  public static MetaResourceField getPrimaryKeyMetaResourceField(MetaResource metaResource) {
-    return metaResource.getChildren().stream()
-        .filter(MetaResourceField.class::isInstance)
-        .filter(e -> ((MetaResourceField) e).isPrimaryKeyAttribute())
-        .map(MetaResourceField.class::cast)
-        .findFirst().get();
-  }
-
-  public static <T> Predicate<T> not(Predicate<T> p) { return o -> !p.test(o); }
-
-  public static Schema transformMetaResourceField(MetaType metaType) {
-  	if(metaType.getImplementationClass() == byte[].class){
-		return new StringSchema();
+	public static Stream<MetaResourceField> attributes(MetaResource metaResource, boolean includePrimaryKey) {
+		return metaResource.getChildren().stream()
+				.filter(not(MetaPrimaryKey.class::isInstance))
+				.map(MetaResourceField.class::cast)
+				.filter(it -> it.getFieldType() != ResourceFieldType.META_INFORMATION && it.getFieldType() != ResourceFieldType.LINKS_INFORMATION)
+				.filter(e -> !e.isPrimaryKeyAttribute() || includePrimaryKey);
 	}
-    if (metaType instanceof MetaResource) {
-      return new ResourceReference((MetaResource) metaType).$ref();
-    } else if (metaType instanceof MetaCollectionType) {
-      return new ArraySchema()
-          .items(transformMetaResourceField(metaType.getElementType()))
-          .uniqueItems(metaType instanceof MetaSetType);
-    } else if (metaType instanceof MetaArrayType) {
-      return new ArraySchema()
-          .items(transformMetaResourceField(metaType.getElementType()))
-          .uniqueItems(false);
-    } else if (metaType instanceof MetaJsonObject) {
-      ObjectSchema objectSchema = new ObjectSchema();
-      for (MetaElement child : metaType.getChildren()) {
-        if (child instanceof MetaAttribute) {
-          MetaAttribute metaAttribute = (MetaAttribute) child;
-          objectSchema.addProperties(child.getName(), transformMetaResourceField(metaAttribute.getType()));
-        }
-      }
-      return objectSchema;
-    } else if (metaType.getName().equals("boolean")) {
-      return new BooleanSchema();
-    } else if (metaType.getName().equals("byte")) {
-      return new ByteArraySchema();
-    } else if (metaType.getName().equals("date")) {
-      return new DateSchema();
-    } else if (metaType.getName().equals("offsetDateTime")) {
-      return new DateTimeSchema();
-    } else if (metaType.getName().equals("localDate")) {
-      return new DateSchema();
-    } else if (metaType.getName().equals("localDateTime")) {
-      return new DateTimeSchema();
-    } else if (metaType.getName().equals("double")) {
-      return new NumberSchema().format("double");
-    } else if (metaType.getName().equals("float")) {
-      return new NumberSchema().format("float");
-    } else if (metaType.getName().equals("integer")) {
-      return new IntegerSchema().format("int32");
-    } else if (metaType.getName().equals("json")) {
-      return new ObjectSchema();
-    } else if (metaType.getName().equals("json.object")) {
-      return new ObjectSchema();
-    } else if (metaType.getName().equals("json.array")) {
-      return new ArraySchema().items(new Schema());
-    } else if (metaType.getName().equals("long")) {
-      return new IntegerSchema().format("int64");
-    } else if (metaType.getName().equals("object")) {
-      return new ObjectSchema();
-    } else if (metaType.getName().equals("short")) {
-      return new IntegerSchema().minimum(BigDecimal.valueOf(Short.MIN_VALUE)).maximum(BigDecimal.valueOf(Short.MAX_VALUE));
-    } else if (metaType.getName().equals("string")) {
-      return new StringSchema();
-    } else if (metaType.getName().equals("uuid")) {
-      return new UUIDSchema();
-    } else if (metaType instanceof MetaMapType) {
-      return new ObjectSchema().additionalProperties(transformMetaResourceField(metaType.getElementType()));
-    } else if (metaType instanceof MetaEnumType) {
-      Schema enumSchema = new StringSchema();
-      for (MetaElement child : metaType.getChildren()) {
-        if (child instanceof MetaLiteral) {
-          enumSchema.addEnumItemObject(child.getName());
-        } else {
-          return new ObjectSchema().additionalProperties(true);
-        }
-      }
-      return enumSchema;
-    } else {
-      return new Schema().type(metaType.getElementType().getName());
-    }
-  }
 
-  public static boolean oneToMany(MetaResourceField metaResourceField) {
-    return metaResourceField.getType().isCollection() || metaResourceField.getType().isMap();
-  }
+	public static Stream<MetaResourceField> notAssociationAttributes(Stream<MetaResourceField> attributes) {
+		return attributes.filter(not(MetaResourceField::isAssociation));
+	}
 
-  public static String getResourcesPath(MetaResource metaResource) {
-    //
-    // TODO: Requires access to CrnkBoot.getWebPathPrefix() and anything that might modify a path
-    // TODO: alternatively, have a config setting for this generator that essentially duplicates the above
-    //
-    return "/" + metaResource.getResourcePath();
-  }
+	public static Stream<MetaResourceField> associationAttributes(Stream<MetaResourceField> attributes) {
+		return attributes.filter(MetaAttribute::isAssociation);
+	}
 
-  public static String getResourcePath(MetaResource metaResource) {
-    StringBuilder keyPath = new StringBuilder(getResourcesPath(metaResource) + "/");
-    for (MetaAttribute metaAttribute : metaResource.getPrimaryKey().getElements()) {
-      keyPath.append("{");
-      keyPath.append(metaAttribute.getName());
-      keyPath.append("}");
-    }
-    return keyPath.toString();
-  }
+	public static Stream<MetaResourceField> notAssociationAttributes(MetaResource metaResource, boolean includePrimaryKey) {
+		return notAssociationAttributes(attributes(metaResource, includePrimaryKey));
+	}
 
-  public static String getNestedPath(MetaResource metaResource, MetaResourceField metaResourceField) {
-    return getResourcePath(metaResource) + "/" + metaResourceField.getName();
-  }
+	public static Stream<MetaResourceField> associationAttributes(MetaResource metaResource, boolean includePrimaryKey) {
+		return associationAttributes(attributes(metaResource, includePrimaryKey));
+	}
 
-  public static String getRelationshipsPath(MetaResource metaResource, MetaResourceField metaResourceField) {
-    return getResourcePath(metaResource) + "/relationships/" + metaResourceField.getName();
-  }
+	public static Stream<MetaResourceField> filterAttributes(MetaResource metaResource, boolean includePrimaryKey) {
+		return attributes(metaResource, includePrimaryKey).filter(MetaAttribute::isFilterable);
+	}
+
+	public static Stream<MetaResourceField> patchAttributes(MetaResource metaResource, boolean includePrimaryKey) {
+		return attributes(metaResource, includePrimaryKey).filter(MetaAttribute::isUpdatable);
+	}
+
+	public static Stream<MetaResourceField> postAttributes(MetaResource metaResource, boolean includePrimaryKey) {
+		return attributes(metaResource, includePrimaryKey).filter(MetaAttribute::isInsertable);
+	}
+
+	public static Stream<MetaResourceField> sortAttributes(MetaResource metaResource, boolean includePrimaryKey) {
+		return attributes(metaResource, includePrimaryKey).filter(MetaAttribute::isSortable);
+	}
+
+	public static MetaResourceField getPrimaryKeyMetaResourceField(MetaResource metaResource) {
+		return metaResource.getChildren().stream()
+				.filter(MetaResourceField.class::isInstance)
+				.filter(e -> ((MetaResourceField) e).isPrimaryKeyAttribute())
+				.map(MetaResourceField.class::cast)
+				.findFirst().get();
+	}
+
+	public static <T> Predicate<T> not(Predicate<T> p) {
+		return o -> !p.test(o);
+	}
+
+	public static Schema transformMetaResourceField(MetaType metaType) {
+		if (metaType.getImplementationClass() == byte[].class) {
+			return new StringSchema();
+		}
+		if (metaType instanceof MetaResource) {
+			return new ResourceReference((MetaResource) metaType).$ref();
+		} else if (metaType instanceof MetaCollectionType) {
+			return new ArraySchema()
+					.items(transformMetaResourceField(metaType.getElementType()))
+					.uniqueItems(metaType instanceof MetaSetType);
+		} else if (metaType instanceof MetaArrayType) {
+			return new ArraySchema()
+					.items(transformMetaResourceField(metaType.getElementType()))
+					.uniqueItems(false);
+		} else if (metaType instanceof MetaJsonObject) {
+			ObjectSchema objectSchema = new ObjectSchema();
+			for (MetaElement child : metaType.getChildren()) {
+				if (child instanceof MetaAttribute) {
+					MetaAttribute metaAttribute = (MetaAttribute) child;
+					objectSchema.addProperties(child.getName(), transformMetaResourceField(metaAttribute.getType()));
+				}
+			}
+			return objectSchema;
+		} else if (metaType.getName().equals("boolean")) {
+			return new BooleanSchema();
+		} else if (metaType.getName().equals("byte")) {
+			return new ByteArraySchema();
+		} else if (metaType.getName().equals("date")) {
+			return new DateSchema();
+		} else if (metaType.getName().equals("offsetDateTime")) {
+			return new DateTimeSchema();
+		} else if (metaType.getName().equals("localDate")) {
+			return new DateSchema();
+		} else if (metaType.getName().equals("localDateTime")) {
+			return new DateTimeSchema();
+		} else if (metaType.getName().equals("double")) {
+			return new NumberSchema().format("double");
+		} else if (metaType.getName().equals("float")) {
+			return new NumberSchema().format("float");
+		} else if (metaType.getName().equals("integer")) {
+			return new IntegerSchema().format("int32");
+		} else if (metaType.getName().equals("json")) {
+			return new ObjectSchema();
+		} else if (metaType.getName().equals("json.object")) {
+			return new ObjectSchema();
+		} else if (metaType.getName().equals("json.array")) {
+			return new ArraySchema().items(new Schema());
+		} else if (metaType.getName().equals("long")) {
+			return new IntegerSchema().format("int64");
+		} else if (metaType.getName().equals("object")) {
+			return new ObjectSchema();
+		} else if (metaType.getName().equals("short")) {
+			return new IntegerSchema().minimum(BigDecimal.valueOf(Short.MIN_VALUE)).maximum(BigDecimal.valueOf(Short.MAX_VALUE));
+		} else if (metaType.getName().equals("string")) {
+			return new StringSchema();
+		} else if (metaType.getName().equals("uuid")) {
+			return new UUIDSchema();
+		} else if (metaType instanceof MetaMapType) {
+			return new ObjectSchema().additionalProperties(transformMetaResourceField(metaType.getElementType()));
+		} else if (metaType instanceof MetaEnumType) {
+			Schema enumSchema = new StringSchema();
+			for (MetaElement child : metaType.getChildren()) {
+				if (child instanceof MetaLiteral) {
+					enumSchema.addEnumItemObject(child.getName());
+				} else {
+					return new ObjectSchema().additionalProperties(true);
+				}
+			}
+			return enumSchema;
+		} else {
+			return new Schema().type(metaType.getElementType().getName());
+		}
+	}
+
+	public static boolean oneToMany(MetaResourceField metaResourceField) {
+		return metaResourceField.getType().isCollection() || metaResourceField.getType().isMap();
+	}
+
+	public static String getResourcesPath(MetaResource metaResource) {
+		//
+		// TODO: Requires access to CrnkBoot.getWebPathPrefix() and anything that might modify a path
+		// TODO: alternatively, have a config setting for this generator that essentially duplicates the above
+		//
+		return "/" + metaResource.getResourcePath();
+	}
+
+	public static String getResourcePath(MetaResource metaResource) {
+		StringBuilder keyPath = new StringBuilder(getResourcesPath(metaResource) + "/");
+		for (MetaAttribute metaAttribute : metaResource.getPrimaryKey().getElements()) {
+			keyPath.append("{");
+			keyPath.append(metaAttribute.getName());
+			keyPath.append("}");
+		}
+		return keyPath.toString();
+	}
+
+	public static String getNestedPath(MetaResource metaResource, MetaResourceField metaResourceField) {
+		return getResourcePath(metaResource) + "/" + metaResourceField.getName();
+	}
+
+	public static String getRelationshipsPath(MetaResource metaResource, MetaResourceField metaResourceField) {
+		return getResourcePath(metaResource) + "/relationships/" + metaResourceField.getName();
+	}
+
+	public static List<Schema> getIncludedSchemaRefs(AbstractSchemaGenerator... schemas) {
+		notNull(schemas, "schemas cannot be null");
+		return Stream.of(schemas)
+				.filter(AbstractSchemaGenerator::isIncluded)
+				.map(AbstractSchemaGenerator::$ref)
+				.collect(Collectors.toList());
+	}
 }

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/AbstractResourceAttributes.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/AbstractResourceAttributes.java
@@ -1,0 +1,35 @@
+package io.crnk.gen.openapi.internal.schemas;
+
+import io.crnk.meta.model.resource.MetaResource;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+
+import java.util.Map;
+
+import static org.apache.commons.lang3.Validate.notEmpty;
+import static org.apache.commons.lang3.Validate.notNull;
+
+abstract class AbstractResourceAttributes extends AbstractSchemaGenerator {
+
+	private final Map<String, Schema> schemaProperties;
+	private final String topLevelName;
+
+	public AbstractResourceAttributes(MetaResource metaResource, String topLevelName, Map<String, Schema> schemaProperties) {
+		super(metaResource);
+		this.schemaProperties = notNull(schemaProperties, "schemaProperties cannot be null");
+		this.topLevelName = notEmpty(topLevelName, "topLevelName cannot be empty");
+	}
+
+	@Override
+	public Schema schema() {
+		return new ObjectSchema().addProperties(topLevelName, new ObjectSchema().properties(schemaProperties));
+	}
+
+	/**
+	 * @return if this schema is included in the final OAS spec
+	 */
+	@Override
+	public boolean isIncluded() {
+		return schemaProperties.size() > 0;
+	}
+}

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/AbstractSchemaGenerator.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/AbstractSchemaGenerator.java
@@ -5,40 +5,46 @@ import io.crnk.meta.model.resource.MetaResource;
 import io.swagger.v3.oas.models.media.Schema;
 import org.apache.commons.lang3.StringUtils;
 
+public abstract class AbstractSchemaGenerator {
 
-abstract class AbstractSchemaGenerator {
+	protected final MetaResource metaResource;
 
-  protected final MetaResource metaResource;
+	protected final MetaAttribute metaAttribute;
 
-  protected final MetaAttribute metaAttribute;
+	private final String prefix;
 
-  private final String prefix;
+	protected AbstractSchemaGenerator() {
+		this.metaResource = null;
+		this.metaAttribute = null;
+		prefix = "";
+	}
 
-  protected AbstractSchemaGenerator() {
-    this.metaResource = null;
-    this.metaAttribute = null;
-    prefix = "";
-  }
+	protected AbstractSchemaGenerator(MetaResource metaResource) {
+		this.metaResource = metaResource;
+		this.metaAttribute = null;
+		prefix = StringUtils.capitalize(metaResource.getResourceType());
+	}
 
-  protected AbstractSchemaGenerator(MetaResource metaResource) {
-    this.metaResource = metaResource;
-    this.metaAttribute = null;
-    prefix = StringUtils.capitalize(metaResource.getResourceType());
-  }
+	protected AbstractSchemaGenerator(MetaResource metaResource, MetaAttribute metaAttribute) {
+		this.metaResource = metaResource;
+		this.metaAttribute = metaAttribute;
+		prefix = StringUtils.capitalize(metaResource.getResourceType()) + StringUtils.capitalize(metaAttribute.getName());
+	}
 
-  protected AbstractSchemaGenerator(MetaResource metaResource, MetaAttribute metaAttribute) {
-    this.metaResource = metaResource;
-    this.metaAttribute = metaAttribute;
-    prefix = StringUtils.capitalize(metaResource.getResourceType()) + StringUtils.capitalize(metaAttribute.getName());
-  }
+	public String getName() {
+		return prefix + getClass().getSimpleName();
+	}
 
-  public String getName() {
-    return prefix + getClass().getSimpleName();
-  }
+	public Schema $ref() {
+		return new Schema().$ref(getName());
+	}
 
-  public Schema $ref() {
-    return new Schema().$ref(getName());
-  }
+	/**
+	 * @return if this schema is included in the final OAS spec
+	 */
+	public boolean isIncluded() {
+		return true;
+	}
 
-  abstract public Schema schema();
+	abstract public Schema schema();
 }

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/PatchResource.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/PatchResource.java
@@ -1,5 +1,6 @@
 package io.crnk.gen.openapi.internal.schemas;
 
+import io.crnk.gen.openapi.internal.OASUtils;
 import io.crnk.meta.model.resource.MetaResource;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.ObjectSchema;
@@ -15,8 +16,11 @@ public class PatchResource extends AbstractSchemaGenerator {
 	public Schema schema() {
 		return new ObjectSchema()
 				.addRequiredItem("data")
-				.addProperties("data", new ComposedSchema()
-						.addAllOfItem(new ResourceReference(metaResource).$ref())
-						.addAllOfItem(new ResourcePatchAttributes(metaResource).$ref()));
+				.addProperties("data", new ComposedSchema().allOf(
+						OASUtils.getIncludedSchemaRefs(
+								new ResourceReference(metaResource),
+								new ResourcePatchAttributes(metaResource),
+								new ResourcePatchRelationships(metaResource)
+						)));
 	}
 }

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/PostResourceData.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/PostResourceData.java
@@ -1,5 +1,6 @@
 package io.crnk.gen.openapi.internal.schemas;
 
+import io.crnk.gen.openapi.internal.OASUtils;
 import io.crnk.meta.model.resource.MetaResource;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
@@ -12,8 +13,11 @@ public class PostResourceData extends AbstractSchemaGenerator {
 
 	@Override
 	public Schema schema() {
-		return new ComposedSchema()
-				.addAllOfItem(new PostResourceReference(metaResource).$ref())
-				.addAllOfItem(new ResourcePostAttributes(metaResource).$ref());
+		return new ComposedSchema().allOf(
+				OASUtils.getIncludedSchemaRefs(
+						new PostResourceReference(metaResource),
+						new ResourcePostAttributes(metaResource),
+						new ResourcePostRelationships(metaResource)
+				));
 	}
 }

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourceAttributes.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourceAttributes.java
@@ -1,32 +1,18 @@
 package io.crnk.gen.openapi.internal.schemas;
 
 import io.crnk.gen.openapi.internal.OASUtils;
-import io.crnk.meta.model.MetaElement;
 import io.crnk.meta.model.resource.MetaResource;
-import io.swagger.v3.oas.models.media.ObjectSchema;
-import io.swagger.v3.oas.models.media.Schema;
+import io.crnk.meta.model.resource.MetaResourceField;
 
-import java.util.Map;
-import java.util.stream.Collectors;
+import static java.util.stream.Collectors.toMap;
 
-public class ResourceAttributes extends AbstractSchemaGenerator {
+public class ResourceAttributes extends AbstractResourceAttributes {
 
-  private final Map<String, Schema> attributes;
-
-  public ResourceAttributes(MetaResource metaResource) {
-    super(metaResource);
-    attributes = OASUtils.attributes(metaResource, false)
-        .collect(
-            Collectors.toMap(
-                MetaElement::getName,
-                e -> new ResourceAttribute(metaResource, e).$ref()));
-  }
-
-  public Schema schema() {
-    return new ObjectSchema()
-        .addProperties(
-            "attributes",
-            new ObjectSchema()
-                .properties(attributes));
-  }
+	public ResourceAttributes(MetaResource metaResource) {
+		super(metaResource, "attributes",
+				OASUtils.notAssociationAttributes(metaResource, false)
+						.collect(toMap(
+								MetaResourceField::getName,
+								e -> new ResourceAttribute(metaResource, e).$ref())));
+	}
 }

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourceLinks.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourceLinks.java
@@ -1,0 +1,26 @@
+package io.crnk.gen.openapi.internal.schemas;
+
+import io.crnk.gen.openapi.internal.OASUtils;
+import io.crnk.meta.model.resource.MetaResource;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+
+public class ResourceLinks extends AbstractSchemaGenerator {
+
+	public ResourceLinks(MetaResource metaResource) {
+		super(metaResource);
+	}
+
+	@Override
+	public Schema schema() {
+		return new ObjectSchema()
+				.description("Links related to the resource")
+				.addProperties("links",
+						new ObjectSchema()
+								.addProperties("self", new StringSchema()
+										._default(OASUtils.getResourcePath(metaResource))
+										.format("uri"))
+								.additionalProperties(new Link().$ref()));
+	}
+}

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourcePatchAttributes.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourcePatchAttributes.java
@@ -1,32 +1,21 @@
 package io.crnk.gen.openapi.internal.schemas;
 
-import io.crnk.gen.openapi.internal.OASUtils;
 import io.crnk.meta.model.MetaElement;
 import io.crnk.meta.model.resource.MetaResource;
-import io.swagger.v3.oas.models.media.ObjectSchema;
-import io.swagger.v3.oas.models.media.Schema;
 
-import java.util.Map;
 import java.util.stream.Collectors;
 
-public class ResourcePatchAttributes extends AbstractSchemaGenerator {
+import static io.crnk.gen.openapi.internal.OASUtils.notAssociationAttributes;
+import static io.crnk.gen.openapi.internal.OASUtils.patchAttributes;
 
-  private final Map<String, Schema> attributes;
+public class ResourcePatchAttributes extends AbstractResourceAttributes {
 
-  public ResourcePatchAttributes(MetaResource metaResource) {
-    super(metaResource);
-    attributes = OASUtils.patchAttributes(metaResource, false)
-        .collect(
-            Collectors.toMap(
-                MetaElement::getName,
-                e -> new ResourceAttribute(metaResource, e).$ref()));
-  }
-
-  public Schema schema() {
-    return new ObjectSchema()
-        .addProperties(
-            "attributes",
-            new ObjectSchema()
-                .properties(attributes));
-  }
+	public ResourcePatchAttributes(MetaResource metaResource) {
+		super(metaResource, "attributes",
+				notAssociationAttributes(patchAttributes(metaResource, false))
+						.collect(
+								Collectors.toMap(
+										MetaElement::getName,
+										e -> new ResourceAttribute(metaResource, e).$ref())));
+	}
 }

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourcePatchRelationships.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourcePatchRelationships.java
@@ -1,0 +1,26 @@
+package io.crnk.gen.openapi.internal.schemas;
+
+import io.crnk.gen.openapi.internal.OASUtils;
+import io.crnk.meta.model.MetaElement;
+import io.crnk.meta.model.resource.MetaResource;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+
+import static io.crnk.gen.openapi.internal.OASUtils.associationAttributes;
+import static io.crnk.gen.openapi.internal.OASUtils.patchAttributes;
+import static java.util.stream.Collectors.toMap;
+
+public class ResourcePatchRelationships extends AbstractResourceAttributes {
+
+	public ResourcePatchRelationships(MetaResource metaResource) {
+		super(metaResource, "relationships",
+				associationAttributes(patchAttributes(metaResource, false))
+						.collect(toMap(
+								MetaElement::getName,
+								e -> new ObjectSchema().addProperties("data", new ComposedSchema()
+										.addOneOfItem(new ArraySchema().items(OASUtils.transformMetaResourceField(e.getType())))
+										.addOneOfItem(OASUtils.transformMetaResourceField(e.getType())))
+						)));
+	}
+}

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourcePostAttributes.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourcePostAttributes.java
@@ -1,32 +1,19 @@
 package io.crnk.gen.openapi.internal.schemas;
 
-import io.crnk.gen.openapi.internal.OASUtils;
 import io.crnk.meta.model.MetaElement;
 import io.crnk.meta.model.resource.MetaResource;
-import io.swagger.v3.oas.models.media.ObjectSchema;
-import io.swagger.v3.oas.models.media.Schema;
 
-import java.util.Map;
-import java.util.stream.Collectors;
+import static io.crnk.gen.openapi.internal.OASUtils.notAssociationAttributes;
+import static io.crnk.gen.openapi.internal.OASUtils.postAttributes;
+import static java.util.stream.Collectors.toMap;
 
-public class ResourcePostAttributes extends AbstractSchemaGenerator {
+public class ResourcePostAttributes extends AbstractResourceAttributes {
 
-  private final Map<String, Schema> attributes;
-
-  public ResourcePostAttributes(MetaResource metaResource) {
-    super(metaResource);
-    attributes = OASUtils.postAttributes(metaResource, false)
-        .collect(
-            Collectors.toMap(
-                MetaElement::getName,
-                e -> new ResourceAttribute(metaResource, e).$ref()));
-  }
-
-  public Schema schema() {
-    return new ObjectSchema()
-        .addProperties(
-            "attributes",
-            new ObjectSchema()
-                .properties(attributes));
-  }
+	public ResourcePostAttributes(MetaResource metaResource) {
+		super(metaResource, "attributes",
+				notAssociationAttributes(postAttributes(metaResource, false))
+						.collect(toMap(
+								MetaElement::getName,
+								e -> new ResourceAttribute(metaResource, e).$ref())));
+	}
 }

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourcePostRelationships.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourcePostRelationships.java
@@ -1,0 +1,26 @@
+package io.crnk.gen.openapi.internal.schemas;
+
+import io.crnk.gen.openapi.internal.OASUtils;
+import io.crnk.meta.model.MetaElement;
+import io.crnk.meta.model.resource.MetaResource;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+
+import static io.crnk.gen.openapi.internal.OASUtils.associationAttributes;
+import static io.crnk.gen.openapi.internal.OASUtils.postAttributes;
+import static java.util.stream.Collectors.toMap;
+
+public class ResourcePostRelationships extends AbstractResourceAttributes {
+
+	public ResourcePostRelationships(MetaResource metaResource) {
+		super(metaResource, "relationships",
+				associationAttributes(postAttributes(metaResource, false))
+						.collect(toMap(
+								MetaElement::getName,
+								e -> new ObjectSchema().addProperties("data", new ComposedSchema()
+										.addOneOfItem(new ArraySchema().items(OASUtils.transformMetaResourceField(e.getType())))
+										.addOneOfItem(OASUtils.transformMetaResourceField(e.getType())))
+						)));
+	}
+}

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourceRelationships.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourceRelationships.java
@@ -1,0 +1,42 @@
+package io.crnk.gen.openapi.internal.schemas;
+
+import io.crnk.gen.openapi.internal.OASUtils;
+import io.crnk.meta.model.resource.MetaResource;
+import io.crnk.meta.model.resource.MetaResourceField;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+
+import static java.util.stream.Collectors.toMap;
+
+public class ResourceRelationships extends AbstractResourceAttributes {
+
+	public ResourceRelationships(MetaResource metaResource) {
+		super(metaResource, "relationships",
+				OASUtils.associationAttributes(metaResource, false)
+				.collect(toMap(
+						MetaResourceField::getName,
+						e -> generateRelationshipSchema(metaResource, e))));
+	}
+
+	private static Schema generateRelationshipSchema(MetaResource metaResource, MetaResourceField field) {
+		return new ObjectSchema()
+				.addProperties("links", new ObjectSchema()
+						.addProperties("self", new StringSchema()
+								._default(OASUtils.getRelationshipsPath(metaResource, field)))
+						.addProperties("related", new StringSchema()
+								._default(OASUtils.getNestedPath(metaResource, field))))
+				.addProperties("data", new ComposedSchema()
+						.addOneOfItem(new ArraySchema().items(OASUtils.transformMetaResourceField(field.getType())))
+						.addOneOfItem(OASUtils.transformMetaResourceField(field.getType()))
+				);
+	}
+
+	@Override
+	public Schema schema() {
+		return super.schema()
+				.description("Relationships between the resource and other JSON:API resources");
+	}
+}

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourceSchema.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/ResourceSchema.java
@@ -1,33 +1,24 @@
 package io.crnk.gen.openapi.internal.schemas;
 
+import io.crnk.gen.openapi.internal.OASUtils;
 import io.crnk.meta.model.resource.MetaResource;
 import io.swagger.v3.oas.models.media.ComposedSchema;
-import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
-
-import java.util.Arrays;
-import java.util.Collections;
 
 public class ResourceSchema extends AbstractSchemaGenerator {
 
-  public ResourceSchema(MetaResource metaResource) {
-    super(metaResource);
-  }
+	public ResourceSchema(MetaResource metaResource) {
+		super(metaResource);
+	}
 
-  public Schema schema() {
-    //Defines a schema for a JSON-API resource, without the enclosing top-level document.
-    return new ComposedSchema()
-        .allOf(
-            Arrays.asList(
-                new ResourceReference(metaResource).$ref(),
-                new ResourceAttributes(metaResource).$ref(),
-                new ObjectSchema()
-                    .addProperties(
-                        "relationships",
-                        new ObjectSchema())
-                    .addProperties(
-                        "links",
-                        new ObjectSchema())))
-        .required(Collections.singletonList("attributes"));
-  }
+	public Schema schema() {
+		//Defines a schema for a JSON-API resource, without the enclosing top-level document.
+		return new ComposedSchema().allOf(
+				OASUtils.getIncludedSchemaRefs(
+						new ResourceReference(metaResource),
+						new ResourceAttributes(metaResource),
+						new ResourceRelationships(metaResource),
+						new ResourceLinks(metaResource)
+				)).addRequiredItem("attributes");
+	}
 }

--- a/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/TypeSchema.java
+++ b/crnk-gen/crnk-gen-openapi/src/main/java/io/crnk/gen/openapi/internal/schemas/TypeSchema.java
@@ -12,8 +12,8 @@ public class TypeSchema extends AbstractSchemaGenerator {
 
   public Schema schema() {
     Schema typeSchema = new StringSchema()
-        .description("The JSON:API resource type (" + metaResource.getName() + ")");
-    typeSchema.addEnumItemObject(metaResource.getName());
+        .description("The JSON:API resource type (" + metaResource.getResourceType() + ")");
+    typeSchema.addEnumItemObject(metaResource.getResourceType());
     return typeSchema;
   }
 }

--- a/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/MetaResourceBaseTest.java
+++ b/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/MetaResourceBaseTest.java
@@ -10,41 +10,53 @@ import java.util.Collections;
 
 public class MetaResourceBaseTest {
 
-  public MetaResource metaResource;
+	public MetaResource metaResource;
 
-  public MetaResourceField metaResourceField;
+	public MetaResourceField metaResourceField;
+	public MetaResourceField additionalMetaResourceField;
+	public MetaResourceField relationshipMetaResourceField;
 
-  @BeforeEach
-  void setUp() {
-    metaResource = getTestMetaResource();
-    metaResourceField = (MetaResourceField) metaResource.getChildren().get(0);
-  }
+	@BeforeEach
+	void setUp() {
+		metaResource = getTestMetaResource();
+		metaResourceField = (MetaResourceField) metaResource.getChildren().get(0);
+	}
 
-  protected MetaResource getTestMetaResource() {
-    MetaResource metaResource = new MetaResource();
-    metaResource.setName("ResourceName");
-    metaResource.setResourceType("ResourceType");
-    metaResource.setResourcePath("ResourcePath");
+	protected MetaResource getTestMetaResource() {
+		MetaResource metaResource = new MetaResource();
+		metaResource.setName("ResourceName");
+		metaResource.setResourceType("ResourceType");
+		metaResource.setResourcePath("ResourcePath");
 
-    // Set up Primary Key
-    MetaPrimaryKey metaPrimaryKey = new MetaPrimaryKey();
-    MetaResourceField metaResourceField = new MetaResourceField();
-    metaResourceField.setName("id");
-    MetaPrimitiveType type = new MetaPrimitiveType();
-    type.setName("string");
-    metaResourceField.setType(type);
-    metaResourceField.setPrimaryKeyAttribute(true);
-    metaPrimaryKey.setElements(Collections.singletonList(metaResourceField));
+		// Set up Primary Key
+		MetaPrimaryKey metaPrimaryKey = new MetaPrimaryKey();
+		MetaResourceField metaResourceField = new MetaResourceField();
+		metaResourceField.setName("id");
+		MetaPrimitiveType type = new MetaPrimitiveType();
+		type.setName("string");
+		metaResourceField.setType(type);
+		metaResourceField.setPrimaryKeyAttribute(true);
+		metaPrimaryKey.setElements(Collections.singletonList(metaResourceField));
 
-    metaResource.setPrimaryKey(metaPrimaryKey);
-    metaResource.addChild(metaResourceField);
+		metaResource.setPrimaryKey(metaPrimaryKey);
+		metaResource.addChild(metaResourceField);
 
-    MetaResourceField additionalMetaResourceField = new MetaResourceField();
-    additionalMetaResourceField.setName("name");
-    additionalMetaResourceField.setType(type);
+		additionalMetaResourceField = new MetaResourceField();
+		additionalMetaResourceField.setName("name");
+		additionalMetaResourceField.setType(type);
+		metaResource.addChild(additionalMetaResourceField);
 
-    metaResource.addChild(additionalMetaResourceField);
+		final MetaResource relatedResource = new MetaResource();
+		relatedResource.setName("RelatedResourceName");
+		relatedResource.setResourceType("RelatedResourceType");
+		relatedResource.setResourcePath("RelatedResourcePath");
+		relatedResource.setElementType(relatedResource);
+		relationshipMetaResourceField = new MetaResourceField();
+		relationshipMetaResourceField.setName("resourceRelation");
+		relationshipMetaResourceField.setType(relatedResource);
+		relationshipMetaResourceField.setAssociation(true);
+		metaResource.addChild(relationshipMetaResourceField);
 
-    return metaResource;
-  }
+		return metaResource;
+	}
 }

--- a/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/parameters/FieldsTest.java
+++ b/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/parameters/FieldsTest.java
@@ -9,15 +9,15 @@ import org.junit.jupiter.api.Test;
 
 class FieldsTest extends MetaResourceBaseTest {
 
-  @Test
-  void parameter() {
-    Parameter parameter = new Fields(metaResource).parameter();
-    Assert.assertEquals("fields", parameter.getName());
-    Assert.assertEquals("query", parameter.getIn());
-    Assert.assertEquals("ResourceType fields to include (csv)", parameter.getDescription());
-    Assert.assertNull(parameter.getRequired());
-    Schema schema = parameter.getSchema();
-    Assert.assertTrue(schema instanceof StringSchema);
-    Assert.assertEquals("id,name", schema.getDefault());  // TODO: Should Primary Key Field(s) be included?
-  }
+	@Test
+	void parameter() {
+		Parameter parameter = new Fields(metaResource).parameter();
+		Assert.assertEquals("fields", parameter.getName());
+		Assert.assertEquals("query", parameter.getIn());
+		Assert.assertEquals("ResourceType fields to include (csv)", parameter.getDescription());
+		Assert.assertNull(parameter.getRequired());
+		Schema schema = parameter.getSchema();
+		Assert.assertTrue(schema instanceof StringSchema);
+		Assert.assertEquals("id,name,resourceRelation", schema.getDefault());  // TODO: Should Primary Key Field(s) be included?
+	}
 }

--- a/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/PatchResourceTest.java
+++ b/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/PatchResourceTest.java
@@ -16,6 +16,7 @@ class PatchResourceTest extends MetaResourceBaseTest {
 
 	@Test
 	void schema() {
+		relationshipMetaResourceField.setUpdatable(true);
 		Schema requestSchema = new PatchResource(metaResource).schema();
 
 		ObjectSchema topLevelSchema = (ObjectSchema) requestSchema;
@@ -25,6 +26,6 @@ class PatchResourceTest extends MetaResourceBaseTest {
 		List<Schema> allOf = ((ComposedSchema) dataSchema).getAllOf();
 		assertEquals(2, allOf.size());
 		assertEquals("#/components/schemas/ResourceTypeResourceReference", allOf.get(0).get$ref());
-		assertEquals("#/components/schemas/ResourceTypeResourcePatchAttributes", allOf.get(1).get$ref());
+		assertEquals("#/components/schemas/ResourceTypeResourcePatchRelationships", allOf.get(1).get$ref());
 	}
 }

--- a/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/PostResourceDataTest.java
+++ b/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/PostResourceDataTest.java
@@ -14,6 +14,7 @@ public class PostResourceDataTest extends MetaResourceBaseTest {
 
 	@Test
 	public void schema() {
+		additionalMetaResourceField.setInsertable(true);
 		final Schema dataSchema = new PostResourceData(metaResource).schema();
 
 		assertNotNull(dataSchema);

--- a/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/ResourceAttributesTest.java
+++ b/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/ResourceAttributesTest.java
@@ -3,27 +3,28 @@ package io.crnk.gen.openapi.internal.schemas;
 import io.crnk.gen.openapi.internal.MetaResourceBaseTest;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+
+import static java.util.Collections.singleton;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class ResourceAttributesTest extends MetaResourceBaseTest {
 
   @Test
   void schema() {
     Schema schema = new ResourceAttributes(metaResource).schema();
-    Assert.assertTrue(schema instanceof ObjectSchema);
 
-    Assert.assertTrue(schema.getProperties().containsKey("attributes"));
-    Assert.assertEquals(1, schema.getProperties().size());
+    assertNotNull(schema);
+    assertEquals(ObjectSchema.class, schema.getClass());
+    assertIterableEquals(singleton("attributes"), schema.getProperties().keySet());
 
-    Schema attributes = (Schema) schema.getProperties().get("attributes");
-    Assert.assertTrue(attributes instanceof ObjectSchema);
-    Assert.assertTrue(attributes.getProperties().containsKey("name"));
-    Assert.assertEquals(1, attributes.getProperties().size());
+    Schema attributesSchema = ((ObjectSchema) schema).getProperties().get("attributes");
+    assertEquals(ObjectSchema.class, attributesSchema.getClass());
+    assertIterableEquals(singleton("name"), attributesSchema.getProperties().keySet());
 
-    Schema name = (Schema) attributes.getProperties().get("name");
-    Assert.assertEquals(
-        "#/components/schemas/ResourceTypeNameResourceAttribute",
-        name.get$ref());
+    Schema nameSchema = ((ObjectSchema) attributesSchema).getProperties().get("name");
+    assertEquals("#/components/schemas/ResourceTypeNameResourceAttribute", nameSchema.get$ref());
   }
 }

--- a/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/ResourcePatchRelationshipsTest.java
+++ b/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/ResourcePatchRelationshipsTest.java
@@ -1,0 +1,57 @@
+package io.crnk.gen.openapi.internal.schemas;
+
+import io.crnk.gen.openapi.internal.MetaResourceBaseTest;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singleton;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResourcePatchRelationshipsTest extends MetaResourceBaseTest {
+
+	@Test
+	void isUpdatable() {
+		final Schema relationshipsSchema = checkRelationshipsSchema(true);
+		assertIterableEquals(singleton("resourceRelation"), relationshipsSchema.getProperties().keySet());
+
+		Schema resourceRelationSchema = ((ObjectSchema) relationshipsSchema).getProperties().get("resourceRelation");
+		assertNotNull(resourceRelationSchema);
+		assertEquals(ObjectSchema.class, resourceRelationSchema.getClass());
+		Map<String, Schema> resourceRelationProps = ((ObjectSchema) resourceRelationSchema).getProperties();
+		assertIterableEquals(singleton("data"), resourceRelationProps.keySet());
+
+		Schema dataSchema = resourceRelationProps.get("data");
+		assertNotNull(dataSchema);
+		assertEquals(ComposedSchema.class, dataSchema.getClass());
+		List<Schema> dataOneOfSchema = ((ComposedSchema) dataSchema).getOneOf();
+		assertNotNull(dataOneOfSchema);
+		assertEquals(2, dataOneOfSchema.size());
+		assertEquals("#/components/schemas/RelatedResourceTypeResourceReference", dataOneOfSchema.get(1).get$ref());
+	}
+
+	@Test
+	void notUpdatable() {
+		final Schema relationshipsSchema = checkRelationshipsSchema(false);
+		assertEquals(0, relationshipsSchema.getProperties().size());
+	}
+
+	private Schema checkRelationshipsSchema(boolean updatable) {
+		relationshipMetaResourceField.setUpdatable(updatable);
+		Schema schema = new ResourcePatchRelationships(metaResource).schema();
+
+		assertNotNull(schema);
+		assertEquals(ObjectSchema.class, schema.getClass());
+		assertIterableEquals(singleton("relationships"), schema.getProperties().keySet());
+
+		Schema relationshipsSchema = ((ObjectSchema) schema).getProperties().get("relationships");
+		assertNotNull(relationshipsSchema);
+		assertEquals(ObjectSchema.class, relationshipsSchema.getClass());
+
+		return relationshipsSchema;
+	}
+}

--- a/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/ResourcePostRelationshipsTest.java
+++ b/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/ResourcePostRelationshipsTest.java
@@ -1,0 +1,57 @@
+package io.crnk.gen.openapi.internal.schemas;
+
+import io.crnk.gen.openapi.internal.MetaResourceBaseTest;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singleton;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResourcePostRelationshipsTest extends MetaResourceBaseTest {
+
+	@Test
+	void isInsertable() {
+		final Schema relationshipsSchema = checkRelationshipsSchema(true);
+		assertIterableEquals(singleton("resourceRelation"), relationshipsSchema.getProperties().keySet());
+
+		Schema resourceRelationSchema = ((ObjectSchema) relationshipsSchema).getProperties().get("resourceRelation");
+		assertNotNull(resourceRelationSchema);
+		assertEquals(ObjectSchema.class, resourceRelationSchema.getClass());
+		Map<String, Schema> resourceRelationProps = ((ObjectSchema) resourceRelationSchema).getProperties();
+		assertIterableEquals(singleton("data"), resourceRelationProps.keySet());
+
+		Schema dataSchema = resourceRelationProps.get("data");
+		assertNotNull(dataSchema);
+		assertEquals(ComposedSchema.class, dataSchema.getClass());
+		List<Schema> dataOneOfSchema = ((ComposedSchema) dataSchema).getOneOf();
+		assertNotNull(dataOneOfSchema);
+		assertEquals(2, dataOneOfSchema.size());
+		assertEquals("#/components/schemas/RelatedResourceTypeResourceReference", dataOneOfSchema.get(1).get$ref());
+	}
+
+	@Test
+	void notInsertable() {
+		final Schema relationshipsSchema = checkRelationshipsSchema(false);
+		assertEquals(0, relationshipsSchema.getProperties().size());
+	}
+
+	private Schema checkRelationshipsSchema(boolean insertable) {
+		relationshipMetaResourceField.setInsertable(insertable);
+		Schema schema = new ResourcePostRelationships(metaResource).schema();
+
+		assertNotNull(schema);
+		assertEquals(ObjectSchema.class, schema.getClass());
+		assertIterableEquals(singleton("relationships"), schema.getProperties().keySet());
+
+		Schema relationshipsSchema = ((ObjectSchema) schema).getProperties().get("relationships");
+		assertNotNull(relationshipsSchema);
+		assertEquals(ObjectSchema.class, relationshipsSchema.getClass());
+
+		return relationshipsSchema;
+	}
+}

--- a/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/ResourceRelationshipsTest.java
+++ b/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/ResourceRelationshipsTest.java
@@ -1,0 +1,47 @@
+package io.crnk.gen.openapi.internal.schemas;
+
+import io.crnk.gen.openapi.internal.MetaResourceBaseTest;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singleton;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResourceRelationshipsTest extends MetaResourceBaseTest {
+
+	@Test
+	void schema() {
+		Schema schema = new ResourceRelationships(metaResource).schema();
+
+		assertNotNull(schema);
+		assertEquals(ObjectSchema.class, schema.getClass());
+		assertIterableEquals(singleton("relationships"), schema.getProperties().keySet());
+
+		Schema relationshipsSchema = ((ObjectSchema) schema).getProperties().get("relationships");
+		assertNotNull(relationshipsSchema);
+		assertEquals(ObjectSchema.class, relationshipsSchema.getClass());
+		assertIterableEquals(singleton("resourceRelation"), relationshipsSchema.getProperties().keySet());
+
+		Schema resourceRelationSchema = ((ObjectSchema) relationshipsSchema).getProperties().get("resourceRelation");
+		assertNotNull(resourceRelationSchema);
+		assertEquals(ObjectSchema.class, resourceRelationSchema.getClass());
+		Map<String, Schema> resourceRelationProps = ((ObjectSchema) resourceRelationSchema).getProperties();
+		assertIterableEquals(Stream.of("data", "links").collect(Collectors.toSet()), new HashSet<>(resourceRelationProps.keySet()));
+
+		Schema dataSchema = resourceRelationProps.get("data");
+		assertNotNull(dataSchema);
+		assertEquals(ComposedSchema.class, dataSchema.getClass());
+		List<Schema> dataOneOfSchema = ((ComposedSchema) dataSchema).getOneOf();
+		assertNotNull(dataOneOfSchema);
+		assertEquals(2, dataOneOfSchema.size());
+		assertEquals("#/components/schemas/RelatedResourceTypeResourceReference", dataOneOfSchema.get(1).get$ref());
+	}
+}

--- a/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/ResourceSchemaTest.java
+++ b/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/ResourceSchemaTest.java
@@ -2,31 +2,35 @@ package io.crnk.gen.openapi.internal.schemas;
 
 import io.crnk.gen.openapi.internal.MetaResourceBaseTest;
 import io.swagger.v3.oas.models.media.ComposedSchema;
-import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class ResourceSchemaTest extends MetaResourceBaseTest {
 
-  @Test
-  void schema() {
-    Schema schema = new ResourceSchema(metaResource).schema();
-    Assert.assertTrue(schema instanceof ComposedSchema);
-    Assert.assertEquals(1, schema.getRequired().size());
-    Assert.assertTrue(schema.getRequired().contains("attributes"));
-    
-    List<Schema> allOf = ((ComposedSchema) schema).getAllOf();
-    Assert.assertEquals(3, allOf.size());
-    Assert.assertEquals("#/components/schemas/ResourceTypeResourceReference", allOf.get(0).get$ref());
-    Assert.assertEquals("#/components/schemas/ResourceTypeResourceAttributes", allOf.get(1).get$ref());
+	@Test
+	void schema() {
+		Schema resourceSchema = new ResourceSchema(metaResource).schema();
+		assertNotNull(resourceSchema);
+		assertEquals(ComposedSchema.class, resourceSchema.getClass());
+		assertIterableEquals(singletonList("attributes"), resourceSchema.getRequired());
 
-    Schema linksAndRelationships = allOf.get(2);
-    Assert.assertTrue(linksAndRelationships instanceof ObjectSchema);
-    Assert.assertEquals(2, linksAndRelationships.getProperties().size());
-    Assert.assertTrue(linksAndRelationships.getProperties().containsKey("links"));
-    Assert.assertTrue(linksAndRelationships.getProperties().containsKey("relationships"));
-  }
+		List<Schema> allOf = ((ComposedSchema) resourceSchema).getAllOf();
+		assertNotNull(allOf);
+		List<String> allOfItems = allOf.stream().map(Schema::get$ref).collect(toList());
+		assertIterableEquals(Stream.of(
+				"#/components/schemas/ResourceTypeResourceReference",
+				"#/components/schemas/ResourceTypeResourceAttributes",
+				"#/components/schemas/ResourceTypeResourceRelationships",
+				"#/components/schemas/ResourceTypeResourceLinks"
+		).collect(toList()), allOfItems);
+	}
 }

--- a/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/TypeSchemaTest.java
+++ b/crnk-gen/crnk-gen-openapi/src/test/java/io/crnk/gen/openapi/internal/schemas/TypeSchemaTest.java
@@ -1,0 +1,20 @@
+package io.crnk.gen.openapi.internal.schemas;
+
+import io.crnk.gen.openapi.internal.MetaResourceBaseTest;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TypeSchemaTest extends MetaResourceBaseTest {
+
+	@Test
+	void schema() {
+		final Schema typeSchema = new TypeSchema(metaResource).schema();
+		assertNotNull(typeSchema);
+		assertEquals(StringSchema.class, typeSchema.getClass());
+		assertIterableEquals(singletonList("ResourceType"), typeSchema.getEnum());
+	}
+}

--- a/crnk-gen/crnk-gen-openapi/src/test/resources/gold/complex.yaml
+++ b/crnk-gen/crnk-gen-openapi/src/test/resources/gold/complex.yaml
@@ -954,6 +954,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/CommentResourceReference'
           - $ref: '#/components/schemas/CommentResourcePatchAttributes'
+          - $ref: '#/components/schemas/CommentResourcePatchRelationships'
       required:
       - data
       type: object
@@ -970,6 +971,7 @@ components:
       allOf:
       - $ref: '#/components/schemas/CommentPostResourceReference'
       - $ref: '#/components/schemas/CommentResourcePostAttributes'
+      - $ref: '#/components/schemas/CommentResourcePostRelationships'
     CommentPostResourceReference:
       properties:
         id:
@@ -997,36 +999,85 @@ components:
       properties:
         attributes:
           properties:
-            post:
-              $ref: '#/components/schemas/CommentPostResourceAttribute'
-            related:
-              $ref: '#/components/schemas/CommentRelatedResourceAttribute'
             value:
               $ref: '#/components/schemas/CommentValueResourceAttribute'
+          type: object
+      type: object
+    CommentResourceLinks:
+      description: Links related to the resource
+      properties:
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /comment/{id}
+              format: uri
+              type: string
           type: object
       type: object
     CommentResourcePatchAttributes:
       properties:
         attributes:
           properties:
-            post:
-              $ref: '#/components/schemas/CommentPostResourceAttribute'
-            related:
-              $ref: '#/components/schemas/CommentRelatedResourceAttribute'
             value:
               $ref: '#/components/schemas/CommentValueResourceAttribute'
+          type: object
+      type: object
+    CommentResourcePatchRelationships:
+      properties:
+        relationships:
+          properties:
+            post:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/PostResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/PostResourceReference'
+              type: object
+            related:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/NestedRelatedResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/NestedRelatedResourceReference'
+              type: object
           type: object
       type: object
     CommentResourcePostAttributes:
       properties:
         attributes:
           properties:
-            post:
-              $ref: '#/components/schemas/CommentPostResourceAttribute'
-            related:
-              $ref: '#/components/schemas/CommentRelatedResourceAttribute'
             value:
               $ref: '#/components/schemas/CommentValueResourceAttribute'
+          type: object
+      type: object
+    CommentResourcePostRelationships:
+      properties:
+        relationships:
+          properties:
+            post:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/PostResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/PostResourceReference'
+              type: object
+            related:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/NestedRelatedResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/NestedRelatedResourceReference'
+              type: object
           type: object
       type: object
     CommentResourceReference:
@@ -1054,6 +1105,49 @@ components:
             $ref: '#/components/schemas/CommentResourceReference'
           type: array
       type: object
+    CommentResourceRelationships:
+      description: Relationships between the resource and other JSON:API resources
+      properties:
+        relationships:
+          properties:
+            post:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/PostResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/PostResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /comment/{id}/post
+                      type: string
+                    self:
+                      default: /comment/{id}/relationships/post
+                      type: string
+                  type: object
+              type: object
+            related:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/NestedRelatedResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/NestedRelatedResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /comment/{id}/related
+                      type: string
+                    self:
+                      default: /comment/{id}/relationships/related
+                      type: string
+                  type: object
+              type: object
+          type: object
+      type: object
     CommentResourceResponseSchema:
       allOf:
       - $ref: '#/components/schemas/Success'
@@ -1066,12 +1160,8 @@ components:
       allOf:
       - $ref: '#/components/schemas/CommentResourceReference'
       - $ref: '#/components/schemas/CommentResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/CommentResourceRelationships'
+      - $ref: '#/components/schemas/CommentResourceLinks'
       required:
       - attributes
     CommentResourcesResponseSchema:
@@ -1114,6 +1204,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/HeaderResourceReference'
           - $ref: '#/components/schemas/HeaderResourcePatchAttributes'
+          - $ref: '#/components/schemas/HeaderResourcePatchRelationships'
       required:
       - data
       type: object
@@ -1130,6 +1221,7 @@ components:
       allOf:
       - $ref: '#/components/schemas/HeaderPostResourceReference'
       - $ref: '#/components/schemas/HeaderResourcePostAttributes'
+      - $ref: '#/components/schemas/HeaderResourcePostRelationships'
     HeaderPostResourceReference:
       properties:
         id:
@@ -1157,36 +1249,85 @@ components:
       properties:
         attributes:
           properties:
-            post:
-              $ref: '#/components/schemas/HeaderPostResourceAttribute'
-            related:
-              $ref: '#/components/schemas/HeaderRelatedResourceAttribute'
             value:
               $ref: '#/components/schemas/HeaderValueResourceAttribute'
+          type: object
+      type: object
+    HeaderResourceLinks:
+      description: Links related to the resource
+      properties:
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /header/{id}
+              format: uri
+              type: string
           type: object
       type: object
     HeaderResourcePatchAttributes:
       properties:
         attributes:
           properties:
-            post:
-              $ref: '#/components/schemas/HeaderPostResourceAttribute'
-            related:
-              $ref: '#/components/schemas/HeaderRelatedResourceAttribute'
             value:
               $ref: '#/components/schemas/HeaderValueResourceAttribute'
+          type: object
+      type: object
+    HeaderResourcePatchRelationships:
+      properties:
+        relationships:
+          properties:
+            post:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/PostResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/PostResourceReference'
+              type: object
+            related:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/NestedRelatedResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/NestedRelatedResourceReference'
+              type: object
           type: object
       type: object
     HeaderResourcePostAttributes:
       properties:
         attributes:
           properties:
-            post:
-              $ref: '#/components/schemas/HeaderPostResourceAttribute'
-            related:
-              $ref: '#/components/schemas/HeaderRelatedResourceAttribute'
             value:
               $ref: '#/components/schemas/HeaderValueResourceAttribute'
+          type: object
+      type: object
+    HeaderResourcePostRelationships:
+      properties:
+        relationships:
+          properties:
+            post:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/PostResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/PostResourceReference'
+              type: object
+            related:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/NestedRelatedResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/NestedRelatedResourceReference'
+              type: object
           type: object
       type: object
     HeaderResourceReference:
@@ -1214,6 +1355,49 @@ components:
             $ref: '#/components/schemas/HeaderResourceReference'
           type: array
       type: object
+    HeaderResourceRelationships:
+      description: Relationships between the resource and other JSON:API resources
+      properties:
+        relationships:
+          properties:
+            post:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/PostResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/PostResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /header/{id}/post
+                      type: string
+                    self:
+                      default: /header/{id}/relationships/post
+                      type: string
+                  type: object
+              type: object
+            related:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/NestedRelatedResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/NestedRelatedResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /header/{id}/related
+                      type: string
+                    self:
+                      default: /header/{id}/relationships/related
+                      type: string
+                  type: object
+              type: object
+          type: object
+      type: object
     HeaderResourceResponseSchema:
       allOf:
       - $ref: '#/components/schemas/Success'
@@ -1226,12 +1410,8 @@ components:
       allOf:
       - $ref: '#/components/schemas/HeaderResourceReference'
       - $ref: '#/components/schemas/HeaderResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/HeaderResourceRelationships'
+      - $ref: '#/components/schemas/HeaderResourceLinks'
       required:
       - attributes
     HeaderResourcesResponseSchema:
@@ -1304,6 +1484,19 @@ components:
               $ref: '#/components/schemas/HistoricTasksNameResourceAttribute'
           type: object
       type: object
+    HistoricTasksResourceLinks:
+      description: Links related to the resource
+      properties:
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /tasks/history/{id}
+              format: uri
+              type: string
+          type: object
+      type: object
     HistoricTasksResourcePatchAttributes:
       properties:
         attributes:
@@ -1357,12 +1550,7 @@ components:
       allOf:
       - $ref: '#/components/schemas/HistoricTasksResourceReference'
       - $ref: '#/components/schemas/HistoricTasksResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/HistoricTasksResourceLinks'
       required:
       - attributes
     HistoricTasksResourcesResponseSchema:
@@ -1431,7 +1619,6 @@ components:
         data:
           allOf:
           - $ref: '#/components/schemas/NestedRelatedResourceReference'
-          - $ref: '#/components/schemas/NestedRelatedResourcePatchAttributes'
       required:
       - data
       type: object
@@ -1445,7 +1632,6 @@ components:
     NestedRelatedPostResourceData:
       allOf:
       - $ref: '#/components/schemas/NestedRelatedPostResourceReference'
-      - $ref: '#/components/schemas/NestedRelatedResourcePostAttributes'
     NestedRelatedPostResourceReference:
       properties:
         id:
@@ -1467,22 +1653,17 @@ components:
       required:
       - data
       type: object
-    NestedRelatedResourceAttributes:
+    NestedRelatedResourceLinks:
+      description: Links related to the resource
       properties:
-        attributes:
-          properties: {}
-          type: object
-      type: object
-    NestedRelatedResourcePatchAttributes:
-      properties:
-        attributes:
-          properties: {}
-          type: object
-      type: object
-    NestedRelatedResourcePostAttributes:
-      properties:
-        attributes:
-          properties: {}
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /nestedRelated/{id}
+              format: uri
+              type: string
           type: object
       type: object
     NestedRelatedResourceReference:
@@ -1521,13 +1702,7 @@ components:
     NestedRelatedResourceSchema:
       allOf:
       - $ref: '#/components/schemas/NestedRelatedResourceReference'
-      - $ref: '#/components/schemas/NestedRelatedResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/NestedRelatedResourceLinks'
       required:
       - attributes
     NestedRelatedResourcesResponseSchema:
@@ -1553,7 +1728,6 @@ components:
         data:
           allOf:
           - $ref: '#/components/schemas/NoAccessTaskResourceReference'
-          - $ref: '#/components/schemas/NoAccessTaskResourcePatchAttributes'
       required:
       - data
       type: object
@@ -1567,7 +1741,6 @@ components:
     NoAccessTaskPostResourceData:
       allOf:
       - $ref: '#/components/schemas/NoAccessTaskPostResourceReference'
-      - $ref: '#/components/schemas/NoAccessTaskResourcePostAttributes'
     NoAccessTaskPostResourceReference:
       properties:
         id:
@@ -1597,16 +1770,17 @@ components:
               $ref: '#/components/schemas/NoAccessTaskNameResourceAttribute'
           type: object
       type: object
-    NoAccessTaskResourcePatchAttributes:
+    NoAccessTaskResourceLinks:
+      description: Links related to the resource
       properties:
-        attributes:
-          properties: {}
-          type: object
-      type: object
-    NoAccessTaskResourcePostAttributes:
-      properties:
-        attributes:
-          properties: {}
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /noAccessTask/{id}
+              format: uri
+              type: string
           type: object
       type: object
     NoAccessTaskResourceReference:
@@ -1646,12 +1820,7 @@ components:
       allOf:
       - $ref: '#/components/schemas/NoAccessTaskResourceReference'
       - $ref: '#/components/schemas/NoAccessTaskResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/NoAccessTaskResourceLinks'
       required:
       - attributes
     NoAccessTaskResourcesResponseSchema:
@@ -1702,7 +1871,7 @@ components:
         data:
           allOf:
           - $ref: '#/components/schemas/PostResourceReference'
-          - $ref: '#/components/schemas/PostResourcePatchAttributes'
+          - $ref: '#/components/schemas/PostResourcePatchRelationships'
       required:
       - data
       type: object
@@ -1718,7 +1887,7 @@ components:
     PostPostResourceData:
       allOf:
       - $ref: '#/components/schemas/PostPostResourceReference'
-      - $ref: '#/components/schemas/PostResourcePostAttributes'
+      - $ref: '#/components/schemas/PostResourcePostRelationships'
     PostPostResourceReference:
       properties:
         id:
@@ -1740,34 +1909,77 @@ components:
       required:
       - data
       type: object
-    PostResourceAttributes:
+    PostResourceLinks:
+      description: Links related to the resource
       properties:
-        attributes:
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
           properties:
-            comments:
-              $ref: '#/components/schemas/PostCommentsResourceAttribute'
-            postHeader:
-              $ref: '#/components/schemas/PostPostHeaderResourceAttribute'
+            self:
+              default: /post/{id}
+              format: uri
+              type: string
           type: object
       type: object
-    PostResourcePatchAttributes:
+    PostResourcePatchRelationships:
       properties:
-        attributes:
+        relationships:
           properties:
             comments:
-              $ref: '#/components/schemas/PostCommentsResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/CommentResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/CommentResourceReference'
+                    type: array
+                    uniqueItems: false
+              type: object
             postHeader:
-              $ref: '#/components/schemas/PostPostHeaderResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/HeaderResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/HeaderResourceReference'
+              type: object
           type: object
       type: object
-    PostResourcePostAttributes:
+    PostResourcePostRelationships:
       properties:
-        attributes:
+        relationships:
           properties:
             comments:
-              $ref: '#/components/schemas/PostCommentsResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/CommentResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/CommentResourceReference'
+                    type: array
+                    uniqueItems: false
+              type: object
             postHeader:
-              $ref: '#/components/schemas/PostPostHeaderResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/HeaderResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/HeaderResourceReference'
+              type: object
           type: object
       type: object
     PostResourceReference:
@@ -1795,6 +2007,55 @@ components:
             $ref: '#/components/schemas/PostResourceReference'
           type: array
       type: object
+    PostResourceRelationships:
+      description: Relationships between the resource and other JSON:API resources
+      properties:
+        relationships:
+          properties:
+            comments:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/CommentResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/CommentResourceReference'
+                    type: array
+                    uniqueItems: false
+                links:
+                  properties:
+                    related:
+                      default: /post/{id}/comments
+                      type: string
+                    self:
+                      default: /post/{id}/relationships/comments
+                      type: string
+                  type: object
+              type: object
+            postHeader:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/HeaderResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/HeaderResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /post/{id}/postHeader
+                      type: string
+                    self:
+                      default: /post/{id}/relationships/postHeader
+                      type: string
+                  type: object
+              type: object
+          type: object
+      type: object
     PostResourceResponseSchema:
       allOf:
       - $ref: '#/components/schemas/Success'
@@ -1806,13 +2067,8 @@ components:
     PostResourceSchema:
       allOf:
       - $ref: '#/components/schemas/PostResourceReference'
-      - $ref: '#/components/schemas/PostResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/PostResourceRelationships'
+      - $ref: '#/components/schemas/PostResourceLinks'
       required:
       - attributes
     PostResourcesResponseSchema:
@@ -2014,6 +2270,19 @@ components:
               $ref: '#/components/schemas/PrimitiveAttributeUuidValueResourceAttribute'
           type: object
       type: object
+    PrimitiveAttributeResourceLinks:
+      description: Links related to the resource
+      properties:
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /primitiveAttribute/{id}
+              format: uri
+              type: string
+          type: object
+      type: object
     PrimitiveAttributeResourcePatchAttributes:
       properties:
         attributes:
@@ -2159,12 +2428,7 @@ components:
       allOf:
       - $ref: '#/components/schemas/PrimitiveAttributeResourceReference'
       - $ref: '#/components/schemas/PrimitiveAttributeResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/PrimitiveAttributeResourceLinks'
       required:
       - attributes
     PrimitiveAttributeResourcesResponseSchema:
@@ -2227,6 +2491,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/ProjectsResourceReference'
           - $ref: '#/components/schemas/ProjectsResourcePatchAttributes'
+          - $ref: '#/components/schemas/ProjectsResourcePatchRelationships'
       required:
       - data
       type: object
@@ -2241,6 +2506,7 @@ components:
       allOf:
       - $ref: '#/components/schemas/ProjectsPostResourceReference'
       - $ref: '#/components/schemas/ProjectsResourcePostAttributes'
+      - $ref: '#/components/schemas/ProjectsResourcePostRelationships'
     ProjectsPostResourceReference:
       properties:
         id:
@@ -2272,10 +2538,19 @@ components:
               $ref: '#/components/schemas/ProjectsDescriptionResourceAttribute'
             name:
               $ref: '#/components/schemas/ProjectsNameResourceAttribute'
-            task:
-              $ref: '#/components/schemas/ProjectsTaskResourceAttribute'
-            tasks:
-              $ref: '#/components/schemas/ProjectsTasksResourceAttribute'
+          type: object
+      type: object
+    ProjectsResourceLinks:
+      description: Links related to the resource
+      properties:
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /projects/{id}
+              format: uri
+              type: string
           type: object
       type: object
     ProjectsResourcePatchAttributes:
@@ -2288,10 +2563,36 @@ components:
               $ref: '#/components/schemas/ProjectsDescriptionResourceAttribute'
             name:
               $ref: '#/components/schemas/ProjectsNameResourceAttribute'
+          type: object
+      type: object
+    ProjectsResourcePatchRelationships:
+      properties:
+        relationships:
+          properties:
             task:
-              $ref: '#/components/schemas/ProjectsTaskResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/TasksResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/TasksResourceReference'
+              type: object
             tasks:
-              $ref: '#/components/schemas/ProjectsTasksResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/TasksResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/TasksResourceReference'
+                    type: array
+                    uniqueItems: false
+              type: object
           type: object
       type: object
     ProjectsResourcePostAttributes:
@@ -2304,10 +2605,36 @@ components:
               $ref: '#/components/schemas/ProjectsDescriptionResourceAttribute'
             name:
               $ref: '#/components/schemas/ProjectsNameResourceAttribute'
+          type: object
+      type: object
+    ProjectsResourcePostRelationships:
+      properties:
+        relationships:
+          properties:
             task:
-              $ref: '#/components/schemas/ProjectsTaskResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/TasksResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/TasksResourceReference'
+              type: object
             tasks:
-              $ref: '#/components/schemas/ProjectsTasksResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/TasksResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/TasksResourceReference'
+                    type: array
+                    uniqueItems: false
+              type: object
           type: object
       type: object
     ProjectsResourceReference:
@@ -2335,6 +2662,55 @@ components:
             $ref: '#/components/schemas/ProjectsResourceReference'
           type: array
       type: object
+    ProjectsResourceRelationships:
+      description: Relationships between the resource and other JSON:API resources
+      properties:
+        relationships:
+          properties:
+            task:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/TasksResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/TasksResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /projects/{id}/task
+                      type: string
+                    self:
+                      default: /projects/{id}/relationships/task
+                      type: string
+                  type: object
+              type: object
+            tasks:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/TasksResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/TasksResourceReference'
+                    type: array
+                    uniqueItems: false
+                links:
+                  properties:
+                    related:
+                      default: /projects/{id}/tasks
+                      type: string
+                    self:
+                      default: /projects/{id}/relationships/tasks
+                      type: string
+                  type: object
+              type: object
+          type: object
+      type: object
     ProjectsResourceResponseSchema:
       allOf:
       - $ref: '#/components/schemas/Success'
@@ -2347,12 +2723,8 @@ components:
       allOf:
       - $ref: '#/components/schemas/ProjectsResourceReference'
       - $ref: '#/components/schemas/ProjectsResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/ProjectsResourceRelationships'
+      - $ref: '#/components/schemas/ProjectsResourceLinks'
       required:
       - attributes
     ProjectsResourcesResponseSchema:
@@ -2386,7 +2758,6 @@ components:
         data:
           allOf:
           - $ref: '#/components/schemas/ReadOnlyTaskResourceReference'
-          - $ref: '#/components/schemas/ReadOnlyTaskResourcePatchAttributes'
       required:
       - data
       type: object
@@ -2400,7 +2771,6 @@ components:
     ReadOnlyTaskPostResourceData:
       allOf:
       - $ref: '#/components/schemas/ReadOnlyTaskPostResourceReference'
-      - $ref: '#/components/schemas/ReadOnlyTaskResourcePostAttributes'
     ReadOnlyTaskPostResourceReference:
       properties:
         id:
@@ -2430,16 +2800,17 @@ components:
               $ref: '#/components/schemas/ReadOnlyTaskNameResourceAttribute'
           type: object
       type: object
-    ReadOnlyTaskResourcePatchAttributes:
+    ReadOnlyTaskResourceLinks:
+      description: Links related to the resource
       properties:
-        attributes:
-          properties: {}
-          type: object
-      type: object
-    ReadOnlyTaskResourcePostAttributes:
-      properties:
-        attributes:
-          properties: {}
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /readOnlyTask/{id}
+              format: uri
+              type: string
           type: object
       type: object
     ReadOnlyTaskResourceReference:
@@ -2479,12 +2850,7 @@ components:
       allOf:
       - $ref: '#/components/schemas/ReadOnlyTaskResourceReference'
       - $ref: '#/components/schemas/ReadOnlyTaskResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/ReadOnlyTaskResourceLinks'
       required:
       - attributes
     ReadOnlyTaskResourcesResponseSchema:
@@ -2511,6 +2877,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/RelationIdTestResourceReference'
           - $ref: '#/components/schemas/RelationIdTestResourcePatchAttributes'
+          - $ref: '#/components/schemas/RelationIdTestResourcePatchRelationships'
       required:
       - data
       type: object
@@ -2525,6 +2892,7 @@ components:
       allOf:
       - $ref: '#/components/schemas/RelationIdTestPostResourceReference'
       - $ref: '#/components/schemas/RelationIdTestResourcePostAttributes'
+      - $ref: '#/components/schemas/RelationIdTestResourcePostRelationships'
     RelationIdTestPostResourceReference:
       properties:
         id:
@@ -2552,22 +2920,19 @@ components:
           properties:
             name:
               $ref: '#/components/schemas/RelationIdTestNameResourceAttribute'
-            testLookupAlways:
-              $ref: '#/components/schemas/RelationIdTestTestLookupAlwaysResourceAttribute'
-            testLookupNone:
-              $ref: '#/components/schemas/RelationIdTestTestLookupNoneResourceAttribute'
-            testLookupWhenNull:
-              $ref: '#/components/schemas/RelationIdTestTestLookupWhenNullResourceAttribute'
-            testMultipleValues:
-              $ref: '#/components/schemas/RelationIdTestTestMultipleValuesResourceAttribute'
-            testNested:
-              $ref: '#/components/schemas/RelationIdTestTestNestedResourceAttribute'
-            testResourceIdRef:
-              $ref: '#/components/schemas/RelationIdTestTestResourceIdRefResourceAttribute'
-            testSerializeEager:
-              $ref: '#/components/schemas/RelationIdTestTestSerializeEagerResourceAttribute'
-            testSerializeOnlyId:
-              $ref: '#/components/schemas/RelationIdTestTestSerializeOnlyIdResourceAttribute'
+          type: object
+      type: object
+    RelationIdTestResourceLinks:
+      description: Links related to the resource
+      properties:
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /relationIdTest/{id}
+              format: uri
+              type: string
           type: object
       type: object
     RelationIdTestResourcePatchAttributes:
@@ -2576,22 +2941,90 @@ components:
           properties:
             name:
               $ref: '#/components/schemas/RelationIdTestNameResourceAttribute'
+          type: object
+      type: object
+    RelationIdTestResourcePatchRelationships:
+      properties:
+        relationships:
+          properties:
             testLookupAlways:
-              $ref: '#/components/schemas/RelationIdTestTestLookupAlwaysResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+              type: object
             testLookupNone:
-              $ref: '#/components/schemas/RelationIdTestTestLookupNoneResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+              type: object
             testLookupWhenNull:
-              $ref: '#/components/schemas/RelationIdTestTestLookupWhenNullResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+              type: object
             testMultipleValues:
-              $ref: '#/components/schemas/RelationIdTestTestMultipleValuesResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/ScheduleResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                    uniqueItems: false
+              type: object
             testNested:
-              $ref: '#/components/schemas/RelationIdTestTestNestedResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/RelationIdTestResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/RelationIdTestResourceReference'
+              type: object
             testResourceIdRef:
-              $ref: '#/components/schemas/RelationIdTestTestResourceIdRefResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+              type: object
             testSerializeEager:
-              $ref: '#/components/schemas/RelationIdTestTestSerializeEagerResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+              type: object
             testSerializeOnlyId:
-              $ref: '#/components/schemas/RelationIdTestTestSerializeOnlyIdResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+              type: object
           type: object
       type: object
     RelationIdTestResourcePostAttributes:
@@ -2600,22 +3033,90 @@ components:
           properties:
             name:
               $ref: '#/components/schemas/RelationIdTestNameResourceAttribute'
+          type: object
+      type: object
+    RelationIdTestResourcePostRelationships:
+      properties:
+        relationships:
+          properties:
             testLookupAlways:
-              $ref: '#/components/schemas/RelationIdTestTestLookupAlwaysResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+              type: object
             testLookupNone:
-              $ref: '#/components/schemas/RelationIdTestTestLookupNoneResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+              type: object
             testLookupWhenNull:
-              $ref: '#/components/schemas/RelationIdTestTestLookupWhenNullResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+              type: object
             testMultipleValues:
-              $ref: '#/components/schemas/RelationIdTestTestMultipleValuesResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/ScheduleResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                    uniqueItems: false
+              type: object
             testNested:
-              $ref: '#/components/schemas/RelationIdTestTestNestedResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/RelationIdTestResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/RelationIdTestResourceReference'
+              type: object
             testResourceIdRef:
-              $ref: '#/components/schemas/RelationIdTestTestResourceIdRefResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+              type: object
             testSerializeEager:
-              $ref: '#/components/schemas/RelationIdTestTestSerializeEagerResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+              type: object
             testSerializeOnlyId:
-              $ref: '#/components/schemas/RelationIdTestTestSerializeOnlyIdResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+              type: object
           type: object
       type: object
     RelationIdTestResourceReference:
@@ -2643,6 +3144,163 @@ components:
             $ref: '#/components/schemas/RelationIdTestResourceReference'
           type: array
       type: object
+    RelationIdTestResourceRelationships:
+      description: Relationships between the resource and other JSON:API resources
+      properties:
+        relationships:
+          properties:
+            testLookupAlways:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /relationIdTest/{id}/testLookupAlways
+                      type: string
+                    self:
+                      default: /relationIdTest/{id}/relationships/testLookupAlways
+                      type: string
+                  type: object
+              type: object
+            testLookupNone:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /relationIdTest/{id}/testLookupNone
+                      type: string
+                    self:
+                      default: /relationIdTest/{id}/relationships/testLookupNone
+                      type: string
+                  type: object
+              type: object
+            testLookupWhenNull:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /relationIdTest/{id}/testLookupWhenNull
+                      type: string
+                    self:
+                      default: /relationIdTest/{id}/relationships/testLookupWhenNull
+                      type: string
+                  type: object
+              type: object
+            testMultipleValues:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/ScheduleResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                    uniqueItems: false
+                links:
+                  properties:
+                    related:
+                      default: /relationIdTest/{id}/testMultipleValues
+                      type: string
+                    self:
+                      default: /relationIdTest/{id}/relationships/testMultipleValues
+                      type: string
+                  type: object
+              type: object
+            testNested:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/RelationIdTestResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/RelationIdTestResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /relationIdTest/{id}/testNested
+                      type: string
+                    self:
+                      default: /relationIdTest/{id}/relationships/testNested
+                      type: string
+                  type: object
+              type: object
+            testResourceIdRef:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /relationIdTest/{id}/testResourceIdRef
+                      type: string
+                    self:
+                      default: /relationIdTest/{id}/relationships/testResourceIdRef
+                      type: string
+                  type: object
+              type: object
+            testSerializeEager:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /relationIdTest/{id}/testSerializeEager
+                      type: string
+                    self:
+                      default: /relationIdTest/{id}/relationships/testSerializeEager
+                      type: string
+                  type: object
+              type: object
+            testSerializeOnlyId:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /relationIdTest/{id}/testSerializeOnlyId
+                      type: string
+                    self:
+                      default: /relationIdTest/{id}/relationships/testSerializeOnlyId
+                      type: string
+                  type: object
+              type: object
+          type: object
+      type: object
     RelationIdTestResourceResponseSchema:
       allOf:
       - $ref: '#/components/schemas/Success'
@@ -2655,12 +3313,8 @@ components:
       allOf:
       - $ref: '#/components/schemas/RelationIdTestResourceReference'
       - $ref: '#/components/schemas/RelationIdTestResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/RelationIdTestResourceRelationships'
+      - $ref: '#/components/schemas/RelationIdTestResourceLinks'
       required:
       - attributes
     RelationIdTestResourcesResponseSchema:
@@ -2750,6 +3404,19 @@ components:
               $ref: '#/components/schemas/RelocatedTaskNameResourceAttribute'
           type: object
       type: object
+    RelocatedTaskResourceLinks:
+      description: Links related to the resource
+      properties:
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /taskNewPath/{id}
+              format: uri
+              type: string
+          type: object
+      type: object
     RelocatedTaskResourcePatchAttributes:
       properties:
         attributes:
@@ -2803,12 +3470,7 @@ components:
       allOf:
       - $ref: '#/components/schemas/RelocatedTaskResourceReference'
       - $ref: '#/components/schemas/RelocatedTaskResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/RelocatedTaskResourceLinks'
       required:
       - attributes
     RelocatedTaskResourcesResponseSchema:
@@ -2830,7 +3492,6 @@ components:
         data:
           allOf:
           - $ref: '#/components/schemas/RenamedIdResourceReference'
-          - $ref: '#/components/schemas/RenamedIdResourcePatchAttributes'
       required:
       - data
       type: object
@@ -2844,7 +3505,6 @@ components:
     RenamedIdPostResourceData:
       allOf:
       - $ref: '#/components/schemas/RenamedIdPostResourceReference'
-      - $ref: '#/components/schemas/RenamedIdResourcePostAttributes'
     RenamedIdPostResourceReference:
       properties:
         id:
@@ -2866,22 +3526,17 @@ components:
       required:
       - data
       type: object
-    RenamedIdResourceAttributes:
+    RenamedIdResourceLinks:
+      description: Links related to the resource
       properties:
-        attributes:
-          properties: {}
-          type: object
-      type: object
-    RenamedIdResourcePatchAttributes:
-      properties:
-        attributes:
-          properties: {}
-          type: object
-      type: object
-    RenamedIdResourcePostAttributes:
-      properties:
-        attributes:
-          properties: {}
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /renamedId/{id}
+              format: uri
+              type: string
           type: object
       type: object
     RenamedIdResourceReference:
@@ -2920,13 +3575,7 @@ components:
     RenamedIdResourceSchema:
       allOf:
       - $ref: '#/components/schemas/RenamedIdResourceReference'
-      - $ref: '#/components/schemas/RenamedIdResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/RenamedIdResourceLinks'
       required:
       - attributes
     RenamedIdResourcesResponseSchema:
@@ -2964,6 +3613,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/ScheduleResourceReference'
           - $ref: '#/components/schemas/ScheduleResourcePatchAttributes'
+          - $ref: '#/components/schemas/ScheduleResourcePatchRelationships'
       required:
       - data
       type: object
@@ -2978,6 +3628,7 @@ components:
       allOf:
       - $ref: '#/components/schemas/SchedulePostResourceReference'
       - $ref: '#/components/schemas/ScheduleResourcePostAttributes'
+      - $ref: '#/components/schemas/ScheduleResourcePostRelationships'
     SchedulePostResourceReference:
       properties:
         id:
@@ -3019,14 +3670,19 @@ components:
               $ref: '#/components/schemas/ScheduleDescriptionResourceAttribute'
             name:
               $ref: '#/components/schemas/ScheduleNameResourceAttribute'
-            project:
-              $ref: '#/components/schemas/ScheduleProjectResourceAttribute'
-            projects:
-              $ref: '#/components/schemas/ScheduleProjectsResourceAttribute'
-            status:
-              $ref: '#/components/schemas/ScheduleStatusResourceAttribute'
-            taskSet:
-              $ref: '#/components/schemas/ScheduleTaskSetResourceAttribute'
+          type: object
+      type: object
+    ScheduleResourceLinks:
+      description: Links related to the resource
+      properties:
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /schedules/{id}
+              format: uri
+              type: string
           type: object
       type: object
     ScheduleResourcePatchAttributes:
@@ -3041,14 +3697,60 @@ components:
               $ref: '#/components/schemas/ScheduleDescriptionResourceAttribute'
             name:
               $ref: '#/components/schemas/ScheduleNameResourceAttribute'
+          type: object
+      type: object
+    ScheduleResourcePatchRelationships:
+      properties:
+        relationships:
+          properties:
             project:
-              $ref: '#/components/schemas/ScheduleProjectResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ProjectsResourceReference'
+              type: object
             projects:
-              $ref: '#/components/schemas/ScheduleProjectsResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/ProjectsResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                    uniqueItems: false
+              type: object
             status:
-              $ref: '#/components/schemas/ScheduleStatusResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleStatusResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleStatusResourceReference'
+              type: object
             taskSet:
-              $ref: '#/components/schemas/ScheduleTaskSetResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/TasksResourceReference'
+                      type: array
+                      uniqueItems: true
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/TasksResourceReference'
+                    type: array
+                    uniqueItems: true
+              type: object
           type: object
       type: object
     ScheduleResourcePostAttributes:
@@ -3063,14 +3765,60 @@ components:
               $ref: '#/components/schemas/ScheduleDescriptionResourceAttribute'
             name:
               $ref: '#/components/schemas/ScheduleNameResourceAttribute'
+          type: object
+      type: object
+    ScheduleResourcePostRelationships:
+      properties:
+        relationships:
+          properties:
             project:
-              $ref: '#/components/schemas/ScheduleProjectResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ProjectsResourceReference'
+              type: object
             projects:
-              $ref: '#/components/schemas/ScheduleProjectsResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/ProjectsResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                    uniqueItems: false
+              type: object
             status:
-              $ref: '#/components/schemas/ScheduleStatusResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleStatusResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleStatusResourceReference'
+              type: object
             taskSet:
-              $ref: '#/components/schemas/ScheduleTaskSetResourceAttribute'
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/TasksResourceReference'
+                      type: array
+                      uniqueItems: true
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/TasksResourceReference'
+                    type: array
+                    uniqueItems: true
+              type: object
           type: object
       type: object
     ScheduleResourceReference:
@@ -3098,6 +3846,97 @@ components:
             $ref: '#/components/schemas/ScheduleResourceReference'
           type: array
       type: object
+    ScheduleResourceRelationships:
+      description: Relationships between the resource and other JSON:API resources
+      properties:
+        relationships:
+          properties:
+            project:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ProjectsResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /schedules/{id}/project
+                      type: string
+                    self:
+                      default: /schedules/{id}/relationships/project
+                      type: string
+                  type: object
+              type: object
+            projects:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/ProjectsResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                    uniqueItems: false
+                links:
+                  properties:
+                    related:
+                      default: /schedules/{id}/projects
+                      type: string
+                    self:
+                      default: /schedules/{id}/relationships/projects
+                      type: string
+                  type: object
+              type: object
+            status:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleStatusResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleStatusResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /schedules/{id}/status
+                      type: string
+                    self:
+                      default: /schedules/{id}/relationships/status
+                      type: string
+                  type: object
+              type: object
+            taskSet:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/TasksResourceReference'
+                      type: array
+                      uniqueItems: true
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/TasksResourceReference'
+                    type: array
+                    uniqueItems: true
+                links:
+                  properties:
+                    related:
+                      default: /schedules/{id}/taskSet
+                      type: string
+                    self:
+                      default: /schedules/{id}/relationships/taskSet
+                      type: string
+                  type: object
+              type: object
+          type: object
+      type: object
     ScheduleResourceResponseSchema:
       allOf:
       - $ref: '#/components/schemas/Success'
@@ -3110,12 +3949,8 @@ components:
       allOf:
       - $ref: '#/components/schemas/ScheduleResourceReference'
       - $ref: '#/components/schemas/ScheduleResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/ScheduleResourceRelationships'
+      - $ref: '#/components/schemas/ScheduleResourceLinks'
       required:
       - attributes
     ScheduleResourcesResponseSchema:
@@ -3187,6 +4022,19 @@ components:
               $ref: '#/components/schemas/ScheduleStatusDescriptionResourceAttribute'
           type: object
       type: object
+    ScheduleStatusResourceLinks:
+      description: Links related to the resource
+      properties:
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /scheduleStatus/{id}
+              format: uri
+              type: string
+          type: object
+      type: object
     ScheduleStatusResourcePatchAttributes:
       properties:
         attributes:
@@ -3240,12 +4088,7 @@ components:
       allOf:
       - $ref: '#/components/schemas/ScheduleStatusResourceReference'
       - $ref: '#/components/schemas/ScheduleStatusResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/ScheduleStatusResourceLinks'
       required:
       - attributes
     ScheduleStatusResourcesResponseSchema:
@@ -3320,6 +4163,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/TasksResourceReference'
           - $ref: '#/components/schemas/TasksResourcePatchAttributes'
+          - $ref: '#/components/schemas/TasksResourcePatchRelationships'
       required:
       - data
       type: object
@@ -3334,6 +4178,7 @@ components:
       allOf:
       - $ref: '#/components/schemas/TasksPostResourceReference'
       - $ref: '#/components/schemas/TasksResourcePostAttributes'
+      - $ref: '#/components/schemas/TasksResourcePostRelationships'
     TasksPostResourceReference:
       properties:
         id:
@@ -3367,66 +4212,175 @@ components:
       properties:
         attributes:
           properties:
-            includedProject:
-              $ref: '#/components/schemas/TasksIncludedProjectResourceAttribute'
-            includedProjects:
-              $ref: '#/components/schemas/TasksIncludedProjectsResourceAttribute'
             name:
               $ref: '#/components/schemas/TasksNameResourceAttribute'
             otherTasks:
               $ref: '#/components/schemas/TasksOtherTasksResourceAttribute'
-            project:
-              $ref: '#/components/schemas/TasksProjectResourceAttribute'
-            projects:
-              $ref: '#/components/schemas/TasksProjectsResourceAttribute'
-            schedule:
-              $ref: '#/components/schemas/TasksScheduleResourceAttribute'
             status:
               $ref: '#/components/schemas/TasksStatusResourceAttribute'
+          type: object
+      type: object
+    TasksResourceLinks:
+      description: Links related to the resource
+      properties:
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /tasks/{id}
+              format: uri
+              type: string
           type: object
       type: object
     TasksResourcePatchAttributes:
       properties:
         attributes:
           properties:
-            includedProject:
-              $ref: '#/components/schemas/TasksIncludedProjectResourceAttribute'
-            includedProjects:
-              $ref: '#/components/schemas/TasksIncludedProjectsResourceAttribute'
             name:
               $ref: '#/components/schemas/TasksNameResourceAttribute'
             otherTasks:
               $ref: '#/components/schemas/TasksOtherTasksResourceAttribute'
-            project:
-              $ref: '#/components/schemas/TasksProjectResourceAttribute'
-            projects:
-              $ref: '#/components/schemas/TasksProjectsResourceAttribute'
-            schedule:
-              $ref: '#/components/schemas/TasksScheduleResourceAttribute'
             status:
               $ref: '#/components/schemas/TasksStatusResourceAttribute'
+          type: object
+      type: object
+    TasksResourcePatchRelationships:
+      properties:
+        relationships:
+          properties:
+            includedProject:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ProjectsResourceReference'
+              type: object
+            includedProjects:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/ProjectsResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                    uniqueItems: false
+              type: object
+            project:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ProjectsResourceReference'
+              type: object
+            projects:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/ProjectsResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                    uniqueItems: false
+              type: object
+            schedule:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+              type: object
           type: object
       type: object
     TasksResourcePostAttributes:
       properties:
         attributes:
           properties:
-            includedProject:
-              $ref: '#/components/schemas/TasksIncludedProjectResourceAttribute'
-            includedProjects:
-              $ref: '#/components/schemas/TasksIncludedProjectsResourceAttribute'
             name:
               $ref: '#/components/schemas/TasksNameResourceAttribute'
             otherTasks:
               $ref: '#/components/schemas/TasksOtherTasksResourceAttribute'
-            project:
-              $ref: '#/components/schemas/TasksProjectResourceAttribute'
-            projects:
-              $ref: '#/components/schemas/TasksProjectsResourceAttribute'
-            schedule:
-              $ref: '#/components/schemas/TasksScheduleResourceAttribute'
             status:
               $ref: '#/components/schemas/TasksStatusResourceAttribute'
+          type: object
+      type: object
+    TasksResourcePostRelationships:
+      properties:
+        relationships:
+          properties:
+            includedProject:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ProjectsResourceReference'
+              type: object
+            includedProjects:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/ProjectsResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                    uniqueItems: false
+              type: object
+            project:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ProjectsResourceReference'
+              type: object
+            projects:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/ProjectsResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                    uniqueItems: false
+              type: object
+            schedule:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+              type: object
           type: object
       type: object
     TasksResourceReference:
@@ -3454,6 +4408,115 @@ components:
             $ref: '#/components/schemas/TasksResourceReference'
           type: array
       type: object
+    TasksResourceRelationships:
+      description: Relationships between the resource and other JSON:API resources
+      properties:
+        relationships:
+          properties:
+            includedProject:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ProjectsResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /tasks/{id}/includedProject
+                      type: string
+                    self:
+                      default: /tasks/{id}/relationships/includedProject
+                      type: string
+                  type: object
+              type: object
+            includedProjects:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/ProjectsResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                    uniqueItems: false
+                links:
+                  properties:
+                    related:
+                      default: /tasks/{id}/includedProjects
+                      type: string
+                    self:
+                      default: /tasks/{id}/relationships/includedProjects
+                      type: string
+                  type: object
+              type: object
+            project:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ProjectsResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /tasks/{id}/project
+                      type: string
+                    self:
+                      default: /tasks/{id}/relationships/project
+                      type: string
+                  type: object
+              type: object
+            projects:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      items:
+                        $ref: '#/components/schemas/ProjectsResourceReference'
+                      type: array
+                      uniqueItems: false
+                    type: array
+                  - items:
+                      $ref: '#/components/schemas/ProjectsResourceReference'
+                    type: array
+                    uniqueItems: false
+                links:
+                  properties:
+                    related:
+                      default: /tasks/{id}/projects
+                      type: string
+                    self:
+                      default: /tasks/{id}/relationships/projects
+                      type: string
+                  type: object
+              type: object
+            schedule:
+              properties:
+                data:
+                  oneOf:
+                  - items:
+                      $ref: '#/components/schemas/ScheduleResourceReference'
+                    type: array
+                  - $ref: '#/components/schemas/ScheduleResourceReference'
+                links:
+                  properties:
+                    related:
+                      default: /tasks/{id}/schedule
+                      type: string
+                    self:
+                      default: /tasks/{id}/relationships/schedule
+                      type: string
+                  type: object
+              type: object
+          type: object
+      type: object
     TasksResourceResponseSchema:
       allOf:
       - $ref: '#/components/schemas/Success'
@@ -3466,12 +4529,8 @@ components:
       allOf:
       - $ref: '#/components/schemas/TasksResourceReference'
       - $ref: '#/components/schemas/TasksResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/TasksResourceRelationships'
+      - $ref: '#/components/schemas/TasksResourceLinks'
       required:
       - attributes
     TasksResourcesResponseSchema:

--- a/crnk-gen/crnk-gen-openapi/src/test/resources/gold/complex.yaml
+++ b/crnk-gen/crnk-gen-openapi/src/test/resources/gold/complex.yaml
@@ -975,9 +975,9 @@ components:
         id:
           $ref: '#/components/schemas/CommentIdResourceAttribute'
         type:
-          description: The JSON:API resource type (Comment)
+          description: The JSON:API resource type (comment)
           enum:
-          - Comment
+          - comment
           type: string
       required:
       - type
@@ -1034,9 +1034,9 @@ components:
         id:
           $ref: '#/components/schemas/CommentIdResourceAttribute'
         type:
-          description: The JSON:API resource type (Comment)
+          description: The JSON:API resource type (comment)
           enum:
-          - Comment
+          - comment
           type: string
       required:
       - id
@@ -1135,9 +1135,9 @@ components:
         id:
           $ref: '#/components/schemas/HeaderIdResourceAttribute'
         type:
-          description: The JSON:API resource type (Header)
+          description: The JSON:API resource type (header)
           enum:
-          - Header
+          - header
           type: string
       required:
       - type
@@ -1194,9 +1194,9 @@ components:
         id:
           $ref: '#/components/schemas/HeaderIdResourceAttribute'
         type:
-          description: The JSON:API resource type (Header)
+          description: The JSON:API resource type (header)
           enum:
-          - Header
+          - header
           type: string
       required:
       - id
@@ -1280,9 +1280,9 @@ components:
         id:
           $ref: '#/components/schemas/HistoricTasksIdResourceAttribute'
         type:
-          description: The JSON:API resource type (HistoricTasks)
+          description: The JSON:API resource type (historicTasks)
           enum:
-          - HistoricTasks
+          - historicTasks
           type: string
       required:
       - type
@@ -1325,9 +1325,9 @@ components:
         id:
           $ref: '#/components/schemas/HistoricTasksIdResourceAttribute'
         type:
-          description: The JSON:API resource type (HistoricTasks)
+          description: The JSON:API resource type (historicTasks)
           enum:
-          - HistoricTasks
+          - historicTasks
           type: string
       required:
       - id
@@ -1451,9 +1451,9 @@ components:
         id:
           $ref: '#/components/schemas/NestedRelatedIdResourceAttribute'
         type:
-          description: The JSON:API resource type (NestedRelated)
+          description: The JSON:API resource type (nestedRelated)
           enum:
-          - NestedRelated
+          - nestedRelated
           type: string
       required:
       - type
@@ -1490,9 +1490,9 @@ components:
         id:
           $ref: '#/components/schemas/NestedRelatedIdResourceAttribute'
         type:
-          description: The JSON:API resource type (NestedRelated)
+          description: The JSON:API resource type (nestedRelated)
           enum:
-          - NestedRelated
+          - nestedRelated
           type: string
       required:
       - id
@@ -1573,9 +1573,9 @@ components:
         id:
           $ref: '#/components/schemas/NoAccessTaskIdResourceAttribute'
         type:
-          description: The JSON:API resource type (NoAccessTask)
+          description: The JSON:API resource type (noAccessTask)
           enum:
-          - NoAccessTask
+          - noAccessTask
           type: string
       required:
       - type
@@ -1614,9 +1614,9 @@ components:
         id:
           $ref: '#/components/schemas/NoAccessTaskIdResourceAttribute'
         type:
-          description: The JSON:API resource type (NoAccessTask)
+          description: The JSON:API resource type (noAccessTask)
           enum:
-          - NoAccessTask
+          - noAccessTask
           type: string
       required:
       - id
@@ -1724,9 +1724,9 @@ components:
         id:
           $ref: '#/components/schemas/PostIdResourceAttribute'
         type:
-          description: The JSON:API resource type (Post)
+          description: The JSON:API resource type (post)
           enum:
-          - Post
+          - post
           type: string
       required:
       - type
@@ -1775,9 +1775,9 @@ components:
         id:
           $ref: '#/components/schemas/PostIdResourceAttribute'
         type:
-          description: The JSON:API resource type (Post)
+          description: The JSON:API resource type (post)
           enum:
-          - Post
+          - post
           type: string
       required:
       - id
@@ -1944,9 +1944,9 @@ components:
         id:
           $ref: '#/components/schemas/PrimitiveAttributeIdResourceAttribute'
         type:
-          description: The JSON:API resource type (PrimitiveAttribute)
+          description: The JSON:API resource type (primitiveAttribute)
           enum:
-          - PrimitiveAttribute
+          - primitiveAttribute
           type: string
       required:
       - type
@@ -2127,9 +2127,9 @@ components:
         id:
           $ref: '#/components/schemas/PrimitiveAttributeIdResourceAttribute'
         type:
-          description: The JSON:API resource type (PrimitiveAttribute)
+          description: The JSON:API resource type (primitiveAttribute)
           enum:
-          - PrimitiveAttribute
+          - primitiveAttribute
           type: string
       required:
       - id
@@ -2246,9 +2246,9 @@ components:
         id:
           $ref: '#/components/schemas/ProjectsIdResourceAttribute'
         type:
-          description: The JSON:API resource type (Projects)
+          description: The JSON:API resource type (projects)
           enum:
-          - Projects
+          - projects
           type: string
       required:
       - type
@@ -2315,9 +2315,9 @@ components:
         id:
           $ref: '#/components/schemas/ProjectsIdResourceAttribute'
         type:
-          description: The JSON:API resource type (Projects)
+          description: The JSON:API resource type (projects)
           enum:
-          - Projects
+          - projects
           type: string
       required:
       - id
@@ -2406,9 +2406,9 @@ components:
         id:
           $ref: '#/components/schemas/ReadOnlyTaskIdResourceAttribute'
         type:
-          description: The JSON:API resource type (ReadOnlyTask)
+          description: The JSON:API resource type (readOnlyTask)
           enum:
-          - ReadOnlyTask
+          - readOnlyTask
           type: string
       required:
       - type
@@ -2447,9 +2447,9 @@ components:
         id:
           $ref: '#/components/schemas/ReadOnlyTaskIdResourceAttribute'
         type:
-          description: The JSON:API resource type (ReadOnlyTask)
+          description: The JSON:API resource type (readOnlyTask)
           enum:
-          - ReadOnlyTask
+          - readOnlyTask
           type: string
       required:
       - id
@@ -2530,9 +2530,9 @@ components:
         id:
           $ref: '#/components/schemas/RelationIdTestIdResourceAttribute'
         type:
-          description: The JSON:API resource type (RelationIdTest)
+          description: The JSON:API resource type (relationIdTest)
           enum:
-          - RelationIdTest
+          - relationIdTest
           type: string
       required:
       - type
@@ -2623,9 +2623,9 @@ components:
         id:
           $ref: '#/components/schemas/RelationIdTestIdResourceAttribute'
         type:
-          description: The JSON:API resource type (RelationIdTest)
+          description: The JSON:API resource type (relationIdTest)
           enum:
-          - RelationIdTest
+          - relationIdTest
           type: string
       required:
       - id
@@ -2726,9 +2726,9 @@ components:
         id:
           $ref: '#/components/schemas/RelocatedTaskIdResourceAttribute'
         type:
-          description: The JSON:API resource type (RelocatedTask)
+          description: The JSON:API resource type (relocatedTask)
           enum:
-          - RelocatedTask
+          - relocatedTask
           type: string
       required:
       - type
@@ -2771,9 +2771,9 @@ components:
         id:
           $ref: '#/components/schemas/RelocatedTaskIdResourceAttribute'
         type:
-          description: The JSON:API resource type (RelocatedTask)
+          description: The JSON:API resource type (relocatedTask)
           enum:
-          - RelocatedTask
+          - relocatedTask
           type: string
       required:
       - id
@@ -2850,9 +2850,9 @@ components:
         id:
           $ref: '#/components/schemas/RenamedIdIdResourceAttribute'
         type:
-          description: The JSON:API resource type (RenamedId)
+          description: The JSON:API resource type (renamedId)
           enum:
-          - RenamedId
+          - renamedId
           type: string
       required:
       - type
@@ -2889,9 +2889,9 @@ components:
         id:
           $ref: '#/components/schemas/RenamedIdIdResourceAttribute'
         type:
-          description: The JSON:API resource type (RenamedId)
+          description: The JSON:API resource type (renamedId)
           enum:
-          - RenamedId
+          - renamedId
           type: string
       required:
       - id
@@ -2983,9 +2983,9 @@ components:
         id:
           $ref: '#/components/schemas/ScheduleIdResourceAttribute'
         type:
-          description: The JSON:API resource type (Schedule)
+          description: The JSON:API resource type (schedule)
           enum:
-          - Schedule
+          - schedule
           type: string
       required:
       - type
@@ -3078,9 +3078,9 @@ components:
         id:
           $ref: '#/components/schemas/ScheduleIdResourceAttribute'
         type:
-          description: The JSON:API resource type (Schedule)
+          description: The JSON:API resource type (schedule)
           enum:
-          - Schedule
+          - schedule
           type: string
       required:
       - id
@@ -3161,9 +3161,9 @@ components:
         id:
           $ref: '#/components/schemas/ScheduleStatusIdResourceAttribute'
         type:
-          description: The JSON:API resource type (ScheduleStatus)
+          description: The JSON:API resource type (scheduleStatus)
           enum:
-          - ScheduleStatus
+          - scheduleStatus
           type: string
       required:
       - type
@@ -3208,9 +3208,9 @@ components:
         id:
           $ref: '#/components/schemas/ScheduleStatusIdResourceAttribute'
         type:
-          description: The JSON:API resource type (ScheduleStatus)
+          description: The JSON:API resource type (scheduleStatus)
           enum:
-          - ScheduleStatus
+          - scheduleStatus
           type: string
       required:
       - id
@@ -3339,9 +3339,9 @@ components:
         id:
           $ref: '#/components/schemas/TasksIdResourceAttribute'
         type:
-          description: The JSON:API resource type (Tasks)
+          description: The JSON:API resource type (tasks)
           enum:
-          - Tasks
+          - tasks
           type: string
       required:
       - type
@@ -3434,9 +3434,9 @@ components:
         id:
           $ref: '#/components/schemas/TasksIdResourceAttribute'
         type:
-          description: The JSON:API resource type (Tasks)
+          description: The JSON:API resource type (tasks)
           enum:
-          - Tasks
+          - tasks
           type: string
       required:
       - id

--- a/crnk-gen/crnk-gen-openapi/src/test/resources/gold/simple.yaml
+++ b/crnk-gen/crnk-gen-openapi/src/test/resources/gold/simple.yaml
@@ -345,9 +345,9 @@ components:
         id:
           $ref: '#/components/schemas/SimpleTasksIdResourceAttribute'
         type:
-          description: The JSON:API resource type (SimpleTasks)
+          description: The JSON:API resource type (simpleTasks)
           enum:
-          - SimpleTasks
+          - simpleTasks
           type: string
       required:
       - type
@@ -390,9 +390,9 @@ components:
         id:
           $ref: '#/components/schemas/SimpleTasksIdResourceAttribute'
         type:
-          description: The JSON:API resource type (SimpleTasks)
+          description: The JSON:API resource type (simpleTasks)
           enum:
-          - SimpleTasks
+          - simpleTasks
           type: string
       required:
       - id

--- a/crnk-gen/crnk-gen-openapi/src/test/resources/gold/simple.yaml
+++ b/crnk-gen/crnk-gen-openapi/src/test/resources/gold/simple.yaml
@@ -369,6 +369,19 @@ components:
               $ref: '#/components/schemas/SimpleTasksNameResourceAttribute'
           type: object
       type: object
+    SimpleTasksResourceLinks:
+      description: Links related to the resource
+      properties:
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          properties:
+            self:
+              default: /simpleTasks/{id}
+              format: uri
+              type: string
+          type: object
+      type: object
     SimpleTasksResourcePatchAttributes:
       properties:
         attributes:
@@ -422,12 +435,7 @@ components:
       allOf:
       - $ref: '#/components/schemas/SimpleTasksResourceReference'
       - $ref: '#/components/schemas/SimpleTasksResourceAttributes'
-      - properties:
-          links:
-            type: object
-          relationships:
-            type: object
-        type: object
+      - $ref: '#/components/schemas/SimpleTasksResourceLinks'
       required:
       - attributes
     SimpleTasksResourcesResponseSchema:


### PR DESCRIPTION
* Generate OpenAPI resource types with correct letters case
* Fix schemas containing or defining resource attributes and relationships
  * relationship fields separated from attributes
  * only valid (containing at least one property) relationships and attributes schemas are generated
  * enhanced relationship inner structures
  * links (with explicitly defined self link) in separate schema

Fixes https://github.com/crnk-project/crnk-framework/issues/695