### PR TITLE
cover non-JSON:API HTTP method by constants

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/http/HttpMethod.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/http/HttpMethod.java
@@ -8,5 +8,8 @@ public enum HttpMethod {
 	GET,
 	POST,
 	DELETE,
-	PATCH
+	PATCH,
+	PUT,
+	OPTIONS,
+	HEAD
 }


### PR DESCRIPTION
will allow custom extensions to make use of those methods