### PR TITLE
Enable PATCH requests to BulkResourceRepository implementations via operations module

### DIFF
--- a/crnk-operations/src/main/java/io/crnk/operations/server/OperationsModule.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/server/OperationsModule.java
@@ -263,8 +263,8 @@ public class OperationsModule implements Module {
             JsonPath repositoryPath = new ResourcePath(rootEntry, null);
 
             PreconditionUtil.assertTrue(
-                method.equals(HttpMethod.POST.toString()) || method.equals(HttpMethod.DELETE.toString()) ,
-                "experimental bulk support is currently limited to POST and DELETE"
+                method.equals(HttpMethod.POST.toString()) || method.equals(HttpMethod.DELETE.toString()) || method.equals(HttpMethod.PATCH.toString()) ,
+                "experimental bulk support is currently limited to POST, PATCH and DELETE"
             );
 
             Document requestBody = new Document();


### PR DESCRIPTION
This begins to address #761 but I am very open to any guidance because I am not sure this handles the issue completely. It does seem that support for `PATCH` requests here is already implemented or expected, and the check for `POST` and `DELETE` requests specifically had just not been updated to reflect that. Let me know if I am mistaken or going down the wrong path here. Happy to write tests as well if this is sufficient.