### PR TITLE
#767 send filter in body instead of URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ gradle.beforeProject { Project project ->
         if (!docs && !examples && !testProject && !legacyBraveProject) {
             apply plugin: "jacoco"
             jacoco {
-                toolVersion = "0.7.6.201602180812"
+                toolVersion = "0.8.5"
             }
 
             rootProject.tasks.jacocoMerge.executionData tasks.withType(Test)

--- a/crnk-client/src/main/java/io/crnk/client/CrnkClient.java
+++ b/crnk-client/src/main/java/io/crnk/client/CrnkClient.java
@@ -322,6 +322,7 @@ public class CrnkClient {
 		setupServiceDiscovery();
 		initHttpAdapter();
 
+		setupUrlMapper();
 		setupPagingBehavior();
 		initObjectMapper();
 		configureObjectMapper();
@@ -334,6 +335,17 @@ public class CrnkClient {
 		Optional<Module> plainJsonModule = moduleRegistry.getModules().stream().filter(it -> it.getModuleName().equals("plain-json")).findFirst();
 		if (plainJsonModule.isPresent()) {
 			format = ClientFormat.PLAINJSON;
+		}
+	}
+
+	private void setupUrlMapper() {
+		if (filterCriteriaInRequestBody) {
+			QuerySpecUrlMapper urlMapper = moduleRegistry.getUrlMapper();
+			if (urlMapper instanceof DefaultQuerySpecUrlMapper) {
+				((DefaultQuerySpecUrlMapper) urlMapper).setFilterCriteriaInRequestBody(filterCriteriaInRequestBody);
+			} else {
+				throw new IllegalStateException("Need DefaultQuerySpecUrlMapper for filterCriteriaInRequestBody option");
+			}
 		}
 	}
 

--- a/crnk-client/src/main/java/io/crnk/client/http/apache/HttpClientRequest.java
+++ b/crnk-client/src/main/java/io/crnk/client/http/apache/HttpClientRequest.java
@@ -39,7 +39,11 @@ public class HttpClientRequest implements HttpAdapterRequest {
         this.listeners = listeners;
         this.requestBody = requestBody;
         if (method == HttpMethod.GET) {
-            requestBase = new HttpGet(url);
+        	if (requestBody == null || requestBody.isEmpty()) {
+				requestBase = new HttpGet(url);
+			} else {
+        		requestBase = new HttpGetWithBody(url, requestBody, CONTENT_TYPE);
+			}
         } else if (method == HttpMethod.POST) {
             HttpPost post = new HttpPost(url);
             post.setEntity(new StringEntity(requestBody, CONTENT_TYPE));

--- a/crnk-client/src/main/java/io/crnk/client/http/apache/HttpGetWithBody.java
+++ b/crnk-client/src/main/java/io/crnk/client/http/apache/HttpGetWithBody.java
@@ -1,0 +1,20 @@
+package io.crnk.client.http.apache;
+
+import io.crnk.core.engine.http.HttpMethod;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+
+import java.net.URI;
+
+public class HttpGetWithBody extends HttpEntityEnclosingRequestBase {
+	public HttpGetWithBody(String url, String body, ContentType contentType) {
+		setURI(URI.create(url));
+		setEntity(new StringEntity(body, contentType));
+	}
+
+	@Override
+	public String getMethod() {
+		return HttpMethod.GET.toString();
+	}
+}

--- a/crnk-client/src/main/java/io/crnk/client/internal/RelationshipRepositoryStubImpl.java
+++ b/crnk-client/src/main/java/io/crnk/client/internal/RelationshipRepositoryStubImpl.java
@@ -21,114 +21,123 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 public class RelationshipRepositoryStubImpl<T, I, D, J> extends ClientStubBase
-        implements RelationshipRepository<T, I, D, J> {
+		implements RelationshipRepository<T, I, D, J> {
 
-    private Class<T> sourceClass;
+	private Class<T> sourceClass;
 
-    private Class<D> targetClass;
+	private Class<D> targetClass;
 
-    private ResourceInformation sourceResourceInformation;
+	private ResourceInformation sourceResourceInformation;
 
-    public RelationshipRepositoryStubImpl(CrnkClient client, Class<T> sourceClass, Class<D> targetClass,
-                                          ResourceInformation sourceResourceInformation, UrlBuilder urlBuilder) {
-        super(client, urlBuilder, targetClass);
-        this.sourceClass = sourceClass;
-        this.targetClass = targetClass;
-        this.sourceResourceInformation = sourceResourceInformation;
-    }
+	public RelationshipRepositoryStubImpl(CrnkClient client, Class<T> sourceClass, Class<D> targetClass,
+										  ResourceInformation sourceResourceInformation, UrlBuilder urlBuilder,
+										  boolean filterCriteriaInRequestBody) {
+		super(client, urlBuilder, targetClass, filterCriteriaInRequestBody);
+		this.sourceClass = sourceClass;
+		this.targetClass = targetClass;
+		this.sourceResourceInformation = sourceResourceInformation;
+	}
 
-    @Override
-    public void setRelation(T source, J targetId, String fieldName) {
-        Serializable sourceId = getSourceId(source);
-        String url = urlBuilder.buildUrl(client.getQueryContext(), sourceResourceInformation, sourceId, (QuerySpec) null, fieldName);
-        executeWithId(url, HttpMethod.PATCH, targetId);
-    }
+	@Override
+	public void setRelation(T source, J targetId, String fieldName) {
+		Serializable sourceId = getSourceId(source);
+		String url = urlBuilder.buildUrl(client.getQueryContext(), sourceResourceInformation, sourceId, (QuerySpec) null, fieldName);
+		executeWithId(url, HttpMethod.PATCH, targetId);
+	}
 
-    @Override
-    public void setRelations(T source, Collection<J> targetIds, String fieldName) {
-        Serializable sourceId = getSourceId(source);
-        String url = urlBuilder.buildUrl(client.getQueryContext(), sourceResourceInformation, sourceId, (QuerySpec) null, fieldName);
-        executeWithIds(url, HttpMethod.PATCH, targetIds);
-    }
+	@Override
+	public void setRelations(T source, Collection<J> targetIds, String fieldName) {
+		Serializable sourceId = getSourceId(source);
+		String url = urlBuilder.buildUrl(client.getQueryContext(), sourceResourceInformation, sourceId, (QuerySpec) null, fieldName);
+		executeWithIds(url, HttpMethod.PATCH, targetIds);
+	}
 
-    @Override
-    public void addRelations(T source, Collection<J> targetIds, String fieldName) {
-        Serializable sourceId = getSourceId(source);
-        String url = urlBuilder.buildUrl(client.getQueryContext(), sourceResourceInformation, sourceId, (QuerySpec) null, fieldName);
-        executeWithIds(url, HttpMethod.POST, targetIds);
-    }
+	@Override
+	public void addRelations(T source, Collection<J> targetIds, String fieldName) {
+		Serializable sourceId = getSourceId(source);
+		String url = urlBuilder.buildUrl(client.getQueryContext(), sourceResourceInformation, sourceId, (QuerySpec) null, fieldName);
+		executeWithIds(url, HttpMethod.POST, targetIds);
+	}
 
-    @Override
-    public void removeRelations(T source, Collection<J> targetIds, String fieldName) {
-        Serializable sourceId = getSourceId(source);
-        String url = urlBuilder.buildUrl(client.getQueryContext(), sourceResourceInformation, sourceId, (QuerySpec) null, fieldName);
-        executeWithIds(url, HttpMethod.DELETE, targetIds);
-    }
+	@Override
+	public void removeRelations(T source, Collection<J> targetIds, String fieldName) {
+		Serializable sourceId = getSourceId(source);
+		String url = urlBuilder.buildUrl(client.getQueryContext(), sourceResourceInformation, sourceId, (QuerySpec) null, fieldName);
+		executeWithIds(url, HttpMethod.DELETE, targetIds);
+	}
 
-    private Serializable getSourceId(T source) {
-        if (source instanceof Resource) {
-            return ((Resource) source).getId();
-        }
-        ResourceField idField = sourceResourceInformation.getIdField();
-        return (Serializable) idField.getAccessor().getValue(source);
-    }
+	private Serializable getSourceId(T source) {
+		if (source instanceof Resource) {
+			return ((Resource) source).getId();
+		}
+		ResourceField idField = sourceResourceInformation.getIdField();
+		return (Serializable) idField.getAccessor().getValue(source);
+	}
 
-    @SuppressWarnings("unchecked")
-    @Override
-    public D findOneTarget(I sourceId, String fieldName, QuerySpec querySpec) {
-        verifyQuerySpec(querySpec);
-        String url = urlBuilder.buildUrl(client.getQueryContext(), sourceResourceInformation, sourceId, querySpec, fieldName, false);
-        return (D) executeGet(url, ResponseType.RESOURCE);
-    }
+	@SuppressWarnings("unchecked")
+	@Override
+	public D findOneTarget(I sourceId, String fieldName, QuerySpec querySpec) {
+		verifyQuerySpec(querySpec);
+		String url = urlBuilder.buildUrl(client.getQueryContext(), sourceResourceInformation, sourceId, querySpec, fieldName, false);
+		String body = null;
+		if (filterCriteriaInRequestBody) {
+			body = serializeFilter(querySpec, sourceResourceInformation);
+		}
+		return (D) executeGet(url, body, ResponseType.RESOURCE);
+	}
 
-    @Override
-    public DefaultResourceList<D> findManyTargets(I sourceId, String fieldName, QuerySpec querySpec) {
-        verifyQuerySpec(querySpec);
-        String url = urlBuilder.buildUrl(client.getQueryContext(), sourceResourceInformation, sourceId, querySpec, fieldName, false);
-        return (DefaultResourceList<D>) executeGet(url, ResponseType.RESOURCES);
-    }
+	@Override
+	public DefaultResourceList<D> findManyTargets(I sourceId, String fieldName, QuerySpec querySpec) {
+		verifyQuerySpec(querySpec);
+		String url = urlBuilder.buildUrl(client.getQueryContext(), sourceResourceInformation, sourceId, querySpec, fieldName, false);
+		String body = null;
+		if (filterCriteriaInRequestBody) {
+			body = serializeFilter(querySpec, sourceResourceInformation);
+		}
+		return (DefaultResourceList<D>) executeGet(url, body, ResponseType.RESOURCES);
+	}
 
-    protected void verifyQuerySpec(QuerySpec querySpec) {
-        Class<?> resourceClass = querySpec.getResourceClass();
-        if (resourceClass != null && !resourceClass.equals(targetClass)) {
-            throw new BadRequestException("resourceClass mismatch between repository and QuerySpec argument: "
-                    + resourceClass + " vs " + targetClass);
-        }
-    }
+	protected void verifyQuerySpec(QuerySpec querySpec) {
+		Class<?> resourceClass = querySpec.getResourceClass();
+		if (resourceClass != null && !resourceClass.equals(targetClass)) {
+			throw new BadRequestException("resourceClass mismatch between repository and QuerySpec argument: "
+					+ resourceClass + " vs " + targetClass);
+		}
+	}
 
 
-    private void executeWithIds(String requestUrl, HttpMethod method, Collection<?> targetIds) {
-        Document document = new Document();
-        ArrayList<ResourceIdentifier> resourceIdentifiers = new ArrayList<>();
-        for (Object targetId : targetIds) {
-            resourceIdentifiers.add(sourceResourceInformation.toResourceIdentifier(targetId));
-        }
-        document.setData(Nullable.of(resourceIdentifiers));
-        Document transportDocument = client.getFormat().toTransportDocument(document);
-        doExecute(requestUrl, method, transportDocument);
-    }
+	private void executeWithIds(String requestUrl, HttpMethod method, Collection<?> targetIds) {
+		Document document = new Document();
+		ArrayList<ResourceIdentifier> resourceIdentifiers = new ArrayList<>();
+		for (Object targetId : targetIds) {
+			resourceIdentifiers.add(sourceResourceInformation.toResourceIdentifier(targetId));
+		}
+		document.setData(Nullable.of(resourceIdentifiers));
+		Document transportDocument = client.getFormat().toTransportDocument(document);
+		doExecute(requestUrl, method, transportDocument);
+	}
 
-    private void executeWithId(String requestUrl, HttpMethod method, Object targetId) {
-        Document document = new Document();
-        ResourceIdentifier resourceIdentifier = sourceResourceInformation.toResourceIdentifier(targetId);
-        document.setData(Nullable.of(resourceIdentifier));
-        Document transportDocument = client.getFormat().toTransportDocument(document);
-        doExecute(requestUrl, method, transportDocument);
-    }
+	private void executeWithId(String requestUrl, HttpMethod method, Object targetId) {
+		Document document = new Document();
+		ResourceIdentifier resourceIdentifier = sourceResourceInformation.toResourceIdentifier(targetId);
+		document.setData(Nullable.of(resourceIdentifier));
+		Document transportDocument = client.getFormat().toTransportDocument(document);
+		doExecute(requestUrl, method, transportDocument);
+	}
 
-    private void doExecute(String requestUrl, HttpMethod method, final Document document) {
-        final ObjectMapper objectMapper = client.getObjectMapper();
-        String requestBodyValue = ExceptionUtil.wrapCatchedExceptions(() -> objectMapper.writeValueAsString(document));
-        execute(requestUrl, ResponseType.NONE, method, requestBodyValue);
-    }
+	private void doExecute(String requestUrl, HttpMethod method, final Document document) {
+		final ObjectMapper objectMapper = client.getObjectMapper();
+		String requestBodyValue = ExceptionUtil.wrapCatchedExceptions(() -> objectMapper.writeValueAsString(document));
+		execute(requestUrl, ResponseType.NONE, method, requestBodyValue);
+	}
 
-    @Override
-    public Class<T> getSourceResourceClass() {
-        return sourceClass;
-    }
+	@Override
+	public Class<T> getSourceResourceClass() {
+		return sourceClass;
+	}
 
-    @Override
-    public Class<D> getTargetResourceClass() {
-        return targetClass;
-    }
+	@Override
+	public Class<D> getTargetResourceClass() {
+		return targetClass;
+	}
 }

--- a/crnk-client/src/main/java/io/crnk/client/internal/ResourceRepositoryStubImpl.java
+++ b/crnk-client/src/main/java/io/crnk/client/internal/ResourceRepositoryStubImpl.java
@@ -11,7 +11,6 @@ import io.crnk.core.engine.information.resource.ResourceField;
 import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.document.mapper.DocumentMappingConfig;
 import io.crnk.core.engine.internal.utils.ExceptionUtil;
-import io.crnk.core.engine.internal.utils.JsonApiUrlBuilder;
 import io.crnk.core.engine.query.QueryAdapter;
 import io.crnk.core.exception.BadRequestException;
 import io.crnk.core.queryspec.QuerySpec;
@@ -37,8 +36,8 @@ public class ResourceRepositoryStubImpl<T, I> extends ClientStubBase
 
 
 	public ResourceRepositoryStubImpl(CrnkClient client, Class<T> resourceClass, ResourceInformation resourceInformation,
-									  UrlBuilder urlBuilder) {
-		super(client, urlBuilder, resourceClass);
+									  UrlBuilder urlBuilder, boolean filterCriteriaInRequestBody) {
+		super(client, urlBuilder, resourceClass, filterCriteriaInRequestBody);
 		this.resourceInformation = resourceInformation;
 	}
 
@@ -171,19 +170,27 @@ public class ResourceRepositoryStubImpl<T, I> extends ClientStubBase
 	public DefaultResourceList<T> findAll(QuerySpec querySpec) {
 		verifyQuerySpec(querySpec);
 		String url = urlBuilder.buildUrl(client.getQueryContext(), resourceInformation, null, querySpec);
-		return findAll(url);
+		String body = null;
+		if (filterCriteriaInRequestBody) {
+			body = serializeFilter(querySpec, resourceInformation);
+		}
+		return findAll(url, body);
 	}
 
 	@Override
 	public DefaultResourceList<T> findAll(Collection<I> ids, QuerySpec querySpec) {
 		verifyQuerySpec(querySpec);
 		String url = urlBuilder.buildUrl(client.getQueryContext(), resourceInformation, ids, querySpec);
-		return findAll(url);
+		String body = null;
+		if (filterCriteriaInRequestBody) {
+			body = serializeFilter(querySpec, resourceInformation);
+		}
+		return findAll(url, body);
 	}
 
 	@SuppressWarnings("unchecked")
-	public DefaultResourceList<T> findAll(String url) {
-		return (DefaultResourceList<T>) executeGet(url, ResponseType.RESOURCES);
+	public DefaultResourceList<T> findAll(String url, String body) {
+		return (DefaultResourceList<T>) executeGet(url, body, ResponseType.RESOURCES);
 	}
 
 	protected void verifyQuerySpec(QuerySpec querySpec) {
@@ -196,7 +203,7 @@ public class ResourceRepositoryStubImpl<T, I> extends ClientStubBase
 
 	@SuppressWarnings("unchecked")
 	protected T findOne(String url) {
-		return (T) executeGet(url, ResponseType.RESOURCE);
+		return (T) executeGet(url, null, ResponseType.RESOURCE);
 	}
 
 }

--- a/crnk-client/src/main/java/io/crnk/client/internal/proxy/ClientProxyFactoryContext.java
+++ b/crnk-client/src/main/java/io/crnk/client/internal/proxy/ClientProxyFactoryContext.java
@@ -7,6 +7,9 @@ public interface ClientProxyFactoryContext {
 
 	ModuleRegistry getModuleRegistry();
 
-	<T> DefaultResourceList<T> getCollection(Class<T> resourceClass, String url);
+	<T> DefaultResourceList<T> getCollection(Class<T> resourceClass, String url, String body);
 
+	default <T> DefaultResourceList<T> getCollection(Class<T> resourceClass, String url) {
+		return getCollection(resourceClass, url, null);
+	}
 }

--- a/crnk-client/src/test/java/io/crnk/client/FilterCriteriaInBodyClientTest.java
+++ b/crnk-client/src/test/java/io/crnk/client/FilterCriteriaInBodyClientTest.java
@@ -1,0 +1,85 @@
+package io.crnk.client;
+
+import io.crnk.client.http.apache.HttpClientAdapter;
+import io.crnk.core.boot.CrnkProperties;
+import io.crnk.core.queryspec.FilterOperator;
+import io.crnk.core.queryspec.FilterSpec;
+import io.crnk.core.queryspec.PathSpec;
+import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.repository.ResourceRepository;
+import io.crnk.core.resource.list.ResourceList;
+import io.crnk.test.mock.models.Project;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertEquals;
+
+public class FilterCriteriaInBodyClientTest extends AbstractClientTest {
+	private static final int PROJECT_COUNT = 10;
+
+	private ResourceRepository<Project, Long> projectRepo;
+
+	@Before
+	public void setup() {
+		super.setup();
+		projectRepo = client.getRepositoryForType(Project.class);
+		createProjects();
+	}
+
+	private void createProjects() {
+		for (long i = 0; i < PROJECT_COUNT; i++) {
+			Project project = new Project();
+			project.setName("Project " + (char) ('A' + i));
+			if (i == 5) {
+				project.setDescription("Test");
+			}
+			projectRepo.create(project);
+		}
+	}
+
+	@Override
+	protected TestApplication configure() {
+		TestApplication app = super.configure();
+		app.setProperties(Collections.singletonMap(CrnkProperties.FILTER_CRITERIA_IN_HTTP_BODY, Boolean.TRUE.toString()));
+		return app;
+	}
+
+	@Override
+	protected void setupClient(CrnkClient client) {
+		client.setHttpAdapter(new HttpClientAdapter());
+		client.setFilterCriteriaInRequestBody(true);
+	}
+
+	@Test
+	public void testWithoutFilter() {
+		ResourceRepository<Project, Long> projectRepo = client.getRepositoryForType(Project.class);
+		ResourceList<Project> projects = projectRepo.findAll(new QuerySpec(Project.class));
+		assertNotNull(projects);
+		assertEquals(PROJECT_COUNT, projects.size());
+	}
+
+	@Test
+	public void testWithSingleFilter() {
+		ResourceRepository<Project, Long> projectRepo = client.getRepositoryForType(Project.class);
+		QuerySpec querySpec = new QuerySpec(Project.class);
+		querySpec.addFilter(PathSpec.of("id").filter(FilterOperator.LT, 5));
+		ResourceList<Project> projects = projectRepo.findAll(querySpec);
+		assertNotNull(projects);
+		assertEquals(4, projects.size());
+	}
+
+	@Test
+	public void testWithCombinedFilter() {
+		ResourceRepository<Project, Long> projectRepo = client.getRepositoryForType(Project.class);
+		QuerySpec querySpec = new QuerySpec(Project.class);
+		querySpec.addFilter(FilterSpec.or(
+				PathSpec.of("id").filter(FilterOperator.LT, 5),
+				PathSpec.of("description").filter(FilterOperator.EQ, "Test")));
+		ResourceList<Project> projects = projectRepo.findAll(querySpec);
+		assertNotNull(projects);
+		assertEquals(5, projects.size());
+	}
+}

--- a/crnk-client/src/test/java/io/crnk/client/internal/ClientStubBaseTest.java
+++ b/crnk-client/src/test/java/io/crnk/client/internal/ClientStubBaseTest.java
@@ -42,7 +42,7 @@ public class ClientStubBaseTest {
 
 		urlBuilder = Mockito.mock(JsonApiUrlBuilder.class);
 
-		stub = new ClientStubBase(client, urlBuilder, Task.class);
+		stub = new ClientStubBase(client, urlBuilder, Task.class, false);
 	}
 
 	@Test

--- a/crnk-core/src/main/java/io/crnk/core/boot/CrnkBoot.java
+++ b/crnk-core/src/main/java/io/crnk/core/boot/CrnkBoot.java
@@ -543,7 +543,9 @@ public class CrnkBoot {
 		if (moduleRegistry.getUrlMapper() == null) {
 			List<QuerySpecUrlMapper> list = serviceDiscovery.getInstancesByType(QuerySpecUrlMapper.class);
 			if (list.isEmpty()) {
-				moduleRegistry.setUrlMapper(new DefaultQuerySpecUrlMapper());
+				DefaultQuerySpecUrlMapper urlMapper = new DefaultQuerySpecUrlMapper();
+				urlMapper.setFilterCriteriaInRequestBody("true".equals(propertiesProvider.getProperty(CrnkProperties.FILTER_CRITERIA_IN_HTTP_BODY)));
+				moduleRegistry.setUrlMapper(urlMapper);
 			}
 			else {
 				moduleRegistry.setUrlMapper(list.get(0));

--- a/crnk-core/src/main/java/io/crnk/core/boot/CrnkProperties.java
+++ b/crnk-core/src/main/java/io/crnk/core/boot/CrnkProperties.java
@@ -152,9 +152,17 @@ public class CrnkProperties {
      * <p>
      * Set a boolean whether Crnk should throw
      * {@link io.crnk.core.exception.ResourceNotFoundException ResourceNotFoundException} if related resources are missing.
-     * </p>
+     * </p>crnk.config.resource.request.filterCriteriaInHttp
      * <p>Set this to <code>false</code> to ignore missing related resources.</p>
      */
     public static final String EXCEPTION_ON_MISSING_RELATED_RESOURCE = "crnk.config.serialize.relation.exceptionOnMissingRelatedResource";
+
+	/**
+	 * <p>Set a boolean if crnk should send filter criteria in the HTTP GET request body.</p>
+	 * <p>By default and in compliance with the JSON API Spec, the filter has to be sent as query param in the URL.
+	 * But this might result in errors related to the maximum supported length of URLs, especially with nested filters.
+	 * Sending the parameters in the request body will allow for longer, more complex filters.</p>
+	 */
+	public static final String FILTER_CRITERIA_IN_HTTP_BODY = "crnk.config.resource.request.filterCriteriaInHttpBody";
 
 }

--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/http/JsonApiRequestProcessorBase.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/http/JsonApiRequestProcessorBase.java
@@ -9,10 +9,7 @@ import io.crnk.core.boot.CrnkProperties;
 import io.crnk.core.engine.dispatcher.Response;
 import io.crnk.core.engine.document.Document;
 import io.crnk.core.engine.document.ErrorData;
-import io.crnk.core.engine.http.HttpHeaders;
-import io.crnk.core.engine.http.HttpRequestContext;
-import io.crnk.core.engine.http.HttpResponse;
-import io.crnk.core.engine.http.HttpStatus;
+import io.crnk.core.engine.http.*;
 import io.crnk.core.exception.MethodNotAllowedException;
 import io.crnk.core.module.Module;
 import org.slf4j.Logger;
@@ -70,7 +67,7 @@ public class JsonApiRequestProcessorBase {
 
 	protected Document getRequestDocument(HttpRequestContext requestContext) throws JsonProcessingException {
 		byte[] requestBody = requestContext.getRequestBody();
-		if (requestBody != null && requestBody.length > 0) {
+		if (requestBody != null && requestBody.length > 0 && !HttpMethod.GET.toString().equals(requestContext.getMethod())) {
 			ObjectMapper objectMapper = moduleContext.getObjectMapper();
 			try {
 				return objectMapper.readerFor(Document.class).readValue(requestBody);

--- a/crnk-core/src/main/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapper.java
+++ b/crnk-core/src/main/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapper.java
@@ -3,6 +3,7 @@ package io.crnk.core.queryspec.mapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.crnk.core.engine.http.HttpMethod;
 import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.utils.ClassUtils;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
@@ -202,7 +203,7 @@ public class DefaultQuerySpecUrlMapper
 					deserializeUnknown(querySpec, parameter);
 			}
 		}
-		if (filterCriteriaInRequestBody) {
+		if (filterCriteriaInRequestBody && HttpMethod.GET.toString().equals(queryContext.getRequestContext().getMethod())) {
 			parseFilterFromBody(resourceInformation, queryContext, rootQuerySpec);
 		}
 

--- a/crnk-core/src/test/java/io/crnk/core/mock/TestHttpRequestContext.java
+++ b/crnk-core/src/test/java/io/crnk/core/mock/TestHttpRequestContext.java
@@ -1,0 +1,107 @@
+package io.crnk.core.mock;
+
+import io.crnk.core.engine.http.HttpRequestContext;
+import io.crnk.core.engine.http.HttpResponse;
+import io.crnk.core.engine.query.QueryContext;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Set;
+
+public class TestHttpRequestContext implements HttpRequestContext {
+	private byte[] requestBody = new byte[0];
+
+	@Override
+	public boolean accepts(String contentType) {
+		return false;
+	}
+
+	@Override
+	public boolean acceptsAny() {
+		return false;
+	}
+
+	@Override
+	public <T> T unwrap(Class<T> type) {
+		return null;
+	}
+
+	@Override
+	public Object getRequestAttribute(String name) {
+		return null;
+	}
+
+	@Override
+	public void setRequestAttribute(String name, Object value) {
+
+	}
+
+	@Override
+	public QueryContext getQueryContext() {
+		return null;
+	}
+
+	@Override
+	public boolean hasResponse() {
+		return false;
+	}
+
+	@Override
+	public Set<String> getRequestHeaderNames() {
+		return null;
+	}
+
+	@Override
+	public String getRequestHeader(String name) {
+		return null;
+	}
+
+	@Override
+	public Map<String, Set<String>> getRequestParameters() {
+		return null;
+	}
+
+	@Override
+	public String getPath() {
+		return null;
+	}
+
+	@Override
+	public String getBaseUrl() {
+		return null;
+	}
+
+	@Override
+	public byte[] getRequestBody() {
+		return requestBody;
+	}
+
+	public void setRequestBody(byte[] requestBody) {
+		this.requestBody = requestBody;
+	}
+
+	public void setRequestBody(String body) {
+		requestBody = body.getBytes(StandardCharsets.UTF_8);
+	}
+
+	@Override
+	public String getMethod() {
+		return null;
+	}
+
+	@Override
+	public URI getRequestUri() {
+		return null;
+	}
+
+	@Override
+	public HttpResponse getResponse() {
+		return null;
+	}
+
+	@Override
+	public void setResponse(HttpResponse response) {
+
+	}
+}

--- a/crnk-core/src/test/java/io/crnk/core/mock/TestHttpRequestContext.java
+++ b/crnk-core/src/test/java/io/crnk/core/mock/TestHttpRequestContext.java
@@ -1,5 +1,6 @@
 package io.crnk.core.mock;
 
+import io.crnk.core.engine.http.HttpMethod;
 import io.crnk.core.engine.http.HttpRequestContext;
 import io.crnk.core.engine.http.HttpResponse;
 import io.crnk.core.engine.query.QueryContext;
@@ -87,7 +88,7 @@ public class TestHttpRequestContext implements HttpRequestContext {
 
 	@Override
 	public String getMethod() {
-		return null;
+		return HttpMethod.GET.toString();
 	}
 
 	@Override

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapperDeserializerFromBodyTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapperDeserializerFromBodyTest.java
@@ -1,0 +1,127 @@
+package io.crnk.core.queryspec.mapper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.crnk.core.CoreTestContainer;
+import io.crnk.core.engine.information.resource.ResourceInformation;
+import io.crnk.core.engine.parser.TypeParser;
+import io.crnk.core.engine.registry.RegistryEntry;
+import io.crnk.core.engine.registry.ResourceRegistry;
+import io.crnk.core.mock.TestHttpRequestContext;
+import io.crnk.core.mock.models.Task;
+import io.crnk.core.mock.repository.TaskWithPagingBehavior;
+import io.crnk.core.mock.repository.TaskWithPagingBehaviorRepository;
+import io.crnk.core.mock.repository.TaskWithPagingBehaviorToProjectRepository;
+import io.crnk.core.module.SimpleModule;
+import io.crnk.core.queryspec.*;
+import io.crnk.core.queryspec.pagingspec.CustomOffsetLimitPagingBehavior;
+import io.crnk.core.queryspec.pagingspec.OffsetLimitPagingBehavior;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class DefaultQuerySpecUrlMapperDeserializerFromBodyTest extends AbstractQuerySpecTest {
+	protected DefaultQuerySpecUrlMapper urlMapper;
+
+	protected ResourceInformation taskInformation;
+
+	private ResourceInformation taskWithPagingBehaviorInformation;
+
+	private QuerySpecUrlContext deserializerContext;
+	private TestHttpRequestContext httpRequestContext;
+
+	@Before
+	public void setup() {
+		super.setup();
+
+		deserializerContext = new QuerySpecUrlContext() {
+
+			@Override
+			public ResourceRegistry getResourceRegistry() {
+				return resourceRegistry;
+			}
+
+			@Override
+			public TypeParser getTypeParser() {
+				return moduleRegistry.getTypeParser();
+			}
+
+			@Override
+			public ObjectMapper getObjectMapper() {
+				return container.getObjectMapper();
+			}
+
+			@Override
+			public UrlBuilder getUrlBuilder() {
+				return container.getModuleRegistry().getUrlBuilder();
+			}
+		};
+
+		urlMapper = new DefaultQuerySpecUrlMapper();
+		urlMapper.setFilterCriteriaInRequestBody(true);
+		urlMapper.init(deserializerContext);
+
+		RegistryEntry taskEntry = resourceRegistry.getEntry(Task.class);
+		taskInformation = taskEntry.getResourceInformation();
+		taskWithPagingBehaviorInformation = resourceRegistry.getEntry(TaskWithPagingBehavior.class).getResourceInformation();
+
+		httpRequestContext = new TestHttpRequestContext();
+		queryContext.setRequestContext(httpRequestContext);
+	}
+
+	@Override
+	protected void setup(CoreTestContainer container) {
+		super.setup(container);
+		SimpleModule customPagingModule = new SimpleModule("customPaging");
+		customPagingModule.addRepository(new TaskWithPagingBehaviorRepository());
+		customPagingModule.addRepository(new TaskWithPagingBehaviorToProjectRepository());
+		customPagingModule.addPagingBehavior(new OffsetLimitPagingBehavior());
+		customPagingModule.addPagingBehavior(new CustomOffsetLimitPagingBehavior());
+		container.addModule(customPagingModule);
+	}
+
+	@Test
+	public void testEmptyFilter() {
+		QuerySpec querySpec = urlMapper.deserialize(taskInformation, Collections.emptyMap(), queryContext);
+		assertNotNull(querySpec.getFilters());
+		assertTrue(querySpec.getFilters().isEmpty());
+	}
+
+	@Test
+	public void testSimpleEqualsFilter() {
+		httpRequestContext.setRequestBody("{\"name\": \"test\"}");
+		QuerySpec querySpec = urlMapper.deserialize(taskInformation, Collections.emptyMap(), queryContext);
+		List<FilterSpec> filters = querySpec.getFilters();
+		assertNotNull(filters);
+		assertEquals(1, filters.size());
+		FilterSpec filter = filters.get(0);
+		assertEquals(FilterOperator.EQ, filter.getOperator());
+		assertEquals(Collections.singletonList("name"), filter.getAttributePath());
+		assertEquals("test", filter.getValue());
+	}
+
+	@Test
+	public void testCompoundFilter() {
+		httpRequestContext.setRequestBody("{ \"OR\": [ {\"id\": [12, 13, 14]}, {\"name\": \"test\"} ] }");
+		QuerySpec querySpec = urlMapper.deserialize(taskInformation, Collections.emptyMap(), queryContext);
+		List<FilterSpec> filters = querySpec.getFilters();
+		assertNotNull(filters);
+		assertEquals(1, filters.size());
+		FilterSpec filter = filters.get(0);
+		assertEquals(FilterOperator.OR, filter.getOperator());
+		List<FilterSpec> expression = Arrays.asList(
+				PathSpec.of("id").filter(FilterOperator.EQ, Arrays.asList(12L, 13L, 14L)),
+				PathSpec.of("name").filter(FilterOperator.EQ, "test")
+		);
+		assertEquals(expression, filter.getExpression());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testFilterInUrlResultsInException() {
+		urlMapper.deserialize(taskInformation, Collections.singletonMap("filter[name]", Collections.singleton("test")), queryContext);
+	}
+}

--- a/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapperSerializerTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/queryspec/mapper/DefaultQuerySpecUrlMapperSerializerTest.java
@@ -12,11 +12,7 @@ import io.crnk.core.mock.models.CustomPagingPojo;
 import io.crnk.core.mock.models.Project;
 import io.crnk.core.mock.models.Schedule;
 import io.crnk.core.mock.models.Task;
-import io.crnk.core.queryspec.Direction;
-import io.crnk.core.queryspec.FilterOperator;
-import io.crnk.core.queryspec.FilterSpec;
-import io.crnk.core.queryspec.QuerySpec;
-import io.crnk.core.queryspec.SortSpec;
+import io.crnk.core.queryspec.*;
 import io.crnk.core.queryspec.pagingspec.NumberSizePagingBehavior;
 import io.crnk.core.queryspec.pagingspec.OffsetLimitPagingBehavior;
 import org.junit.Assert;
@@ -49,6 +45,7 @@ public class DefaultQuerySpecUrlMapperSerializerTest {
 		container.boot();
 
 		urlMapper = (DefaultQuerySpecUrlMapper) container.getBoot().getUrlMapper();
+		urlMapper.setFilterCriteriaInRequestBody(false);
 
 		resourceRegistry = container.getResourceRegistry();
 		urlBuilder = container.getModuleRegistry().getUrlBuilder();
@@ -277,5 +274,13 @@ public class DefaultQuerySpecUrlMapperSerializerTest {
 		RegistryEntry entry = resourceRegistry.getEntry(querySpec.getResourceClass());
 		String actualUrl = urlBuilder.buildUrl(queryContext, entry.getResourceInformation(), id, querySpec);
 		assertEquals(expectedUrl, actualUrl);
+	}
+
+	@Test
+	public void testFilterNotAddedToUrlWhenInHttpBody() {
+		urlMapper.setFilterCriteriaInRequestBody(true);
+		QuerySpec querySpec = new QuerySpec(Schedule.class);
+		querySpec.addFilter(new FilterSpec(PathSpec.of("desc"), FilterOperator.EQ, "test"));
+		check("http://127.0.0.1/schedules", null, querySpec);
 	}
 }

--- a/crnk-ui/package-lock.json
+++ b/crnk-ui/package-lock.json
@@ -470,15 +470,13 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
 			"integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"are-we-there-yet": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"delegates": "1.0.0",
 				"readable-stream": "2.3.3"
@@ -1522,8 +1520,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -1919,8 +1916,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"denodeify": {
 			"version": "1.2.1",
@@ -2733,7 +2729,6 @@
 			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"inherits": "2.0.3",
@@ -2752,7 +2747,6 @@
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"aproba": "1.1.2",
 				"console-control-strings": "1.1.0",
@@ -2769,7 +2763,6 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -2779,7 +2772,6 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -2808,8 +2800,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
 			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -3015,8 +3006,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"hash-base": {
 			"version": "2.0.2",
@@ -4554,8 +4544,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
 			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"matcher-collection": {
 			"version": "1.0.4",
@@ -4966,7 +4955,6 @@
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"are-we-there-yet": "1.1.4",
 				"console-control-strings": "1.1.0",
@@ -7281,6 +7269,15 @@
 			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
 			"dev": true
 		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -7306,15 +7303,6 @@
 						"ansi-regex": "3.0.0"
 					}
 				}
-			}
-		},
-		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "5.1.1"
 			}
 		},
 		"stringstream": {
@@ -8404,7 +8392,6 @@
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
 			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"string-width": "1.0.2"
 			},
@@ -8414,7 +8401,6 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -8424,7 +8410,6 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",


### PR DESCRIPTION
Let's continue our discussion here.

I noticed that OkHttp client does not support bodies in GET requests. It only works with Apache's HTTP client, using a custom request type.

Bodies in GET requests are not that common nowadays. In fact, it was discouraged in the deprecated RFC 2616. The new RFCs 7230-7237 for HTTP protocol do not contain this limitation any more. However, some legacy implementations do not support it and do not plan to support it in future versions. OkHttp client is one of them, see https://github.com/square/okhttp/issues/3154