### PR TITLE
Fix premature builder invocation in okhttp

### DIFF
--- a/crnk-client/src/main/java/io/crnk/client/http/okhttp/OkHttpRequest.java
+++ b/crnk-client/src/main/java/io/crnk/client/http/okhttp/OkHttpRequest.java
@@ -58,8 +58,8 @@ public class OkHttpRequest implements HttpAdapterRequest {
 
     @Override
     public HttpAdapterResponse execute() throws IOException {
-        Request request = builder.build();
         listeners.stream().forEach(it -> it.onRequest(this));
+        Request request = builder.build();
         Response response = client.newCall(request).execute();
         OkHttpResponse adapterResponse = new OkHttpResponse(response);
         listeners.stream().forEach(it -> it.onResponse(this, adapterResponse));


### PR DESCRIPTION
Listeners are not invoked as request is built before their registration.