### PR TITLE
Modified DocumentMapper to use ServiceUrlProvider for generating document self links

### DIFF
--- a/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/DocumentMapper.java
+++ b/crnk-core/src/main/java/io/crnk/core/engine/internal/document/mapper/DocumentMapper.java
@@ -1,5 +1,7 @@
 package io.crnk.core.engine.internal.document.mapper;
 
+import io.crnk.core.engine.internal.utils.UrlUtils;
+import io.crnk.core.engine.url.ServiceUrlProvider;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -143,7 +145,8 @@ public class DocumentMapper {
 							linksInformation = selfLinksInformation;
 						}
 
-						JsonApiUrlBuilder.UrlParameterBuilder urlBuilder = new JsonApiUrlBuilder.UrlParameterBuilder(requestUri.toString());
+						String selfLinkUrl = UrlUtils.concat(queryAdapter.getResourceRegistry().getServiceUrlProvider().getUrl(), requestContext.getPath());
+						JsonApiUrlBuilder.UrlParameterBuilder urlBuilder = new JsonApiUrlBuilder.UrlParameterBuilder(selfLinkUrl);
 						urlBuilder.addQueryParameters(requestContext.getRequestParameters());
 						selfLinksInformation.setSelf(urlBuilder.toString());
 					}

--- a/crnk-core/src/test/java/io/crnk/core/engine/internal/document/mapper/DocumentMapperTest.java
+++ b/crnk-core/src/test/java/io/crnk/core/engine/internal/document/mapper/DocumentMapperTest.java
@@ -78,7 +78,7 @@ public class DocumentMapperTest extends AbstractDocumentMapperTest {
 		QueryAdapter adapter = createAdapter(Task.class);
 		Mockito.when(container.getRequestContextBase().getRequestUri()).thenReturn(URI.create("http://localhost/api/foo"));
 		Document document = mapper.toDocument(toResponse(task), adapter, mappingConfig).get();
-		Assert.assertEquals("http://localhost/api/foo", getLinkText(document.getLinks().get("self")));
+		Assert.assertEquals("http://127.0.0.1/api/foo", getLinkText(document.getLinks().get("self")));
 	}
 
 	public static class TaskLinks implements LinksInformation {


### PR DESCRIPTION
This allows for relative urls (by emptying crnk.domain-name) and also improves configurability in situations where the system runs behind a proxy.

Fixes #789