### PR TITLE
Update CrnkErrorController to be compatible with Spring Boot >= 2.3.X

### DIFF
--- a/crnk-setup/crnk-setup-spring-boot2/build.gradle
+++ b/crnk-setup/crnk-setup-spring-boot2/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	compileOnly 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.springframework.boot:spring-boot-configuration-processor'
 	compileOnly 'org.springframework.boot:spring-boot-starter-actuator'
+    compileOnly 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.springframework.security:spring-security-core'
 
 	compileOnly 'org.springframework:spring-orm'
@@ -49,6 +50,7 @@ dependencies {
 	testCompile 'org.springframework.boot:spring-boot-starter-web'
 	testCompile 'org.springframework.boot:spring-boot-starter-test'
 	testCompile 'org.springframework.boot:spring-boot-starter-actuator'
+	testCompile 'org.springframework.boot:spring-boot-starter-validation'
 
 	testCompile 'org.hibernate:hibernate-core'
 	testCompile 'org.hibernate:hibernate-entitymanager'

--- a/crnk-setup/crnk-setup-spring-boot2/build.gradle
+++ b/crnk-setup/crnk-setup-spring-boot2/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'java'
 apply plugin: 'io.spring.dependency-management'
 dependencyManagement {
 	imports {
-		mavenBom 'org.springframework.boot:spring-boot-dependencies:2.0.3.RELEASE'
+		mavenBom 'org.springframework.boot:spring-boot-dependencies:2.3.12.RELEASE'
 	}
 }
 

--- a/crnk-setup/crnk-setup-spring-boot2/src/main/java/io/crnk/spring/setup/boot/mvc/CrnkErrorController.java
+++ b/crnk-setup/crnk-setup-spring-boot2/src/main/java/io/crnk/spring/setup/boot/mvc/CrnkErrorController.java
@@ -37,7 +37,7 @@ public class CrnkErrorController extends BasicErrorController {
 	@ResponseBody
 	public ResponseEntity<Document> errorToJsonApi(HttpServletRequest request) {
 		Map<String, Object> body = getErrorAttributes(request,
-				isIncludeStackTrace(request, MediaType.ALL));
+				getErrorAttributeOptions(request, MediaType.ALL));
 		HttpStatus status = getStatus(request);
 
 		ErrorDataBuilder errorDataBuilder = ErrorData.builder();

--- a/crnk-setup/crnk-setup-spring-boot2/src/test/java/io/crnk/spring/boot/BasicSpringBoot2Test.java
+++ b/crnk-setup/crnk-setup-spring-boot2/src/test/java/io/crnk/spring/boot/BasicSpringBoot2Test.java
@@ -68,7 +68,7 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = BasicSpringBoot2Application.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = BasicSpringBoot2Application.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "server.error.include-message=always")
 @DirtiesContext
 public class BasicSpringBoot2Test {
 


### PR DESCRIPTION
The `getErrorAttributes` method that the `CrnkErrorController` was calling had been deprecated in Spring Boot 2.3 and then was removed in Spring Boot 2.5 - this pull request updates the controller to use the new / non-deprecated version of the `getErrorAttributes` method.

Closes #816