### PR TITLE
Update GitHub Actions to use Temurin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,15 +9,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Ubuntu AdoptOpenJDK 8
+    name: Ubuntu Temurin Java 8
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '8'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: Set Gradle Wrapper Permissions
       run: chmod +x gradlew
     - name: Build

--- a/README.md
+++ b/README.md
@@ -1,21 +1,10 @@
 # crnk.io - Crank up the development of RESTful applications!
 
-<!--
-currently broken: https://github.com/badges/shields/issues/658
-https://img.shields.io/bintray/v/crnk-project/maven/crnk-core.svg
-
-[![Maven Central](https://img.shields.io/maven-central/v/io.crnk/crnk-core.svg)](http://mvnrepository.com/artifact/io.crnk/crnk-core)
-
--->
-
 [![Build Status](https://github.com/crnk-project/crnk-framework/workflows/build/badge.svg)](https://github.com/crnk-project/crnk-framework/actions)
 [![Gitter](https://img.shields.io/gitter/room/crkn-io/lobby.svg)](https://gitter.im/crnk-io/Lobby)
 [![License](https://img.shields.io/badge/License-Apache%202.0-yellowgreen.svg)](https://github.com/crnk-project/crnk-framework/blob/master/LICENSE.txt)
 [![Coverage Status](https://coveralls.io/repos/github/crnk-project/crnk-framework/badge.svg?branch=master)](https://coveralls.io/github/crnk-project/crnk-framework?branch=master)
-
-[![Bintray](https://img.shields.io/bintray/v/crnk-project/maven/crnk-core.svg)](https://bintray.com/crnk-project/maven/crnk-core) release on jcenter\
-[![Bintray](https://img.shields.io/bintray/v/crnk-project/mavenLatest/crnk-core.svg)](https://bintray.com/crnk-project/mavenLatest/crnk-core) latest in private repository
-
+[![maven-central](https://img.shields.io/maven-central/v/io.crnk/crnk-core)](https://search.maven.org/artifact/io.crnk/crnk-core)
 
 ## What is Crnk?
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ buildscript {
 		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2'
 		classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16'
 		classpath 'com.moowork.gradle:gradle-node-plugin:1.1.1'
-		classpath 'org.ajoberstar:gradle-git-publish:3.0.0'
-		classpath 'org.ajoberstar.grgit:grgit-gradle:3.0.0'
+		classpath 'org.ajoberstar.git-publish:gradle-git-publish:3.0.1'
+		classpath 'org.ajoberstar.grgit:grgit-gradle:4.1.1'
 
 		// classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.5-rc1'
 		classpath "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.1"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use [Eclipse Temurin](https://projects.eclipse.org/projects/adoptium.temurin), which is the successor to AdoptOpenJDK.

Additional updates include upgrading the `gradle-git-publish` plugin versions to support retrieval from Maven Central using versions compatible with Java 8.